### PR TITLE
Add Gate baseline evidence workflow

### DIFF
--- a/.github/workflows/reusable-gate-baseline.yml
+++ b/.github/workflows/reusable-gate-baseline.yml
@@ -1,0 +1,77 @@
+name: Reusable Gate Baseline Evidence
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-missing:
+        description: Fail when required baseline checks are missing
+        required: false
+        default: false
+        type: boolean
+      require-deploy:
+        description: Require at least one reusable deploy workflow caller
+        required: false
+        default: true
+        type: boolean
+      require-renovate:
+        description: Require a Renovate config extending this repo's presets
+        required: false
+        default: true
+        type: boolean
+      gate-contract-path:
+        description: Path to the consumer repo Gate integration contract
+        required: false
+        default: .gate/baseline.yml
+        type: string
+      devops-ref:
+        description: Ref used to fetch baseline scan support from this repo
+        required: false
+        default: v1
+        type: string
+      upload-artifact:
+        description: Upload baseline evidence as an artifact
+        required: false
+        default: true
+        type: boolean
+      artifact-retention-days:
+        description: Retention period for baseline evidence artifacts
+        required: false
+        default: 30
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout consumer repository
+        uses: actions/checkout@v6
+        with:
+          path: consumer
+
+      - name: Checkout devops baseline support
+        uses: actions/checkout@v6
+        with:
+          repository: marcel-tuinstra/devops
+          ref: ${{ inputs.devops-ref }}
+          path: devops-platform
+
+      - name: Scan baseline
+        run: |
+          bash devops-platform/scripts/gate-baseline-scan.sh \
+            --repo consumer \
+            --output-dir gate-baseline-evidence \
+            --fail-on-missing "${{ inputs.fail-on-missing }}" \
+            --require-deploy "${{ inputs.require-deploy }}" \
+            --require-renovate "${{ inputs.require-renovate }}" \
+            --gate-contract-path "${{ inputs.gate-contract-path }}"
+
+      - name: Upload baseline evidence
+        if: ${{ always() && inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-baseline-evidence
+          path: gate-baseline-evidence/
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Auth0 is the accepted central identity provider for the DevOps platform and down
 ## Consumer Onboarding
 
 See `docs/onboarding/consumer-migration-checklist.md` for a step-by-step guide to integrating your project with these reusable workflows.
+Gate rollout readiness is documented in `docs/standards/gate-baseline.md`.
 
 ## Reusable Workflow Example
 
@@ -52,6 +53,13 @@ Pipeline and deployment control requirements are documented in
 
 Reusable workflow release channels, deprecation rules, and migration guidance are
 documented in `docs/workflows/versioning-policy.md`.
+
+## Gate Baseline Evidence
+
+Consumer repositories can add the Gate baseline evidence workflow from
+`templates/workflows/caller-gate-baseline.yml`. The reusable workflow produces
+an artifact with rollout evidence for CI, release, deploy, Renovate, artifact
+retention, branch protection, and the repo-owned Gate integration contract.
 
 ## Deployment Automation
 

--- a/docs/onboarding/consumer-migration-checklist.md
+++ b/docs/onboarding/consumer-migration-checklist.md
@@ -193,14 +193,29 @@ cp <devops-repo>/templates/workflows/caller-release-tag.yml .github/workflows/re
 
 Git tags are used for release traceability. GitHub Releases are optional. The release PR remains the audit trail and the Docker image digest remains the rollback unit.
 
-## 10. DNS and Reverse Proxy
+## 10. Gate Baseline Evidence
+
+Copy the Gate baseline workflow template into your consumer repo:
+
+```bash
+cp <devops-repo>/templates/workflows/caller-gate-baseline.yml .github/workflows/gate-baseline.yml
+```
+
+Create a repo-owned Gate integration contract at `.gate/baseline.yml`. Use
+`docs/standards/gate-baseline.md` for the required fields and rollout checklist.
+
+Start with `fail-on-missing: false` while onboarding so the workflow produces an
+evidence artifact without blocking unrelated work. After the checklist is green,
+set `fail-on-missing: true` and add the workflow to branch protection.
+
+## 11. DNS and Reverse Proxy
 
 - **DNS**: Add a wildcard A-record `*.<your-domain>` pointing to your server.
 - **Staging URL**: `staging.<your-domain>` (e.g. `staging.marcel.tuinstra.dev`)
 - **Production URL**: `<your-domain>` (e.g. `marcel.tuinstra.dev`)
 - **Reverse proxy**: Configure Nginx Proxy Manager (or similar) to proxy each hostname to the corresponding local port with SSL.
 
-## 11. Validation
+## 12. Validation
 
 After setup, verify end-to-end:
 
@@ -209,8 +224,9 @@ After setup, verify end-to-end:
 3. **Health check**: Verify the staging health URL returns HTTP 200.
 4. **Production CD**: Push to `main` and confirm production deployment succeeds.
 5. **Health check**: Verify the production health URL returns HTTP 200.
+6. **Gate baseline**: Run the Gate baseline workflow and confirm the evidence artifact is uploaded.
 
-## 12. Rollback
+## 13. Rollback
 
 If a deployment fails:
 

--- a/docs/standards/gate-baseline.md
+++ b/docs/standards/gate-baseline.md
@@ -1,0 +1,140 @@
+# Gate DevOps Baseline
+
+This baseline defines the minimum DevOps evidence expected before a consumer
+repository is considered ready for Gate integration. It is intentionally small:
+the goal is to make release, dependency, artifact, deployment, and ownership
+signals easy to verify across repos.
+
+## Consumer Repository Checklist
+
+### Required workflows
+
+- CI workflow calls the appropriate reusable workflow from this repo:
+  - Node/Nuxt/Vite: `reusable-ci.yml@v1`
+  - PHP/Symfony: `reusable-php-lint.yml@v1` and `reusable-php-test.yml@v1`
+- Containerized services run Docker build and vulnerability scanning through
+  `reusable-ci-docker.yml@v1`.
+- Deployable services have environment-specific deployment callers for staging
+  and production using the matching `reusable-cd-*.yml@v1` workflow.
+- Release automation is installed:
+  - `reusable-release-pr.yml@v1` for `develop` to `main` promotion PRs.
+  - `reusable-release-tag.yml@v1` for release tags on `main`.
+- The Gate baseline evidence workflow is installed from
+  `templates/workflows/caller-gate-baseline.yml`.
+
+### Release and tag policy
+
+- Normal product flow is feature branches to `develop`, then release PR from
+  `develop` to `main`.
+- Release PR titles use `release: vX.Y.Z` unless the repository has documented
+  date-based releases.
+- Tags are immutable release markers created after merge to `main`.
+- Docker image digests are the deploy and rollback unit for services.
+
+### Artifact retention
+
+- Workflows that upload evidence, build outputs, scan reports, or test reports
+  set explicit `retention-days`.
+- Baseline evidence artifacts should be retained for at least 30 days.
+- Security scan uploads may also publish SARIF to the GitHub Security tab when
+  the reusable workflow supports it.
+
+### Deploy readiness
+
+- Deployable repos have `staging` and `production` GitHub Environments.
+- Environment secrets and variables are configured at the environment level:
+  - `SSH_PRIVATE_KEY` as a secret.
+  - `SSH_HOST` as a variable.
+- Compose files exist per environment, or the repository documents why it does
+  not deploy through Docker Compose.
+- Health checks use a stable path, normally `/health`, and the CD workflow
+  verifies the running container over SSH before completing.
+- Rollback instructions identify the previous image digest or workflow pin to
+  restore.
+
+### Renovate and devops pinning
+
+- Renovate is enabled and extends the appropriate preset from this repo:
+  - `github>marcel-tuinstra/devops:renovate/nuxt`
+  - `github>marcel-tuinstra/devops:renovate/symfony`
+  - or `github>marcel-tuinstra/devops:renovate/default`
+- Consumer workflows pin reusable workflows to a stable major tag such as `@v1`
+  for normal operation.
+- `@main` is only used for canary validation and should not be required by
+  branch protection.
+- If a reusable workflow regression is suspected, callers may temporarily pin
+  to a known-good commit SHA while the platform fix rolls forward.
+
+### Branch protection expectations
+
+- `main` requires pull requests and passing required checks before merge.
+- `develop` requires passing CI before merge when it is used as the staging
+  branch.
+- Production deployments use the `production` environment and require manual
+  approval when the repo has user-facing production traffic.
+- Required checks include CI and, after rollout, the Gate baseline evidence
+  workflow in enforcing mode.
+
+### Gate integration contract
+
+Each consumer repo should carry a small Gate contract at `.gate/baseline.yml`.
+The file is repo-owned and may include more detail, but it should at least
+answer:
+
+```yaml
+owner: marcel-tuinstra
+repository: example-repo
+production_branch: main
+staging_branch: develop
+release_policy: semver-release-pr
+required_checks:
+  - ci
+  - gate-baseline
+deployments:
+  staging:
+    environment: staging
+    health_path: /health
+  production:
+    environment: production
+    health_path: /health
+renovate:
+  preset: github>marcel-tuinstra/devops:renovate/nuxt
+evidence_workflow: .github/workflows/gate-baseline.yml
+```
+
+The contract is not a secret store. It should contain only routing, ownership,
+release, and evidence expectations that Gate and maintainers can read safely.
+
+## Baseline Evidence Workflow
+
+Consumer repos can copy
+`templates/workflows/caller-gate-baseline.yml` to
+`.github/workflows/gate-baseline.yml`.
+
+Start in report-only mode:
+
+```yaml
+jobs:
+  gate-baseline:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-gate-baseline.yml@v1
+    with:
+      fail-on-missing: false
+```
+
+After the checklist is green, switch to enforcing mode:
+
+```yaml
+jobs:
+  gate-baseline:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-gate-baseline.yml@v1
+    with:
+      fail-on-missing: true
+```
+
+The workflow uploads a `gate-baseline-evidence` artifact containing a Markdown
+summary. It can also be run locally from a consumer repo when this devops repo
+is checked out nearby:
+
+```bash
+bash /path/to/devops/scripts/gate-baseline-scan.sh --repo . --fail-on-missing false
+```

--- a/docs/workflows/contracts/README.md
+++ b/docs/workflows/contracts/README.md
@@ -34,6 +34,12 @@ Workflow contracts document the stable API surface of each reusable workflow:
 | [reusable-php-test.yml](reusable-php-test.md) | v1 | Stable |
 | [reusable-php-security.yml](reusable-php-security.md) | v1 | Stable |
 
+### Gate / Baseline Evidence
+
+| Workflow | Version | Status |
+|----------|---------|--------|
+| [reusable-gate-baseline.yml](reusable-gate-baseline.md) | v1 | Stable |
+
 ## Governance
 
 Changes to workflow contracts require:

--- a/docs/workflows/contracts/reusable-gate-baseline.md
+++ b/docs/workflows/contracts/reusable-gate-baseline.md
@@ -1,0 +1,77 @@
+# Contract: reusable-gate-baseline.yml
+
+## Status
+
+- Version: v1
+- Stability: Stable after the first `v1` tag that includes this workflow.
+- Purpose: Produce Gate baseline evidence for consumer repositories and
+  optionally fail when required rollout checks are missing.
+
+## Caller
+
+```yaml
+jobs:
+  gate-baseline:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-gate-baseline.yml@v1
+    with:
+      fail-on-missing: false
+```
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|---:|---|---|
+| `fail-on-missing` | boolean | no | `false` | Exit non-zero when required checks fail. Use `false` for report-only rollout and `true` after onboarding. |
+| `require-deploy` | boolean | no | `true` | Require at least one caller for a reusable CD workflow. Set `false` for libraries or non-deployable repos. |
+| `require-renovate` | boolean | no | `true` | Require a Renovate config extending a preset from this repo. |
+| `gate-contract-path` | string | no | `.gate/baseline.yml` | Path to the repo-owned Gate integration contract. |
+| `devops-ref` | string | no | `v1` | Ref used to fetch the scan script from this repo. Use `main` only when canary-testing the reusable workflow from `@main`. |
+| `upload-artifact` | boolean | no | `true` | Upload the generated evidence files. |
+| `artifact-retention-days` | number | no | `30` | Retention period for the uploaded evidence artifact. |
+
+## Outputs
+
+This workflow does not expose workflow outputs.
+
+## Permissions
+
+The workflow requests:
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Evidence artifact
+
+When `upload-artifact` is true, the workflow uploads
+`gate-baseline-evidence` containing:
+
+- `gate-baseline-summary.md`
+- `gate-baseline-summary.tsv`
+
+The Markdown summary is also appended to the GitHub Actions step summary.
+
+## Checks
+
+The scan verifies:
+
+- `.github/workflows` exists.
+- A reusable CI caller is present.
+- Release PR and release tag callers are present.
+- A reusable deploy caller is present when `require-deploy` is true.
+- Devops reusable workflows are not pinned to `@main`.
+- Renovate extends a shared devops preset when `require-renovate` is true.
+- `actions/upload-artifact` steps set explicit `retention-days`.
+- The Gate integration contract file exists.
+- Branch protection evidence is present through `CODEOWNERS`,
+  `docs/branch-protection.md`, or manual rollout evidence.
+
+Branch protection settings cannot be fully verified from repository files. The
+workflow records that gap as a warning unless file-based evidence exists.
+
+## Compatibility
+
+This is an additive workflow. Changes to defaults, required inputs, artifact
+file names, or failure semantics are breaking changes and require a new major
+version.

--- a/scripts/gate-baseline-scan.sh
+++ b/scripts/gate-baseline-scan.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="."
+output_dir="gate-baseline-evidence"
+fail_on_missing="${GATE_BASELINE_FAIL_ON_MISSING:-false}"
+require_deploy="${GATE_BASELINE_REQUIRE_DEPLOY:-true}"
+require_renovate="${GATE_BASELINE_REQUIRE_RENOVATE:-true}"
+gate_contract_path="${GATE_BASELINE_CONTRACT_PATH:-.gate/baseline.yml}"
+
+usage() {
+  cat <<'USAGE'
+Usage: gate-baseline-scan.sh [options]
+
+Options:
+  --repo PATH                  Repository to scan (default: .)
+  --output-dir PATH            Evidence output directory (default: gate-baseline-evidence)
+  --fail-on-missing true|false Exit non-zero when required checks fail (default: false)
+  --require-deploy true|false  Require reusable CD workflow callers (default: true)
+  --require-renovate true|false Require Renovate preset configuration (default: true)
+  --gate-contract-path PATH    Gate contract path relative to repo (default: .gate/baseline.yml)
+  -h, --help                   Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="$2"
+      shift 2
+      ;;
+    --fail-on-missing)
+      fail_on_missing="$2"
+      shift 2
+      ;;
+    --require-deploy)
+      require_deploy="$2"
+      shift 2
+      ;;
+    --require-renovate)
+      require_renovate="$2"
+      shift 2
+      ;;
+    --gate-contract-path)
+      gate_contract_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "$repo" ]]; then
+  echo "Repository path does not exist: $repo" >&2
+  exit 2
+fi
+
+mkdir -p "$output_dir"
+summary_file="$output_dir/gate-baseline-summary.md"
+machine_file="$output_dir/gate-baseline-summary.tsv"
+
+failures=0
+warnings=0
+checks=0
+
+repo_rel() {
+  local path="$1"
+  path="${path#"$repo"/}"
+  printf '%s' "$path"
+}
+
+bool_is_true() {
+  [[ "$1" == "true" || "$1" == "1" || "$1" == "yes" ]]
+}
+
+workflow_files() {
+  if [[ -d "$repo/.github/workflows" ]]; then
+    find "$repo/.github/workflows" -type f \( -name '*.yml' -o -name '*.yaml' \) | sort
+  fi
+}
+
+workflow_matches() {
+  local pattern="$1"
+  local matches=""
+  local file
+
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    if grep -Eq "$pattern" "$file"; then
+      matches="${matches}$(repo_rel "$file") "
+    fi
+  done < <(workflow_files)
+
+  printf '%s' "$matches"
+}
+
+record() {
+  local status="$1"
+  local name="$2"
+  local details="$3"
+
+  checks=$((checks + 1))
+  case "$status" in
+    FAIL) failures=$((failures + 1)) ;;
+    WARN) warnings=$((warnings + 1)) ;;
+  esac
+
+  printf '| %s | %s | %s |\n' "$status" "$name" "$details" >> "$summary_file"
+  printf '%s\t%s\t%s\n' "$status" "$name" "$details" >> "$machine_file"
+}
+
+require_file() {
+  local path="$1"
+  local name="$2"
+
+  if [[ -f "$repo/$path" ]]; then
+    record "PASS" "$name" "$path exists"
+  else
+    record "FAIL" "$name" "$path is missing"
+  fi
+}
+
+require_workflow_pattern() {
+  local name="$1"
+  local pattern="$2"
+  local matches
+
+  matches="$(workflow_matches "$pattern")"
+  if [[ -n "$matches" ]]; then
+    record "PASS" "$name" "$matches"
+  else
+    record "FAIL" "$name" "No workflow matched pattern: $pattern"
+  fi
+}
+
+warn_workflow_pattern() {
+  local name="$1"
+  local pattern="$2"
+  local matches
+
+  matches="$(workflow_matches "$pattern")"
+  if [[ -n "$matches" ]]; then
+    record "PASS" "$name" "$matches"
+  else
+    record "WARN" "$name" "No workflow matched pattern: $pattern"
+  fi
+}
+
+{
+  echo "# Gate baseline evidence"
+  echo
+  echo "- Repository: $repo"
+  echo "- Gate contract path: $gate_contract_path"
+  echo "- Require deploy: $require_deploy"
+  echo "- Require Renovate: $require_renovate"
+  echo
+  echo "| Status | Check | Evidence |"
+  echo "|---|---|---|"
+} > "$summary_file"
+: > "$machine_file"
+
+if [[ -d "$repo/.github/workflows" ]]; then
+  record "PASS" "workflow directory" ".github/workflows exists"
+else
+  record "FAIL" "workflow directory" ".github/workflows is missing"
+fi
+
+require_workflow_pattern \
+  "reusable CI caller" \
+  'marcel-tuinstra/devops/\.github/workflows/reusable-(ci|php-(lint|test))\.yml@'
+
+warn_workflow_pattern \
+  "container scan caller" \
+  'marcel-tuinstra/devops/\.github/workflows/reusable-ci-docker\.yml@'
+
+require_workflow_pattern \
+  "release PR caller" \
+  'marcel-tuinstra/devops/\.github/workflows/reusable-release-pr\.yml@'
+
+require_workflow_pattern \
+  "release tag caller" \
+  'marcel-tuinstra/devops/\.github/workflows/reusable-release-tag\.yml@'
+
+if bool_is_true "$require_deploy"; then
+  require_workflow_pattern \
+    "deploy caller" \
+    'marcel-tuinstra/devops/\.github/workflows/reusable-cd-[a-z0-9-]+\.yml@'
+else
+  warn_workflow_pattern \
+    "deploy caller" \
+    'marcel-tuinstra/devops/\.github/workflows/reusable-cd-[a-z0-9-]+\.yml@'
+fi
+
+main_channel_matches="$(workflow_matches 'marcel-tuinstra/devops/\.github/workflows/[^[:space:]]+@main')"
+if [[ -n "$main_channel_matches" ]]; then
+  record "FAIL" "devops workflow pinning" "Uses @main in: $main_channel_matches"
+else
+  record "PASS" "devops workflow pinning" "No devops reusable workflow caller is pinned to @main"
+fi
+
+renovate_config=""
+for candidate in "$repo/renovate.json" "$repo/.github/renovate.json"; do
+  if [[ -f "$candidate" ]]; then
+    renovate_config="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$renovate_config" ]] && grep -q 'github>marcel-tuinstra/devops:renovate/' "$renovate_config"; then
+  record "PASS" "Renovate preset" "$(repo_rel "$renovate_config") extends devops preset"
+elif bool_is_true "$require_renovate"; then
+  record "FAIL" "Renovate preset" "renovate.json or .github/renovate.json must extend github>marcel-tuinstra/devops:renovate/*"
+else
+  record "WARN" "Renovate preset" "No devops Renovate preset found"
+fi
+
+artifact_issues=""
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  if grep -q 'actions/upload-artifact' "$file" && ! grep -q 'retention-days:' "$file"; then
+    artifact_issues="${artifact_issues}$(repo_rel "$file") "
+  fi
+done < <(workflow_files)
+
+if [[ -n "$artifact_issues" ]]; then
+  record "FAIL" "artifact retention" "Upload artifact steps missing retention-days in: $artifact_issues"
+else
+  record "PASS" "artifact retention" "No upload-artifact steps without retention-days were found"
+fi
+
+require_file "$gate_contract_path" "Gate integration contract"
+
+if [[ -f "$repo/.github/CODEOWNERS" || -f "$repo/CODEOWNERS" || -f "$repo/docs/branch-protection.md" ]]; then
+  record "PASS" "branch protection evidence" "CODEOWNERS or docs/branch-protection.md exists"
+else
+  record "WARN" "branch protection evidence" "Branch protection cannot be verified locally; attach settings evidence during rollout"
+fi
+
+{
+  echo
+  echo "## Summary"
+  echo
+  echo "- Checks: $checks"
+  echo "- Failures: $failures"
+  echo "- Warnings: $warnings"
+} >> "$summary_file"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "Gate baseline evidence written to $summary_file"
+
+if bool_is_true "$fail_on_missing" && [[ "$failures" -gt 0 ]]; then
+  echo "Gate baseline failed with $failures missing requirement(s)." >&2
+  exit 1
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 
 required_paths=(
   ".github/workflows/reusable-ci.yml"
+  ".github/workflows/reusable-gate-baseline.yml"
   "README.md"
   "docs/testing.md"
+  "docs/standards/gate-baseline.md"
+  "docs/workflows/contracts/reusable-gate-baseline.md"
+  "scripts/gate-baseline-scan.sh"
+  "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
 

--- a/templates/workflows/caller-gate-baseline.yml
+++ b/templates/workflows/caller-gate-baseline.yml
@@ -1,0 +1,23 @@
+# Template: Gate baseline evidence workflow for consumer repos.
+# Copy this file to your consumer repo at .github/workflows/gate-baseline.yml.
+#
+# Start with fail-on-missing: false while onboarding. Switch to true after the
+# repo satisfies docs/standards/gate-baseline.md and make the check required in
+# branch protection.
+
+name: gate-baseline
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1"
+
+jobs:
+  gate-baseline:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-gate-baseline.yml@v1
+    with:
+      fail-on-missing: false
+      require-deploy: true
+      require-renovate: true
+      gate-contract-path: .gate/baseline.yml


### PR DESCRIPTION
## Summary
- adds reusable Gate baseline evidence workflow
- adds local baseline scanner, consumer workflow template, contract docs, and rollout checklist
- wires the new baseline files into repo linting

## Validation
- make lint
- make test
- Ruby YAML parse for workflows/templates
- bash scripts/gate-baseline-scan.sh --repo . --fail-on-missing false