### PR TITLE
chore(ci): default templates to Node 24 LTS

### DIFF
--- a/.github/workflows/example-caller.yml
+++ b/.github/workflows/example-caller.yml
@@ -7,6 +7,6 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "20"
+      node-version: "24"
       workdir: "."
       test-command: npm test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Run lint
         run: make lint
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Run test
         run: make test

--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -99,7 +99,7 @@ jobs:
       image-ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Resolve build args from environment
         id: resolve-args
@@ -223,7 +223,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -141,10 +141,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -152,7 +152,7 @@ jobs:
 
       # Build PHP image
       - name: Build PHP image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Push PHP image to GHCR
         id: php-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -211,7 +211,7 @@ jobs:
 
       # Build nginx image
       - name: Build nginx image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -231,7 +231,7 @@ jobs:
 
       - name: Push nginx image to GHCR
         id: nginx-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -138,7 +138,7 @@ jobs:
       nginx-image-ref: ${{ steps.nginx-image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -257,7 +257,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -96,7 +96,7 @@ jobs:
       image-ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Resolve build args from environment
         id: resolve-args
@@ -210,7 +210,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -138,17 +138,17 @@ jobs:
           ALL_VARS: ${{ toJSON(vars) }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Push image to GHCR
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -37,7 +37,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -40,10 +40,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.workdir }}/${{ inputs.dockerfile }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: Node.js version to use
         required: false
-        default: "22"
+        default: "24"
         type: string
       workdir:
         description: Working directory for monorepos

--- a/.github/workflows/reusable-gate-baseline.yml
+++ b/.github/workflows/reusable-gate-baseline.yml
@@ -47,12 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout consumer repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: consumer
 
       - name: Checkout devops baseline support
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: marcel-tuinstra/devops
           ref: ${{ inputs.devops-ref }}

--- a/.github/workflows/reusable-php-lint.yml
+++ b/.github/workflows/reusable-php-lint.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231

--- a/.github/workflows/reusable-php-security.yml
+++ b/.github/workflows/reusable-php-security.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231

--- a/.github/workflows/reusable-php-test.yml
+++ b/.github/workflows/reusable-php-test.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-release-pr.yml
+++ b/.github/workflows/reusable-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/reusable-release-tag.yml
+++ b/.github/workflows/reusable-release-tag.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/docs/onboarding/consumer-migration-checklist.md
+++ b/docs/onboarding/consumer-migration-checklist.md
@@ -14,7 +14,7 @@ Create a `Dockerfile` in the consumer repo root. Use the template at
 `templates/docker/nuxt-ssg-nginx.Dockerfile` as a starting point:
 
 ```dockerfile
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/docs/workflows/contracts/reusable-ci-docker.md
+++ b/docs/workflows/contracts/reusable-ci-docker.md
@@ -107,7 +107,7 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "22"
+      node-version: "24"
   
   docker-scan:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1

--- a/docs/workflows/contracts/reusable-ci.md
+++ b/docs/workflows/contracts/reusable-ci.md
@@ -19,7 +19,7 @@ on:
 
 | Input | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `node-version` | string | No | `"22"` | Node.js version to use |
+| `node-version` | string | No | `"24"` | Node.js version to use |
 | `workdir` | string | No | `"."` | Working directory for monorepos |
 | `install-command` | string | No | `"npm ci"` | Install command |
 | `test-command` | string | No | `""` | Command to run tests (empty = skip) |
@@ -79,6 +79,6 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "22"
+      node-version: "24"
       test-command: "npm test"
 ```

--- a/docs/workflows/node-version-strategy.md
+++ b/docs/workflows/node-version-strategy.md
@@ -2,12 +2,12 @@
 
 ## Current Default
 
-The devops platform templates default to **Node.js 22 LTS** (Alpine-based images).
+The devops platform templates default to **Node.js 24 LTS** (Alpine-based images).
 
 This applies to:
 
-- `templates/docker/nuxt-ssg-nginx.Dockerfile` — base image `node:22-alpine`.
-- Reusable CI workflow (`reusable-ci.yml`) — uses `node-version` input, defaulting to `22`.
+- `templates/docker/nuxt-ssg-nginx.Dockerfile` — base image `node:24-alpine`.
+- Reusable CI workflow (`reusable-ci.yml`) — uses `node-version` input, defaulting to `24`.
 
 ## Override Mechanism
 
@@ -22,7 +22,7 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: '20'
+      node-version: '24'
 ```
 
 ### 2. Custom Dockerfile
@@ -30,7 +30,7 @@ jobs:
 Consumer repos provide their own `Dockerfile` and can use any base image:
 
 ```dockerfile
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 # ...
 ```
 

--- a/docs/workflows/reusable-ci-nuxt.md
+++ b/docs/workflows/reusable-ci-nuxt.md
@@ -11,7 +11,7 @@ Nuxt CI pipeline with the following sequence:
 
 ## Inputs
 
-- `node-version`: Node.js version (default `20`).
+- `node-version`: Node.js version (default `24`).
 - `workdir`: working directory for monorepos (default `.`).
 - `test-command`: optional test command (default empty).
 
@@ -27,7 +27,7 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "20"
+      node-version: "24"
       workdir: "."
       test-command: npm test
 ```

--- a/templates/docker/nuxt-ssg-nginx.Dockerfile
+++ b/templates/docker/nuxt-ssg-nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./

--- a/templates/docker/vite-spa-nginx.Dockerfile
+++ b/templates/docker/vite-spa-nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 # Update base image packages for security patches

--- a/templates/workflows/caller-ci-canary.yml
+++ b/templates/workflows/caller-ci-canary.yml
@@ -7,6 +7,6 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@main
     with:
-      node-version: "20"
+      node-version: "24"
       workdir: "."
       test-command: npm test

--- a/templates/workflows/caller-ci-nuxt.yml
+++ b/templates/workflows/caller-ci-nuxt.yml
@@ -7,6 +7,6 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "22"
+      node-version: "24"
       workdir: "."
       test-command: npm test

--- a/templates/workflows/caller-ci-stable.yml
+++ b/templates/workflows/caller-ci-stable.yml
@@ -8,6 +8,6 @@ jobs:
   ci:
     uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
     with:
-      node-version: "20"
+      node-version: "24"
       workdir: "."
       test-command: npm test


### PR DESCRIPTION
## Summary
- default reusable Node CI to Node 24
- update reusable Docker workflows to Docker Actions using Node 24 runtime
- update Node Docker templates and docs/examples from Node 20/22 to Node 24 LTS

## Verification
- Ruby YAML parse for changed workflow/template files
- git diff --check