### PR TITLE
bug[SC-264] support explicit SSH key secret in reusable CD

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -2,6 +2,10 @@ name: Reusable CD Nuxt SSG
 
 on:
   workflow_call:
+    secrets:
+      SSH_PRIVATE_KEY:
+        description: SSH private key for deployment host authentication
+        required: true
     inputs:
       service-name:
         description: Docker Compose service name on target host


### PR DESCRIPTION
## Summary
- declare `SSH_PRIVATE_KEY` under `workflow_call.secrets` in reusable CD Nuxt SSG workflow
- enables cross-org consumers to pass deploy key explicitly instead of relying on `secrets: inherit`

## Validation
- `make lint`
- `make test`

## Shortcut
- https://app.shortcut.com/tuinstradev/story/264