### PR TITLE
fix[SC-282]: make SSH_PRIVATE_KEY secret optional at call time

### DIFF
--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -5,7 +5,7 @@ on:
     secrets:
       SSH_PRIVATE_KEY:
         description: SSH private key for deployment host authentication
-        required: true
+        required: false
     inputs:
       service-name:
         description: Docker Compose PHP service name on target host


### PR DESCRIPTION
## Summary
- Changes `SSH_PRIVATE_KEY` from `required: true` to `required: false` in reusable-cd-php.yml

## Problem
Environment-scoped secrets are not available during workflow call validation. When a caller uses `secrets: inherit`, GitHub validates required secrets before any job runs - but environment secrets only become available when a job specifies that environment.

## Solution
Setting `required: false` allows the secret to be resolved when the `deploy` job runs with `environment: ${{ inputs.environment }}`, which makes environment-scoped secrets available.

The secret is still required for the deploy to work - it just won't fail at call-time validation.