### PR TITLE
fix(ci): read production host in reusable job

### DIFF
--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -98,11 +98,6 @@ on:
         required: false
         default: false
         type: boolean
-      deploy_host:
-        description: Public host or IP address for the restricted deployment endpoint.
-        required: false
-        default: ""
-        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -337,7 +332,7 @@ jobs:
 
       - name: Deploy Git SHA through restricted endpoint
         env:
-          DEPLOY_HOST: ${{ inputs.deploy_host }}
+          DEPLOY_HOST: ${{ vars.PROD_HOST }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           test -n "$DEPLOY_HOST"


### PR DESCRIPTION
GitHub evaluates caller variables before the reusable job binds its Environment. Resolve PROD_HOST inside the restricted deploy job instead, where the production environment variables are available.