### PR TITLE
chore[SC-211] Shared PR template + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,36 @@
+name: Chore
+description: Maintenance task, refactoring, or documentation update
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for maintenance tasks, refactoring, or documentation updates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - Refactoring
+        - Documentation
+        - Dependency update
+        - CI/CD improvement
+        - Cleanup
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context or details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Shortcut Stories
+    url: https://app.shortcut.com/tuinstradev
+    about: For tracked work, create stories in Shortcut instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,13 @@
 ## Summary
-- 
 
-## Testing
-- [ ] make lint
-- [ ] make test
+<!-- Describe what this PR changes and why -->
+
+## Checklist
+
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] Documentation updated (if applicable)
 
 ## Shortcut
-- Story: 
+
+<!-- Link to Shortcut story: https://app.shortcut.com/tuinstradev/story/XXX -->

--- a/templates/github/ISSUE_TEMPLATE/bug_report.yml
+++ b/templates/github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs.

--- a/templates/github/ISSUE_TEMPLATE/chore.yml
+++ b/templates/github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,36 @@
+name: Chore
+description: Maintenance task, refactoring, or documentation update
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for maintenance tasks, refactoring, or documentation updates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - Refactoring
+        - Documentation
+        - Dependency update
+        - CI/CD improvement
+        - Cleanup
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context or details.

--- a/templates/github/ISSUE_TEMPLATE/config.yml
+++ b/templates/github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Shortcut Stories
+    url: https://app.shortcut.com/tuinstradev
+    about: For tracked work, create stories in Shortcut instead.

--- a/templates/github/ISSUE_TEMPLATE/feature_request.yml
+++ b/templates/github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples.

--- a/templates/github/pull_request_template.md
+++ b/templates/github/pull_request_template.md
@@ -1,0 +1,24 @@
+# Consumer PR Template
+#
+# Copy this file to your repository at: .github/pull_request_template.md
+#
+# The badge URLs below use relative paths that GitHub resolves automatically
+# to your repository. No need to update URLs when copying!
+
+## Status
+
+[![CI](../../actions/workflows/ci.yml/badge.svg)](../../actions/workflows/ci.yml)
+
+## Summary
+
+<!-- Describe what this PR changes and why -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)
+- [ ] Linked to Shortcut story
+
+## Shortcut
+
+<!-- Link to Shortcut story: https://app.shortcut.com/tuinstradev/story/XXX -->


### PR DESCRIPTION
## Summary

Add shared community health files (PR template + issue templates) that can be used across all repos.

**Changes:**
- Add issue templates: bug report, feature request, chore (YAML form format)
- Enhance PR template with consistent checklist
- Add consumer templates in `templates/github/` with relative badge URLs that auto-resolve per-repo
- Consumer templates prevent copy-paste bugs (like the airporttoday-api badge issue)

## Checklist

- [x] `make lint` passes
- [x] `make test` passes
- [x] Documentation updated (if applicable)

## Shortcut

https://app.shortcut.com/tuinstradev/story/211