### PR TITLE
ci: allow SARIF workflows to read Actions metadata

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
+      actions: read
       contents: read
       packages: write
       security-events: write

--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -127,6 +127,7 @@ jobs:
   build-scan-push:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       packages: write
       security-events: write
@@ -182,7 +183,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload PHP SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always() && hashFiles('trivy-php-results.sarif') != ''
         continue-on-error: true
         with:

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
+      actions: read
       contents: read
       packages: write
       security-events: write
@@ -177,7 +178,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -33,6 +33,7 @@ jobs:
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:
@@ -72,7 +73,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         continue-on-error: true
         with:


### PR DESCRIPTION
## What
- Add `actions: read` to reusable workflow jobs that produce or upload Trivy/SARIF results.
- Upgrade remaining `github/codeql-action/upload-sarif` usages from `v3` to `v4`.

## Why
- SARIF/Trivy telemetry attempts to read workflow-run metadata from the Actions API.
- Without `actions: read`, runs show `Resource not accessible by integration` annotations.
- Keeping this in a new devops tag preserves auditability instead of mutating an existing tag.

## Security impact
- Adds read-only access to Actions metadata only on scan/build jobs.
- Does not add write access and does not broaden secret/package permissions.

## Validation
- Parsed all workflow YAML files locally.
- `git diff --check` passed.
- Confirmed no `upload-sarif@v3` references remain.