### PR TITLE
bug[SC-263] make CD SARIF upload non-blocking

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         if: always()
+        continue-on-error: true
         with:
           sarif_file: trivy-results.sarif
 


### PR DESCRIPTION
## Summary
- make SARIF upload non-blocking in `reusable-cd-nuxt-ssg.yml`
- keep Trivy vulnerability gate unchanged
- prevent hard failures in repositories without GitHub Advanced Security

## Validation
- `make lint`
- `make test`

## Shortcut
- https://app.shortcut.com/tuinstradev/story/263