### PR TITLE
feat[SC-282] Add reusable PHP CI workflows

### DIFF
--- a/.github/workflows/reusable-php-lint.yml
+++ b/.github/workflows/reusable-php-lint.yml
@@ -1,0 +1,106 @@
+name: Reusable PHP Lint
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: PHP version to use
+        required: false
+        default: "8.4"
+        type: string
+      extensions:
+        description: "Comma-separated PHP extensions to install"
+        required: false
+        default: "intl, pdo_pgsql"
+        type: string
+      phpstan-level:
+        description: "PHPStan analysis level (1-9 or max)"
+        required: false
+        default: "max"
+        type: string
+      phpstan-config:
+        description: "Path to custom phpstan.neon (empty = auto-detect)"
+        required: false
+        default: ""
+        type: string
+      phpstan-memory-limit:
+        description: "Memory limit for PHPStan"
+        required: false
+        default: "256M"
+        type: string
+      lint-tool:
+        description: "Lint tool to use: php-cs-fixer or ecs"
+        required: false
+        default: "php-cs-fixer"
+        type: string
+      lint-paths:
+        description: "Paths to lint (space-separated)"
+        required: false
+        default: "src tests"
+        type: string
+      run-rector:
+        description: "Run Rector in dry-run mode"
+        required: false
+        default: false
+        type: boolean
+      workdir:
+        description: "Working directory"
+        required: false
+        default: "."
+        type: string
+
+jobs:
+  lint:
+    name: PHP Lint & Static Analysis
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extensions }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHP-CS-Fixer
+        if: ${{ inputs.lint-tool == 'php-cs-fixer' }}
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run ECS
+        if: ${{ inputs.lint-tool == 'ecs' }}
+        run: vendor/bin/ecs check ${{ inputs.lint-paths }}
+
+      - name: Run PHPStan
+        run: |
+          PHPSTAN_ARGS="--memory-limit=${{ inputs.phpstan-memory-limit }}"
+          if [ -n "${{ inputs.phpstan-config }}" ]; then
+            PHPSTAN_ARGS="$PHPSTAN_ARGS -c ${{ inputs.phpstan-config }}"
+          fi
+          if [ "${{ inputs.phpstan-level }}" != "max" ]; then
+            PHPSTAN_ARGS="$PHPSTAN_ARGS --level=${{ inputs.phpstan-level }}"
+          fi
+          vendor/bin/phpstan analyse $PHPSTAN_ARGS
+
+      - name: Run Rector (dry-run)
+        if: ${{ inputs.run-rector }}
+        run: vendor/bin/rector process --dry-run

--- a/.github/workflows/reusable-php-security.yml
+++ b/.github/workflows/reusable-php-security.yml
@@ -1,0 +1,60 @@
+name: Reusable PHP Security
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: PHP version to use
+        required: false
+        default: "8.4"
+        type: string
+      workdir:
+        description: "Working directory"
+        required: false
+        default: "."
+        type: string
+      fail-on-vulnerabilities:
+        description: "Fail if vulnerabilities are found"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  security:
+    name: PHP Security Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        with:
+          php-version: ${{ inputs.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Check for vulnerabilities
+        run: |
+          if [ "${{ inputs.fail-on-vulnerabilities }}" == "true" ]; then
+            composer audit
+          else
+            composer audit || true
+          fi

--- a/.github/workflows/reusable-php-test.yml
+++ b/.github/workflows/reusable-php-test.yml
@@ -1,0 +1,176 @@
+name: Reusable PHP Test
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: PHP version to use
+        required: false
+        default: "8.4"
+        type: string
+      extensions:
+        description: "Comma-separated PHP extensions to install"
+        required: false
+        default: "intl, pdo_pgsql"
+        type: string
+      test-suites:
+        description: "Comma-separated test suites to run (empty = all)"
+        required: false
+        default: ""
+        type: string
+      database:
+        description: "Database to use: sqlite or postgres"
+        required: false
+        default: "sqlite"
+        type: string
+      postgres-version:
+        description: "PostgreSQL version (when database=postgres)"
+        required: false
+        default: "16"
+        type: string
+      coverage:
+        description: "Generate coverage report"
+        required: false
+        default: false
+        type: boolean
+      diff-coverage-threshold:
+        description: "Minimum coverage % on changed lines (0 = disabled)"
+        required: false
+        default: "0"
+        type: string
+      run-migrations:
+        description: "Run Doctrine migrations before tests"
+        required: false
+        default: true
+        type: boolean
+      workdir:
+        description: "Working directory"
+        required: false
+        default: "."
+        type: string
+    outputs:
+      coverage-percentage:
+        description: "Overall coverage percentage"
+        value: ${{ jobs.test.outputs.coverage }}
+
+jobs:
+  test:
+    name: PHP Tests
+    runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.coverage-report.outputs.percentage }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdir }}
+    services:
+      postgres:
+        image: ${{ inputs.database == 'postgres' && format('postgres:{0}', inputs.postgres-version) || '' }}
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      APP_ENV: test
+      APP_DEBUG: 1
+      APP_SECRET: test_secret_for_ci
+      DATABASE_URL: ${{ inputs.database == 'postgres' && 'postgresql://test:test@127.0.0.1:5432/test_db?serverVersion=16' || format('sqlite:///{0}/var/cache/test/app_ci.db', github.workspace) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extensions }}${{ inputs.database == 'sqlite' && ', pdo_sqlite' || '' }}
+          tools: composer:v2
+          coverage: ${{ inputs.coverage && 'xdebug' || 'none' }}
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Prepare test directories
+        run: mkdir -p var/cache/test var/coverage
+
+      - name: Run migrations
+        if: ${{ inputs.run-migrations }}
+        run: |
+          php bin/console doctrine:database:create --env=test --if-not-exists || true
+          php bin/console doctrine:migrations:migrate --env=test --no-interaction || true
+
+      - name: Run PHPUnit (without coverage)
+        if: ${{ !inputs.coverage }}
+        run: |
+          PHPUNIT_ARGS=""
+          if [ -n "${{ inputs.test-suites }}" ]; then
+            IFS=',' read -ra SUITES <<< "${{ inputs.test-suites }}"
+            for suite in "${SUITES[@]}"; do
+              vendor/bin/phpunit --testsuite "$(echo $suite | xargs)"
+            done
+          else
+            vendor/bin/phpunit
+          fi
+
+      - name: Run PHPUnit (with coverage)
+        if: ${{ inputs.coverage }}
+        run: |
+          PHPUNIT_ARGS="--coverage-cobertura var/coverage/cobertura.xml --coverage-text"
+          if [ -n "${{ inputs.test-suites }}" ]; then
+            IFS=',' read -ra SUITES <<< "${{ inputs.test-suites }}"
+            SUITE_ARGS=""
+            for suite in "${SUITES[@]}"; do
+              SUITE_ARGS="$SUITE_ARGS --testsuite $(echo $suite | xargs)"
+            done
+            vendor/bin/phpunit $SUITE_ARGS $PHPUNIT_ARGS
+          else
+            vendor/bin/phpunit $PHPUNIT_ARGS
+          fi
+
+      - name: Install diff-cover
+        if: ${{ inputs.coverage && inputs.diff-coverage-threshold != '0' }}
+        run: pip install diff-cover
+
+      - name: Enforce diff coverage threshold
+        if: ${{ inputs.coverage && inputs.diff-coverage-threshold != '0' && github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          diff-cover var/coverage/cobertura.xml \
+            --compare-branch origin/${{ github.base_ref }} \
+            --fail-under ${{ inputs.diff-coverage-threshold }}
+
+      - name: Extract coverage percentage
+        id: coverage-report
+        if: ${{ inputs.coverage }}
+        run: |
+          COVERAGE=$(grep -oP 'Lines:\s+\K[\d.]+' var/coverage/cobertura.xml 2>/dev/null || echo "0")
+          echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+
+      - name: Upload coverage artifact
+        if: ${{ inputs.coverage }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: coverage-report
+          path: var/coverage/
+          retention-days: 7

--- a/docs/workflows/contracts/README.md
+++ b/docs/workflows/contracts/README.md
@@ -12,11 +12,21 @@ Workflow contracts document the stable API surface of each reusable workflow:
 
 ## Available Contracts
 
+### Node.js / Nuxt
+
 | Workflow | Version | Status |
 |----------|---------|--------|
 | [reusable-ci.yml](reusable-ci.md) | v1 | Stable |
 | [reusable-ci-docker.yml](reusable-ci-docker.md) | v1 | Stable |
 | [reusable-cd-nuxt-ssg.yml](reusable-cd-nuxt-ssg.md) | v1 | Stable |
+
+### PHP / Symfony
+
+| Workflow | Version | Status |
+|----------|---------|--------|
+| [reusable-php-lint.yml](reusable-php-lint.md) | v1 | Stable |
+| [reusable-php-test.yml](reusable-php-test.md) | v1 | Stable |
+| [reusable-php-security.yml](reusable-php-security.md) | v1 | Stable |
 
 ## Governance
 

--- a/docs/workflows/contracts/reusable-php-lint.md
+++ b/docs/workflows/contracts/reusable-php-lint.md
@@ -1,0 +1,98 @@
+# Workflow Contract: reusable-php-lint.yml
+
+**Version:** v1  
+**Status:** Stable  
+**Last Updated:** 2026-02-10
+
+## Purpose
+
+Reusable CI workflow for PHP projects. Runs code style checking (PHP-CS-Fixer or ECS) and static analysis (PHPStan). Optionally runs Rector in dry-run mode.
+
+## Trigger
+
+```yaml
+on:
+  workflow_call:
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `php-version` | string | No | `"8.4"` | PHP version to use |
+| `extensions` | string | No | `"intl, pdo_pgsql"` | Comma-separated PHP extensions |
+| `phpstan-level` | string | No | `"max"` | PHPStan analysis level (1-9 or max) |
+| `phpstan-config` | string | No | `""` | Path to custom phpstan.neon |
+| `phpstan-memory-limit` | string | No | `"256M"` | Memory limit for PHPStan |
+| `lint-tool` | string | No | `"php-cs-fixer"` | Lint tool: php-cs-fixer or ecs |
+| `lint-paths` | string | No | `"src tests"` | Paths to lint (space-separated) |
+| `run-rector` | boolean | No | `false` | Run Rector in dry-run mode |
+| `workdir` | string | No | `"."` | Working directory |
+
+## Outputs
+
+None.
+
+## Required Secrets
+
+None. Use `secrets: inherit` if your project has private Composer dependencies.
+
+## Required Permissions
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Jobs
+
+| Job | Description |
+|-----|-------------|
+| `lint` | Runs code style and static analysis checks |
+
+## Expected Behavior
+
+1. Checkout code
+2. Setup PHP with specified version and extensions
+3. Cache Composer dependencies
+4. Install dependencies via `composer install`
+5. Run PHP-CS-Fixer (if `lint-tool=php-cs-fixer`) or ECS (if `lint-tool=ecs`)
+6. Run PHPStan with specified level and config
+7. Run Rector dry-run (if `run-rector=true`)
+
+## Breaking Change Policy
+
+See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
+
+Changes that require a major version bump:
+- Removing or renaming existing inputs
+- Changing default values in breaking ways
+- Changing from non-failing to failing by default
+- Changing required permissions
+
+## Example Caller
+
+```yaml
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-lint.yml@v1
+    with:
+      php-version: "8.4"
+      phpstan-level: "8"
+      lint-tool: "php-cs-fixer"
+
+  # Alternative: for projects using ECS and Rector
+  lint-ecs:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-lint.yml@v1
+    with:
+      php-version: "8.3"
+      lint-tool: "ecs"
+      run-rector: true
+```

--- a/docs/workflows/contracts/reusable-php-security.md
+++ b/docs/workflows/contracts/reusable-php-security.md
@@ -1,0 +1,87 @@
+# Workflow Contract: reusable-php-security.yml
+
+**Version:** v1  
+**Status:** Stable  
+**Last Updated:** 2026-02-10
+
+## Purpose
+
+Reusable CI workflow for PHP projects. Runs Composer security audit to check for known vulnerabilities in dependencies.
+
+## Trigger
+
+```yaml
+on:
+  workflow_call:
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `php-version` | string | No | `"8.4"` | PHP version to use |
+| `workdir` | string | No | `"."` | Working directory |
+| `fail-on-vulnerabilities` | boolean | No | `true` | Fail if vulnerabilities are found |
+
+## Outputs
+
+None.
+
+## Required Secrets
+
+None. Use `secrets: inherit` if your project has private Composer dependencies.
+
+## Required Permissions
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Jobs
+
+| Job | Description |
+|-----|-------------|
+| `security` | Runs Composer security audit |
+
+## Expected Behavior
+
+1. Checkout code
+2. Setup PHP with specified version
+3. Cache Composer dependencies
+4. Install dependencies via `composer install`
+5. Run `composer audit` to check for vulnerabilities
+
+### Vulnerability Handling
+
+- By default, the workflow fails if any vulnerabilities are found
+- Set `fail-on-vulnerabilities: false` to report vulnerabilities without failing
+
+## Breaking Change Policy
+
+See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
+
+Changes that require a major version bump:
+- Removing or renaming existing inputs
+- Changing default values in breaking ways
+- Changing required permissions
+
+## Example Caller
+
+```yaml
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+  schedule:
+    # Run daily at 6am UTC
+    - cron: '0 6 * * *'
+
+jobs:
+  security:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-security.yml@v1
+    with:
+      php-version: "8.4"
+```

--- a/docs/workflows/contracts/reusable-php-test.md
+++ b/docs/workflows/contracts/reusable-php-test.md
@@ -1,0 +1,123 @@
+# Workflow Contract: reusable-php-test.yml
+
+**Version:** v1  
+**Status:** Stable  
+**Last Updated:** 2026-02-10
+
+## Purpose
+
+Reusable CI workflow for PHP projects. Runs PHPUnit tests with optional PostgreSQL service, coverage reporting, and diff-coverage enforcement on changed lines.
+
+## Trigger
+
+```yaml
+on:
+  workflow_call:
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `php-version` | string | No | `"8.4"` | PHP version to use |
+| `extensions` | string | No | `"intl, pdo_pgsql"` | Comma-separated PHP extensions |
+| `test-suites` | string | No | `""` | Comma-separated test suites (empty = all) |
+| `database` | string | No | `"sqlite"` | Database: sqlite or postgres |
+| `postgres-version` | string | No | `"16"` | PostgreSQL version (when database=postgres) |
+| `coverage` | boolean | No | `false` | Generate coverage report |
+| `diff-coverage-threshold` | string | No | `"0"` | Min % on changed lines (0 = disabled) |
+| `run-migrations` | boolean | No | `true` | Run Doctrine migrations before tests |
+| `workdir` | string | No | `"."` | Working directory |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `coverage-percentage` | Overall coverage percentage (when coverage=true) |
+
+## Required Secrets
+
+None. Use `secrets: inherit` if your project has private Composer dependencies.
+
+## Required Permissions
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Jobs
+
+| Job | Description |
+|-----|-------------|
+| `test` | Runs PHPUnit tests with optional coverage |
+
+## Expected Behavior
+
+1. Checkout code with full history (for diff-cover)
+2. Setup PHP with specified version, extensions, and coverage driver (xdebug if coverage=true)
+3. Start PostgreSQL service container (if database=postgres)
+4. Cache Composer dependencies
+5. Install dependencies via `composer install`
+6. Create test directories
+7. Run Doctrine migrations (if run-migrations=true)
+8. Run PHPUnit (with or without coverage)
+9. Install diff-cover (Python) if coverage + threshold configured
+10. Enforce diff coverage threshold on PR (compares against base branch)
+11. Upload coverage artifact
+
+### Diff Coverage
+
+When `coverage=true` and `diff-coverage-threshold` > 0:
+- Uses [diff-cover](https://github.com/Bachmann1234/diff_cover) to check coverage on changed lines only
+- Only enforced on pull requests (compares against `github.base_ref`)
+- Allows gradual coverage improvement without requiring overall coverage threshold
+
+## Breaking Change Policy
+
+See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
+
+Changes that require a major version bump:
+- Removing or renaming existing inputs
+- Changing default values in breaking ways
+- Changing required permissions
+- Changing database connection behavior
+
+## Example Caller
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Simple test without coverage
+  test:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-test.yml@v1
+    with:
+      php-version: "8.4"
+      database: "postgres"
+
+  # Test with coverage and diff-coverage enforcement
+  test-coverage:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-test.yml@v1
+    with:
+      php-version: "8.4"
+      database: "postgres"
+      coverage: true
+      diff-coverage-threshold: "70"
+
+  # Test specific suites
+  test-suites:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-test.yml@v1
+    with:
+      test-suites: "Unit, Integration, Functional"
+      database: "sqlite"
+```

--- a/templates/workflows/caller-php-ci.yml
+++ b/templates/workflows/caller-php-ci.yml
@@ -1,0 +1,60 @@
+# Template: PHP CI Workflow
+#
+# Copy this file to your repository as .github/workflows/ci.yml
+# Customize the inputs as needed for your project.
+#
+# Requirements:
+# - PHP project with composer.json and composer.lock
+# - PHPUnit configured (phpunit.xml.dist or phpunit.dist.xml)
+# - PHPStan configured (phpstan.neon or phpstan.neon.dist)
+# - PHP-CS-Fixer or ECS configured (.php-cs-fixer.dist.php or ecs.php)
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & Static Analysis
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-lint.yml@v1
+    with:
+      php-version: "8.4"
+      phpstan-level: "8"
+      lint-tool: "php-cs-fixer"
+      # Uncomment for ECS-based projects:
+      # lint-tool: "ecs"
+      # run-rector: true
+
+  test:
+    name: Tests
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-test.yml@v1
+    with:
+      php-version: "8.4"
+      database: "postgres"
+      postgres-version: "16"
+      coverage: true
+      diff-coverage-threshold: "70"
+      # Uncomment to run specific test suites:
+      # test-suites: "Unit, Integration, Functional"
+
+  security:
+    name: Security Check
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-php-security.yml@v1
+    with:
+      php-version: "8.4"
+
+  # Optional: Docker image security scanning
+  # Uncomment if your project has a Dockerfile
+  # docker:
+  #   name: Docker Build & Scan
+  #   uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+  #   with:
+  #     trivy-severity: "CRITICAL,HIGH"
+  #     trivy-exit-code: "1"


### PR DESCRIPTION
## Summary

Add reusable GitHub Actions workflows for PHP projects, enabling standardized CI/CD across all PHP repositories (devops-dashboard, airporttoday-api, subtrack).

## Changes

### New Workflows

- **reusable-php-lint.yml** - Code style and static analysis
  - Supports PHP-CS-Fixer or ECS
  - PHPStan with configurable level
  - Optional Rector dry-run

- **reusable-php-test.yml** - PHPUnit testing
  - SQLite or PostgreSQL support
  - Coverage with xdebug
  - diff-cover for PR coverage on changed lines only
  - Configurable test suites

- **reusable-php-security.yml** - Security scanning
  - Composer audit for vulnerabilities

### Documentation

- Contract docs for all three workflows
- Caller template for quick adoption
- Updated contracts README

## Related

- Shortcut: [SC-282](https://app.shortcut.com/tuinstradev/story/282)
- Blocked by: SC-218 (completed)