### PR TITLE
bug[SC-262] make reusable docker scan SARIF upload non-blocking

### DIFF
--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -74,5 +74,6 @@ jobs:
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         if: always()
+        continue-on-error: true
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
- make `github/codeql-action/upload-sarif` non-blocking in `reusable-ci-docker.yml`
- keep Trivy scanning behavior unchanged (still fails on configured severities/exit code)
- allow repositories without GitHub Advanced Security to use the reusable Docker CI workflow without hard failure on SARIF upload

## Validation
- `make lint`
- `make test`

## Shortcut
- https://app.shortcut.com/tuinstradev/story/262