### PR TITLE
chore[SC-214] Docker image security scanning (Trivy)

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -58,13 +58,24 @@ on:
         required: false
         default: ""
         type: string
+      trivy-severity:
+        description: "Comma-separated severity levels to scan for"
+        required: false
+        default: "CRITICAL,HIGH"
+        type: string
+      trivy-exit-code:
+        description: "Exit code when vulnerabilities are found (1 = fail, 0 = warn only)"
+        required: false
+        default: "1"
+        type: string
 
 jobs:
-  build-and-push:
+  build-scan-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      security-events: write
     defaults:
       run:
         working-directory: ${{ inputs.workdir }}
@@ -84,8 +95,43 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push image
-        id: build
+      - name: Build image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.dockerfile }}
+          push: false
+          load: true
+          tags: scan-target:${{ github.sha }}
+          build-args: ${{ inputs.build-args }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: scan-target:${{ github.sha }}
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: aquasecurity/trivy-action@0.28.0
+        if: always()
+        with:
+          image-ref: scan-target:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Push image to GHCR
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.workdir }}
@@ -98,13 +144,13 @@ jobs:
       - name: Prepare immutable image reference
         id: image
         run: |
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${{ steps.push.outputs.digest }}"
           image_ref="${{ inputs.image-name }}@${digest}"
           echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: build-scan-push
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
@@ -135,7 +181,7 @@ jobs:
           cat > .deploy-override.yml <<OVERRIDE
           services:
             ${{ inputs.service-name }}:
-              image: ${{ needs.build-and-push.outputs.image-ref }}
+              image: ${{ needs.build-scan-push.outputs.image-ref }}
           OVERRIDE
           docker compose -f "${{ inputs.compose-file }}" -f .deploy-override.yml pull "${{ inputs.service-name }}"
           docker compose -f "${{ inputs.compose-file }}" -f .deploy-override.yml up -d --no-deps "${{ inputs.service-name }}"

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -1,0 +1,78 @@
+name: Reusable CI Docker
+
+on:
+  workflow_call:
+    inputs:
+      workdir:
+        description: Working directory containing Dockerfile
+        required: false
+        default: "."
+        type: string
+      dockerfile:
+        description: Dockerfile path relative to workdir
+        required: false
+        default: "Dockerfile"
+        type: string
+      build-args:
+        description: "Newline-separated Docker build args (e.g. ARG_NAME=value)"
+        required: false
+        default: ""
+        type: string
+      trivy-severity:
+        description: "Comma-separated severity levels to scan for"
+        required: false
+        default: "CRITICAL,HIGH"
+        type: string
+      trivy-exit-code:
+        description: "Exit code when vulnerabilities are found (1 = fail, 0 = warn only)"
+        required: false
+        default: "1"
+        type: string
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.workdir }}/${{ inputs.dockerfile }}
+          push: false
+          load: true
+          tags: scan-target:${{ github.sha }}
+          build-args: ${{ inputs.build-args }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: scan-target:${{ github.sha }}
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: aquasecurity/trivy-action@0.28.0
+        if: always()
+        with:
+          image-ref: scan-target:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif

--- a/docs/workflows/contracts/README.md
+++ b/docs/workflows/contracts/README.md
@@ -15,6 +15,7 @@ Workflow contracts document the stable API surface of each reusable workflow:
 | Workflow | Version | Status |
 |----------|---------|--------|
 | [reusable-ci.yml](reusable-ci.md) | v1 | Stable |
+| [reusable-ci-docker.yml](reusable-ci-docker.md) | v1 | Stable |
 | [reusable-cd-nuxt-ssg.yml](reusable-cd-nuxt-ssg.md) | v1 | Stable |
 
 ## Governance

--- a/docs/workflows/contracts/reusable-cd-nuxt-ssg.md
+++ b/docs/workflows/contracts/reusable-cd-nuxt-ssg.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Reusable CD workflow for deploying Nuxt SSG (static site generation) applications via Docker to a remote host.
+Reusable CD workflow for deploying Nuxt SSG (static site generation) applications via Docker to a remote host. Includes security scanning with Trivy before deployment.
 
 ## Trigger
 
@@ -31,6 +31,8 @@ on:
 | `ssh-port` | number | No | `22` | SSH port |
 | `compose-file` | string | No | `docker-compose.yml` | Compose file path |
 | `build-args` | string | No | `""` | Newline-separated Docker build args |
+| `trivy-severity` | string | No | `"CRITICAL,HIGH"` | Comma-separated severity levels to scan |
+| `trivy-exit-code` | string | No | `"1"` | Exit code on findings (1 = fail, 0 = warn) |
 
 ## Outputs
 
@@ -38,7 +40,7 @@ None exposed to caller. Internal outputs:
 
 | Output | Source Job | Description |
 |--------|-----------|-------------|
-| `image-ref` | `build-and-push` | Immutable image reference with digest |
+| `image-ref` | `build-scan-push` | Immutable image reference with digest |
 
 ## Required Secrets
 
@@ -60,23 +62,28 @@ These must be configured in the GitHub Environment:
 permissions:
   contents: read
   packages: write
+  security-events: write
 ```
 
 ## Jobs
 
 | Job | Description |
 |-----|-------------|
-| `build-and-push` | Build Docker image and push to GHCR |
+| `build-scan-push` | Build image, scan with Trivy, push to GHCR |
 | `deploy` | Deploy image to remote host via SSH |
 
 ## Expected Behavior
 
-### build-and-push
+### build-scan-push
 1. Checkout code
 2. Setup Docker Buildx
 3. Login to GHCR
-4. Build and push image with SHA tag
-5. Output immutable image reference (digest)
+4. Build image locally (no push)
+5. Run Trivy security scan
+6. Upload SARIF results to GitHub Security tab
+7. **Fail if CRITICAL/HIGH vulnerabilities found** (configurable)
+8. Push image to GHCR only if scan passes
+9. Output immutable image reference (digest)
 
 ### deploy
 1. Checkout code
@@ -84,6 +91,23 @@ permissions:
 3. Upload compose file to remote host
 4. Deploy using digest-pinned image reference
 5. Run health check on localhost (via SSH tunnel)
+
+## Security Scanning
+
+The workflow uses [Trivy](https://trivy.dev/) to scan Docker images for vulnerabilities before deployment.
+
+**Default behavior:**
+- Scans for `CRITICAL` and `HIGH` severity vulnerabilities
+- Fails the pipeline if any are found (exit code 1)
+- Ignores unfixed vulnerabilities (only actionable findings)
+- Uploads results to GitHub Security tab (SARIF format)
+
+**Customization:**
+```yaml
+with:
+  trivy-severity: "CRITICAL"        # Only fail on CRITICAL
+  trivy-exit-code: "0"              # Warn only, don't fail
+```
 
 ## Health Check Contract
 
@@ -101,6 +125,7 @@ Changes that require a major version bump:
 - Changing required secrets or environment variables
 - Modifying health check behavior
 - Changing image tagging strategy
+- Changing default security scan behavior
 
 ## Example Caller
 

--- a/docs/workflows/contracts/reusable-ci-docker.md
+++ b/docs/workflows/contracts/reusable-ci-docker.md
@@ -1,0 +1,116 @@
+# Workflow Contract: reusable-ci-docker.yml
+
+**Version:** v1  
+**Status:** Stable  
+**Last Updated:** 2026-02-08
+
+## Purpose
+
+Reusable CI workflow for Docker-based projects. Builds the Docker image and scans it with Trivy for security vulnerabilities during pull requests. This enables developers to catch and fix vulnerabilities before merging.
+
+## Trigger
+
+```yaml
+on:
+  workflow_call:
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `workdir` | string | No | `.` | Working directory containing Dockerfile |
+| `dockerfile` | string | No | `Dockerfile` | Dockerfile path relative to workdir |
+| `build-args` | string | No | `""` | Newline-separated Docker build args |
+| `trivy-severity` | string | No | `"CRITICAL,HIGH"` | Comma-separated severity levels to scan |
+| `trivy-exit-code` | string | No | `"1"` | Exit code on findings (1 = fail, 0 = warn) |
+
+## Outputs
+
+None.
+
+## Required Secrets
+
+None. This workflow does not push images or access external services.
+
+## Required Permissions
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+## Jobs
+
+| Job | Description |
+|-----|-------------|
+| `build-and-scan` | Build Docker image locally and scan with Trivy |
+
+## Expected Behavior
+
+1. Checkout code
+2. Setup Docker Buildx
+3. Build image locally (no push)
+4. Run Trivy vulnerability scan
+5. Upload SARIF results to GitHub Security tab
+6. **Fail PR if CRITICAL/HIGH vulnerabilities found** (configurable)
+
+## Security Scanning
+
+The workflow uses [Trivy](https://trivy.dev/) to scan Docker images.
+
+**Default behavior:**
+- Scans for `CRITICAL` and `HIGH` severity vulnerabilities
+- Fails the pipeline if any are found (blocks merge)
+- Ignores unfixed vulnerabilities (only actionable findings)
+- Uploads results to GitHub Security tab (SARIF format)
+
+**Use cases:**
+- Shift security left: developers fix vulnerabilities in PRs
+- Consistent scanning across CI and CD pipelines
+- Visibility via GitHub Security tab
+
+## Breaking Change Policy
+
+See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
+
+Changes that require a major version bump:
+- Removing or renaming existing inputs
+- Changing default security scan behavior
+- Changing required permissions
+
+## Example Caller
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  docker-scan:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+    with:
+      dockerfile: Dockerfile
+```
+
+### Combined with Node.js CI
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  ci:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
+    with:
+      node-version: "22"
+  
+  docker-scan:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+    with:
+      dockerfile: Dockerfile
+```

--- a/templates/workflows/caller-ci-docker.yml
+++ b/templates/workflows/caller-ci-docker.yml
@@ -1,0 +1,20 @@
+# Template: Docker CI workflow for consumer repos.
+# Copy this file to your consumer repo at .github/workflows/ci-docker.yml.
+#
+# Builds Docker image and scans for vulnerabilities on pull requests.
+# Blocks merge if CRITICAL or HIGH vulnerabilities are found.
+
+name: CI Docker
+
+on:
+  pull_request:
+
+jobs:
+  docker-scan:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+    with:
+      dockerfile: Dockerfile
+      # Uncomment to customize:
+      # workdir: .
+      # trivy-severity: "CRITICAL,HIGH"
+      # trivy-exit-code: "1"


### PR DESCRIPTION
## Summary

Add Trivy security scanning to Docker workflows to detect vulnerabilities before deployment.

**Changes:**
- Add new `reusable-ci-docker.yml` for PR-time vulnerability scanning (shift left)
- Add Trivy scan step to `reusable-cd-nuxt-ssg.yml` before pushing to GHCR
- CRITICAL/HIGH vulnerabilities block merge/deploy by default
- Results uploaded to GitHub Security tab (SARIF format)
- Add caller template and contract documentation

**How it works:**
1. **CI (PRs):** Developers use `reusable-ci-docker.yml` to scan during PRs - fix vulnerabilities before merge
2. **CD (Deploy):** `reusable-cd-nuxt-ssg.yml` scans again before push - final gate before production

**Configurable:**
- `trivy-severity`: Which severities to scan (default: `CRITICAL,HIGH`)
- `trivy-exit-code`: `1` to fail, `0` to warn only

## Checklist

- [x] `make lint` passes
- [x] `make test` passes
- [x] Documentation updated (if applicable)

## Shortcut

https://app.shortcut.com/tuinstradev/story/214