### PR TITLE
fix: broaden release-tag regex and guard SARIF upload

### DIFF
--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload PHP SARIF file
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('trivy-php-results.sarif') != ''
         continue-on-error: true
         with:
           sarif_file: trivy-php-results.sarif

--- a/.github/workflows/reusable-release-tag.yml
+++ b/.github/workflows/reusable-release-tag.yml
@@ -7,7 +7,7 @@ on:
         description: "Regex used to extract semver from release PR title"
         required: false
         type: string
-        default: '^release:[[:space:]]v([0-9]+\.[0-9]+\.[0-9]+)$'
+        default: '^[Rr]elease:?[[:space:]]v([0-9]+\.[0-9]+\.[0-9]+)$'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- **Release-tag regex**: Broadened default regex from `^release: v...` to `^[Rr]elease:? v...` — now accepts both `release: v1.2.3` and `Release v1.2.3` (case-insensitive, optional colon). This matches the PR title convention used by consumer repos.
- **SARIF upload guard**: Added `hashFiles()` check to the PHP CD workflow's SARIF upload step, preventing failures when Trivy doesn't produce output (e.g., binary install failure).

## Changed Files

| File | Change |
|------|--------|
| `.github/workflows/reusable-release-tag.yml` | Regex: `^[Rr]elease:?[[:space:]]v(...)$` |
| `.github/workflows/reusable-cd-php.yml` | SARIF upload: `if: always() && hashFiles(...) != ''` |