### PR TITLE
ci: make SARIF upload opt-in

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -80,6 +80,11 @@ on:
         required: false
         default: "1"
         type: string
+      upload-sarif:
+        description: "Upload Trivy SARIF results to GitHub code scanning"
+        required: false
+        default: false
+        type: boolean
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -174,6 +179,7 @@ jobs:
         working-directory: .
 
       - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ always() && inputs.upload-sarif }}
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -185,13 +191,12 @@ jobs:
             --format sarif \
             --output trivy-results.sarif \
             "scan-target:${{ github.sha }}"
-        if: always()
         continue-on-error: true
         working-directory: .
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         continue-on-error: true
         with:
           sarif_file: ${{ inputs.workdir }}/trivy-results.sarif

--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -87,6 +87,11 @@ on:
         required: false
         default: "1"
         type: string
+      upload-sarif:
+        description: "Upload Trivy SARIF results to GitHub code scanning"
+        required: false
+        default: false
+        type: boolean
       run-migrations:
         description: "Run Doctrine migrations after deploy"
         required: false
@@ -174,7 +179,7 @@ jobs:
 
       - name: Upload Trivy PHP scan results
         uses: aquasecurity/trivy-action@0.35.0
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         with:
           image-ref: scan-target-php:${{ github.sha }}
           format: sarif
@@ -184,7 +189,7 @@ jobs:
 
       - name: Upload PHP SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: always() && hashFiles('trivy-php-results.sarif') != ''
+        if: ${{ always() && inputs.upload-sarif && hashFiles('trivy-php-results.sarif') != '' }}
         continue-on-error: true
         with:
           sarif_file: trivy-php-results.sarif

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -80,6 +80,11 @@ on:
         required: false
         default: "1"
         type: string
+      upload-sarif:
+        description: "Upload Trivy SARIF results to GitHub code scanning"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-scan-push:
@@ -169,7 +174,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: aquasecurity/trivy-action@0.35.0
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         with:
           image-ref: scan-target:${{ github.sha }}
           format: sarif
@@ -179,7 +184,7 @@ jobs:
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         continue-on-error: true
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: "1"
         type: string
+      upload-sarif:
+        description: "Upload Trivy SARIF results to GitHub code scanning"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-and-scan:
@@ -64,7 +69,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: aquasecurity/trivy-action@0.35.0
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         with:
           image-ref: scan-target:${{ github.sha }}
           format: sarif
@@ -74,7 +79,7 @@ jobs:
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: ${{ always() && inputs.upload-sarif }}
         continue-on-error: true
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## What
- Add an `upload-sarif` boolean input to Docker/CD reusable scan workflows.
- Default SARIF upload to `false`.
- Keep Trivy table scans and vulnerability failure behavior unchanged.

## Why
- Private repos without code scanning enabled cannot upload SARIF and emit noisy CodeQL/code scanning annotations.
- These repos still need the image scan, just not the GitHub code scanning upload.

## Security impact
- Does not weaken image scanning: table scans still run and still fail according to `trivy-exit-code`.
- Repos with code scanning can opt in explicitly with `upload-sarif: true`.

## Validation
- Parsed all workflow YAML files locally.
- `git diff --check` passed.
- Verified all SARIF upload steps are gated by `inputs.upload-sarif`.