### PR TITLE
feat[SC-282]: add reusable CD workflow for PHP/Symfony

### DIFF
--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -1,0 +1,318 @@
+name: Reusable CD PHP
+
+on:
+  workflow_call:
+    secrets:
+      SSH_PRIVATE_KEY:
+        description: SSH private key for deployment host authentication
+        required: true
+    inputs:
+      service-name:
+        description: Docker Compose PHP service name on target host
+        required: true
+        type: string
+      nginx-service-name:
+        description: Docker Compose nginx service name on target host
+        required: false
+        default: "nginx"
+        type: string
+      image-name:
+        description: Full GHCR image name without tag (used for both php and nginx images)
+        required: true
+        type: string
+      health-url:
+        description: "Public health URL (optional, informational only - health check runs via SSH on localhost)"
+        required: false
+        default: ""
+        type: string
+      port:
+        description: Exposed nginx service port (internal container port)
+        required: false
+        default: 80
+        type: number
+      environment:
+        description: GitHub Environment name (staging or production)
+        required: true
+        type: string
+      workdir:
+        description: Project working directory
+        required: false
+        default: .
+        type: string
+      dockerfile:
+        description: Dockerfile path relative to consumer repo root
+        required: false
+        default: Dockerfile
+        type: string
+      remote-path:
+        description: Deploy path on target host containing compose file
+        required: true
+        type: string
+      ssh-user:
+        description: SSH user for deploy host
+        required: true
+        type: string
+      ssh-port:
+        description: SSH port
+        required: false
+        default: 22
+        type: number
+      compose-file:
+        description: Compose file path relative to consumer repo root
+        required: false
+        default: docker-compose.yml
+        type: string
+      build-args:
+        description: "Newline-separated Docker build args (e.g. ARG_NAME=value)"
+        required: false
+        default: ""
+        type: string
+      trivy-severity:
+        description: "Comma-separated severity levels to scan for"
+        required: false
+        default: "CRITICAL,HIGH"
+        type: string
+      trivy-exit-code:
+        description: "Exit code when vulnerabilities are found (1 = fail, 0 = warn only)"
+        required: false
+        default: "1"
+        type: string
+      run-migrations:
+        description: "Run Doctrine migrations after deploy"
+        required: false
+        default: false
+        type: boolean
+      restart-worker:
+        description: "Restart messenger worker service after deploy"
+        required: false
+        default: false
+        type: boolean
+      worker-service:
+        description: "Name of worker service in compose file"
+        required: false
+        default: "worker"
+        type: string
+
+jobs:
+  build-scan-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdir }}
+    outputs:
+      php-image-ref: ${{ steps.php-image.outputs.image_ref }}
+      nginx-image-ref: ${{ steps.nginx-image.outputs.image_ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Build PHP image
+      - name: Build PHP image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.dockerfile }}
+          target: php_prod
+          push: false
+          load: true
+          tags: scan-target-php:${{ github.sha }}
+          build-args: ${{ inputs.build-args }}
+
+      - name: Run Trivy on PHP image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: scan-target-php:${{ github.sha }}
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload Trivy PHP scan results
+        uses: aquasecurity/trivy-action@0.28.0
+        if: always()
+        with:
+          image-ref: scan-target-php:${{ github.sha }}
+          format: sarif
+          output: trivy-php-results.sarif
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Upload PHP SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: trivy-php-results.sarif
+          category: trivy-php
+
+      - name: Push PHP image to GHCR
+        id: php-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.dockerfile }}
+          target: php_prod
+          push: true
+          tags: |
+            ${{ inputs.image-name }}:${{ github.sha }}
+            ${{ inputs.image-name }}:latest
+          build-args: ${{ inputs.build-args }}
+
+      - name: Prepare PHP image reference
+        id: php-image
+        run: |
+          digest="${{ steps.php-push.outputs.digest }}"
+          image_ref="${{ inputs.image-name }}@${digest}"
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
+
+      # Build nginx image
+      - name: Build nginx image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.dockerfile }}
+          target: nginx_prod
+          push: false
+          load: true
+          tags: scan-target-nginx:${{ github.sha }}
+
+      - name: Run Trivy on nginx image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: scan-target-nginx:${{ github.sha }}
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: true
+
+      - name: Push nginx image to GHCR
+        id: nginx-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.dockerfile }}
+          target: nginx_prod
+          push: true
+          tags: |
+            ${{ inputs.image-name }}:nginx-${{ github.sha }}
+            ${{ inputs.image-name }}:nginx-latest
+          build-args: ${{ inputs.build-args }}
+
+      - name: Prepare nginx image reference
+        id: nginx-image
+        run: |
+          digest="${{ steps.nginx-push.outputs.digest }}"
+          image_ref="${{ inputs.image-name }}@${digest}"
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-scan-push
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "${{ inputs.ssh-port }}" "${{ vars.SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload compose file
+        run: |
+          ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" \
+            "mkdir -p '${{ inputs.remote-path }}'"
+          scp -P "${{ inputs.ssh-port }}" \
+            "${{ inputs.compose-file }}" \
+            "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}:${{ inputs.remote-path }}/docker-compose.yml"
+
+      - name: Deploy services over SSH
+        run: |
+          ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" <<'EOF'
+          set -euo pipefail
+          cd "${{ inputs.remote-path }}"
+
+          # Create override file with pinned image digests
+          cat > .deploy-override.yml <<OVERRIDE
+          services:
+            ${{ inputs.service-name }}:
+              image: ${{ needs.build-scan-push.outputs.php-image-ref }}
+            ${{ inputs.nginx-service-name }}:
+              image: ${{ needs.build-scan-push.outputs.nginx-image-ref }}
+            ${{ inputs.worker-service }}:
+              image: ${{ needs.build-scan-push.outputs.php-image-ref }}
+          OVERRIDE
+
+          # Pull and deploy
+          docker compose -f docker-compose.yml -f .deploy-override.yml pull
+          docker compose -f docker-compose.yml -f .deploy-override.yml up -d
+
+          # Cleanup override
+          rm -f .deploy-override.yml
+          EOF
+
+      - name: Run database migrations
+        if: ${{ inputs.run-migrations }}
+        run: |
+          ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" <<'EOF'
+          set -euo pipefail
+          cd "${{ inputs.remote-path }}"
+
+          # Wait for PHP container to be ready
+          sleep 5
+
+          # Run migrations
+          docker compose exec -T ${{ inputs.service-name }} \
+            php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+          EOF
+
+      - name: Restart worker service
+        if: ${{ inputs.restart-worker }}
+        run: |
+          ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" <<'EOF'
+          set -euo pipefail
+          cd "${{ inputs.remote-path }}"
+          docker compose restart ${{ inputs.worker-service }}
+          EOF
+
+      - name: Health check
+        run: |
+          timeout=180
+          interval=5
+          deadline=$(( $(date +%s) + timeout ))
+
+          # Resolve the host port from the running container
+          mapped=$(ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" \
+            "cd '${{ inputs.remote-path }}' && docker compose port '${{ inputs.nginx-service-name }}' ${{ inputs.port }}")
+          host_port=$(echo "$mapped" | cut -d: -f2)
+          echo "Container mapped to localhost:${host_port}"
+
+          while [[ $(date +%s) -lt $deadline ]]; do
+            if ssh -p "${{ inputs.ssh-port }}" "${{ inputs.ssh-user }}@${{ vars.SSH_HOST }}" \
+              "curl -fsS http://localhost:${host_port}/health" >/dev/null 2>&1; then
+              echo "Health check passed on localhost:${host_port}/health"
+              exit 0
+            fi
+            sleep "$interval"
+          done
+
+          echo "Health check failed on localhost:${host_port}/health" >&2
+          exit 1

--- a/docs/workflows/contracts/reusable-cd-php.md
+++ b/docs/workflows/contracts/reusable-cd-php.md
@@ -1,0 +1,242 @@
+# Workflow Contract: reusable-cd-php.yml
+
+**Version:** v1  
+**Status:** Stable  
+**Last Updated:** 2026-02-10
+
+## Purpose
+
+Reusable CD workflow for deploying PHP/Symfony applications via Docker to a remote host. Builds separate PHP-FPM and nginx images, includes security scanning with Trivy, and supports Doctrine migrations and Messenger worker restarts.
+
+## Trigger
+
+```yaml
+on:
+  workflow_call:
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `service-name` | string | Yes | - | Docker Compose PHP service name on target host |
+| `nginx-service-name` | string | No | `"nginx"` | Docker Compose nginx service name on target host |
+| `image-name` | string | Yes | - | Full GHCR image name without tag (used for both php and nginx images) |
+| `health-url` | string | No | `""` | Public health URL (informational only) |
+| `port` | number | No | `80` | Exposed nginx service port (internal container port) |
+| `environment` | string | Yes | - | GitHub Environment name (staging/production) |
+| `workdir` | string | No | `.` | Project working directory |
+| `dockerfile` | string | No | `Dockerfile` | Dockerfile path relative to repo root |
+| `remote-path` | string | Yes | - | Deploy path on target host containing compose file |
+| `ssh-user` | string | Yes | - | SSH user for deploy host |
+| `ssh-port` | number | No | `22` | SSH port |
+| `compose-file` | string | No | `docker-compose.yml` | Compose file path relative to repo root |
+| `build-args` | string | No | `""` | Newline-separated Docker build args |
+| `trivy-severity` | string | No | `"CRITICAL,HIGH"` | Comma-separated severity levels to scan |
+| `trivy-exit-code` | string | No | `"1"` | Exit code on findings (1 = fail, 0 = warn) |
+| `run-migrations` | boolean | No | `false` | Run Doctrine migrations after deploy |
+| `restart-worker` | boolean | No | `false` | Restart messenger worker service after deploy |
+| `worker-service` | string | No | `"worker"` | Name of worker service in compose file |
+
+## Outputs
+
+None exposed to caller. Internal outputs:
+
+| Output | Source Job | Description |
+|--------|-----------|-------------|
+| `php-image-ref` | `build-scan-push` | Immutable PHP image reference with digest |
+| `nginx-image-ref` | `build-scan-push` | Immutable nginx image reference with digest |
+
+## Required Secrets
+
+These must be configured in the GitHub Environment:
+
+| Secret | Description |
+|--------|-------------|
+| `SSH_PRIVATE_KEY` | Ed25519 private key for deploy host access |
+
+## Required Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SSH_HOST` | Target host for deployment |
+
+## Required Permissions
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+```
+
+## Jobs
+
+| Job | Description |
+|-----|-------------|
+| `build-scan-push` | Build PHP and nginx images, scan with Trivy, push to GHCR |
+| `deploy` | Deploy images to remote host via SSH |
+
+## Expected Behavior
+
+### build-scan-push
+1. Checkout code
+2. Setup Docker Buildx
+3. Login to GHCR
+4. Build PHP image (`php_prod` target) locally
+5. Run Trivy security scan on PHP image
+6. Upload PHP SARIF results to GitHub Security tab
+7. **Fail if CRITICAL/HIGH vulnerabilities found** (configurable)
+8. Push PHP image to GHCR with tags: `image:sha`, `image:latest`
+9. Build nginx image (`nginx_prod` target) locally
+10. Run Trivy security scan on nginx image
+11. Push nginx image to GHCR with tags: `image:nginx-sha`, `image:nginx-latest`
+12. Output immutable image references (digests)
+
+### deploy
+1. Checkout code
+2. Configure SSH with environment secrets
+3. Upload compose file to remote host
+4. Create override file with pinned image digests for php, nginx, and worker services
+5. Pull and deploy using docker compose
+6. **Optionally run Doctrine migrations** (if `run-migrations: true`)
+7. **Optionally restart worker service** (if `restart-worker: true`)
+8. Run health check on localhost (via SSH tunnel)
+
+## Dockerfile Requirements
+
+The Dockerfile must define these targets:
+
+```dockerfile
+# PHP-FPM production image
+FROM php:8.3-fpm-alpine AS php_prod
+# ... your PHP-FPM setup
+
+# nginx production image (copies static assets from php_prod)
+FROM nginx:1.27-alpine AS nginx_prod
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=php_prod /app/public /app/public
+```
+
+## Image Tagging
+
+| Image | Tags |
+|-------|------|
+| PHP | `image:latest`, `image:<sha>` |
+| nginx | `image:nginx-latest`, `image:nginx-<sha>` |
+
+Deployments use immutable digest references, not tags.
+
+## Security Scanning
+
+The workflow uses [Trivy](https://trivy.dev/) to scan Docker images for vulnerabilities before deployment.
+
+**Default behavior:**
+- Scans both PHP and nginx images
+- Scans for `CRITICAL` and `HIGH` severity vulnerabilities
+- Fails the pipeline if any are found (exit code 1)
+- Ignores unfixed vulnerabilities (only actionable findings)
+- Uploads PHP results to GitHub Security tab (SARIF format)
+
+**Customization:**
+```yaml
+with:
+  trivy-severity: "CRITICAL"        # Only fail on CRITICAL
+  trivy-exit-code: "0"              # Warn only, don't fail
+```
+
+## Health Check Contract
+
+The deployed container must:
+- Expose a `/health` endpoint on the nginx service
+- Return HTTP 200 within 180 seconds of container start
+- Health check runs via SSH on localhost, not public URL
+
+## Doctrine Migrations
+
+When `run-migrations: true`:
+1. Waits 5 seconds for PHP container to be ready
+2. Runs `php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration`
+3. Fails deployment if migrations fail
+
+## Worker Service
+
+When `restart-worker: true`:
+- Restarts the service specified by `worker-service` input
+- Default service name: `worker`
+- Useful for Symfony Messenger consumers
+
+## Breaking Change Policy
+
+See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
+
+Changes that require a major version bump:
+- Removing or renaming existing inputs
+- Changing required secrets or environment variables
+- Modifying Dockerfile target names (`php_prod`, `nginx_prod`)
+- Changing health check behavior
+- Changing image tagging strategy
+- Changing default security scan behavior
+
+## Example Caller
+
+```yaml
+name: Deploy Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-cd-php.yml@v1
+    with:
+      service-name: php
+      nginx-service-name: nginx
+      image-name: ghcr.io/my-org/my-app
+      environment: production
+      remote-path: /opt/my-app/production
+      ssh-user: deploy
+      compose-file: docker-compose.production.yml
+      run-migrations: true
+      restart-worker: true
+    secrets: inherit
+```
+
+## Example Compose File
+
+```yaml
+services:
+  php:
+    image: ghcr.io/my-org/my-app:latest
+    environment:
+      DATABASE_URL: postgresql://user:pass@postgres:5432/app
+    depends_on:
+      - postgres
+
+  nginx:
+    image: ghcr.io/my-org/my-app:nginx-latest
+    ports:
+      - "8000:80"
+    depends_on:
+      - php
+
+  worker:
+    image: ghcr.io/my-org/my-app:latest
+    command: php bin/console messenger:consume async --time-limit=3600
+    depends_on:
+      - php
+      - postgres
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: app
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+```


### PR DESCRIPTION
## Summary
- Adds `reusable-cd-php.yml` for deploying PHP/Symfony applications via Docker
- Builds separate PHP-FPM (`php_prod`) and nginx (`nginx_prod`) images
- Includes Trivy security scanning for both images

## Features
- `run-migrations` input for Doctrine migrations after deploy
- `restart-worker` input for Symfony Messenger worker restart
- Uses immutable digest references for deployments
- Contract documentation in `docs/workflows/contracts/reusable-cd-php.md`

## Relates to
SC-282: CI/CD baseline with reusable workflows