### PR TITLE
Disable Trivy Actions cache

### DIFF
--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -176,6 +176,7 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload Trivy PHP scan results
         uses: aquasecurity/trivy-action@0.35.0
@@ -186,6 +187,7 @@ jobs:
           output: trivy-php-results.sarif
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload PHP SARIF file
         uses: github/codeql-action/upload-sarif@v4
@@ -234,6 +236,7 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Push nginx image to GHCR
         id: nginx-push

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -171,6 +171,7 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: aquasecurity/trivy-action@0.35.0
@@ -181,6 +182,7 @@ jobs:
           output: trivy-results.sarif
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -66,6 +66,7 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: aquasecurity/trivy-action@0.35.0
@@ -76,6 +77,7 @@ jobs:
           output: trivy-results.sarif
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: true
+          cache: false
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## What changed
- Set `cache: false` on Trivy scan steps in reusable Docker CI/CD workflows.

## Why
`aquasecurity/trivy-action@0.35.0` defaults to GitHub Actions cache and currently invokes `actions/cache@v4.2.4`, which targets Node.js 20 and creates the Console deploy warning. Disabling that cache removes the transitive Node 20 action and reduces Actions storage usage.

## Verification
- Workflow YAML parses locally.
- `git diff --check` is clean.

## Actions budget impact
No extra jobs or triggers. Trivy may spend a little more network time fetching its DB, but it stops writing Trivy DB cache into GitHub Actions storage and removes the Node 20 cache action path.