### PR TITLE
DEV-2: add trusted-heavy CI workflow contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,7 @@ docs/workflows/contracts/ @marcel-tuinstra
 # Versioning and release policy - require platform owner review
 docs/workflows/versioning-policy.md @marcel-tuinstra
 docs/workflows/release-procedure.md @marcel-tuinstra
+
+# Security policy and executable workflow contract checks
+docs/security/pipeline-security-policy.md @marcel-tuinstra
+scripts/workflow-contract-test.sh @marcel-tuinstra

--- a/.github/workflows/reusable-browser-quality.yml
+++ b/.github/workflows/reusable-browser-quality.yml
@@ -1,0 +1,129 @@
+name: Reusable Browser Quality
+
+on:
+  workflow_call:
+    inputs:
+      execution-class:
+        description: "Execution class: hosted or trusted-heavy"
+        required: false
+        default: hosted
+        type: string
+      node-version:
+        description: Node.js version used for the browser suite
+        required: false
+        default: "24"
+        type: string
+      workdir:
+        description: Working directory containing package-lock.json
+        required: false
+        default: "."
+        type: string
+      browser:
+        description: "Playwright browser: chromium, firefox, or webkit"
+        required: false
+        default: chromium
+        type: string
+      test-script:
+        description: npm package script that executes the browser suite
+        required: false
+        default: test:ui
+        type: string
+      report-path:
+        description: Repository-relative path produced by the browser reporter
+        required: false
+        default: playwright-report
+        type: string
+      artifact-retention-days:
+        description: Number of days to retain the browser report
+        required: false
+        default: 14
+        type: number
+    outputs:
+      report-artifact:
+        description: Deterministic browser report artifact name
+        value: ${{ jobs['browser-quality'].outputs['report-artifact'] }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  browser-quality:
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdir }}
+    outputs:
+      report-artifact: ${{ steps.contract.outputs['report-artifact'] }}
+    steps:
+      - name: Validate contract inputs
+        id: contract
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        env:
+          EXECUTION_CLASS: ${{ inputs['execution-class'] }}
+          EVENT_NAME: ${{ github.event_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          ACTOR: ${{ github.actor }}
+          WORKDIR: ${{ inputs.workdir }}
+          BROWSER: ${{ inputs.browser }}
+          TEST_SCRIPT: ${{ inputs['test-script'] }}
+          REPORT_PATH: ${{ inputs['report-path'] }}
+          RETENTION_DAYS: ${{ inputs['artifact-retention-days'] }}
+        run: |
+          set -euo pipefail
+          case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+            exit 2
+          fi
+          case "$BROWSER" in chromium|firefox|webkit) ;; *) echo "browser must be chromium, firefox, or webkit" >&2; exit 2 ;; esac
+          if [[ ! "$TEST_SCRIPT" =~ ^[A-Za-z0-9:_-]+$ ]]; then
+            echo "test-script must be an npm script name, not a shell command" >&2
+            exit 2
+          fi
+          for path in "$WORKDIR" "$REPORT_PATH"; do
+            if [[ -z "$path" || "$path" = /* || "$path" =~ (^|/)\.\.(/|$) ]]; then
+              echo "workdir and report-path must be non-empty repository-relative paths without '..'" >&2
+              exit 2
+            fi
+          done
+          if (( RETENTION_DAYS < 1 || RETENTION_DAYS > 90 )); then
+            echo "artifact-retention-days must be between 1 and 90" >&2
+            exit 2
+          fi
+          echo "report-artifact=browser-quality-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.2.0
+        with:
+          node-version: ${{ inputs['node-version'] }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.workdir }}/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Install requested Playwright browser
+        env:
+          BROWSER: ${{ inputs.browser }}
+        run: ./node_modules/.bin/playwright install --with-deps "$BROWSER"
+
+      - name: Run browser quality suite
+        env:
+          TEST_SCRIPT: ${{ inputs['test-script'] }}
+        run: npm run "$TEST_SCRIPT"
+
+      - name: Upload deterministic browser report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.contract.outputs['report-artifact'] }}
+          path: ${{ inputs.workdir }}/${{ inputs['report-path'] }}
+          if-no-files-found: error
+          retention-days: ${{ inputs['artifact-retention-days'] }}
+          compression-level: 9

--- a/.github/workflows/reusable-cd-nuxt-ssg.yml
+++ b/.github/workflows/reusable-cd-nuxt-ssg.yml
@@ -118,7 +118,7 @@ jobs:
       image-ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Resolve build args from environment
         id: resolve-args
@@ -208,7 +208,7 @@ jobs:
         working-directory: .
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4.32.6
         if: ${{ always() && inputs.upload-sarif }}
         continue-on-error: true
         with:
@@ -243,7 +243,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-cd-php.yml
+++ b/.github/workflows/reusable-cd-php.yml
@@ -144,13 +144,13 @@ jobs:
       nginx-image-ref: ${{ steps.nginx-image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
 
       # Build PHP image
       - name: Build PHP image for scanning
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -169,7 +169,7 @@ jobs:
           build-args: ${{ inputs.build-args }}
 
       - name: Run Trivy on PHP image
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-target-php:${{ github.sha }}
           format: table
@@ -179,7 +179,7 @@ jobs:
           cache: false
 
       - name: Upload Trivy PHP scan results
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: ${{ always() && inputs.upload-sarif }}
         with:
           image-ref: scan-target-php:${{ github.sha }}
@@ -190,7 +190,7 @@ jobs:
           cache: false
 
       - name: Upload PHP SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4.32.6
         if: ${{ always() && inputs.upload-sarif && hashFiles('trivy-php-results.sarif') != '' }}
         continue-on-error: true
         with:
@@ -199,7 +199,7 @@ jobs:
 
       - name: Push PHP image to GHCR
         id: php-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -219,7 +219,7 @@ jobs:
 
       # Build nginx image
       - name: Build nginx image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -229,7 +229,7 @@ jobs:
           tags: scan-target-nginx:${{ github.sha }}
 
       - name: Run Trivy on nginx image
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-target-nginx:${{ github.sha }}
           format: table
@@ -240,7 +240,7 @@ jobs:
 
       - name: Push nginx image to GHCR
         id: nginx-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -266,7 +266,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-cd-vite-spa.yml
+++ b/.github/workflows/reusable-cd-vite-spa.yml
@@ -102,7 +102,7 @@ jobs:
       image-ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Resolve build args from environment
         id: resolve-args
@@ -144,17 +144,17 @@ jobs:
           ALL_VARS: ${{ toJSON(vars) }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build image for scanning
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -164,7 +164,7 @@ jobs:
           build-args: ${{ steps.resolve-args.outputs.args }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-target:${{ github.sha }}
           format: table
@@ -174,7 +174,7 @@ jobs:
           cache: false
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: ${{ always() && inputs.upload-sarif }}
         with:
           image-ref: scan-target:${{ github.sha }}
@@ -185,7 +185,7 @@ jobs:
           cache: false
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4.32.6
         if: ${{ always() && inputs.upload-sarif }}
         continue-on-error: true
         with:
@@ -193,7 +193,7 @@ jobs:
 
       - name: Push image to GHCR
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.dockerfile }}
@@ -218,7 +218,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Ensure SSH key is present
         env:

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -3,85 +3,168 @@ name: Reusable CI Docker
 on:
   workflow_call:
     inputs:
+      execution-class:
+        description: "Execution class: hosted or trusted-heavy"
+        required: false
+        default: hosted
+        type: string
       workdir:
-        description: Working directory containing Dockerfile
+        description: Working directory containing the Docker build context
         required: false
         default: "."
         type: string
       dockerfile:
         description: Dockerfile path relative to workdir
         required: false
-        default: "Dockerfile"
+        default: Dockerfile
         type: string
       build-args:
-        description: "Newline-separated Docker build args (e.g. ARG_NAME=value)"
+        description: "Explicit, newline-separated non-secret Docker build arguments"
         required: false
         default: ""
         type: string
       trivy-severity:
-        description: "Comma-separated severity levels to scan for"
+        description: Comma-separated vulnerability severity levels
         required: false
-        default: "CRITICAL,HIGH"
+        default: CRITICAL,HIGH
         type: string
       trivy-exit-code:
-        description: "Exit code when vulnerabilities are found (1 = fail, 0 = warn only)"
+        description: "Exit code on findings: 1 fails, 0 reports only"
         required: false
         default: "1"
         type: string
       upload-sarif:
-        description: "Upload Trivy SARIF results to GitHub code scanning"
+        description: Upload the SARIF report to GitHub code scanning
         required: false
         default: false
         type: boolean
+      artifact-retention-days:
+        description: Number of days to retain scan reports
+        required: false
+        default: 14
+        type: number
+    outputs:
+      image-digest:
+        description: Digest of the locally built scan image
+        value: ${{ jobs['build-and-scan'].outputs['image-digest'] }}
+      scan-artifact:
+        description: Deterministic artifact name containing table and SARIF reports
+        value: ${{ jobs['build-and-scan'].outputs['scan-artifact'] }}
+      sarif-artifact:
+        description: Scan artifact used for an optional code-scanning upload
+        value: ${{ jobs['build-and-scan'].outputs['scan-artifact'] }}
 
 jobs:
   build-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
     permissions:
-      actions: read
       contents: read
-      security-events: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+      scan-artifact: ${{ steps.contract.outputs['scan-artifact'] }}
     steps:
+      - name: Validate contract inputs
+        shell: bash
+        env:
+          EXECUTION_CLASS: ${{ inputs['execution-class'] }}
+          EVENT_NAME: ${{ github.event_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          ACTOR: ${{ github.actor }}
+          WORKDIR: ${{ inputs.workdir }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          TRIVY_EXIT_CODE: ${{ inputs['trivy-exit-code'] }}
+          RETENTION_DAYS: ${{ inputs['artifact-retention-days'] }}
+        run: |
+          set -euo pipefail
+          case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+            exit 2
+          fi
+          for path in "$WORKDIR" "$DOCKERFILE"; do
+            if [[ -z "$path" || "$path" = /* || "$path" =~ (^|/)\.\.(/|$) ]]; then
+              echo "workdir and dockerfile must be non-empty repository-relative paths without '..'" >&2
+              exit 2
+            fi
+          done
+          case "$TRIVY_EXIT_CODE" in 0|1) ;; *) echo "trivy-exit-code must be 0 or 1" >&2; exit 2 ;; esac
+          if (( RETENTION_DAYS < 1 || RETENTION_DAYS > 90 )); then
+            echo "artifact-retention-days must be between 1 and 90" >&2
+            exit 2
+          fi
+          echo "scan-artifact=docker-scan-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        id: contract
+
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
 
       - name: Build image for scanning
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: ${{ inputs.workdir }}
           file: ${{ inputs.workdir }}/${{ inputs.dockerfile }}
           push: false
           load: true
           tags: scan-target:${{ github.sha }}
-          build-args: ${{ inputs.build-args }}
+          build-args: ${{ inputs['build-args'] }}
+          provenance: false
+          sbom: false
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      - name: Run enforcing vulnerability scan
+        id: scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-target:${{ github.sha }}
           format: table
-          exit-code: ${{ inputs.trivy-exit-code }}
-          severity: ${{ inputs.trivy-severity }}
+          output: trivy-results.txt
+          exit-code: ${{ inputs['trivy-exit-code'] }}
+          severity: ${{ inputs['trivy-severity'] }}
           ignore-unfixed: true
           cache: false
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: aquasecurity/trivy-action@0.35.0
-        if: ${{ always() && inputs.upload-sarif }}
+      - name: Produce deterministic SARIF report
+        if: ${{ always() && steps.build.outcome == 'success' }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: scan-target:${{ github.sha }}
           format: sarif
           output: trivy-results.sarif
-          severity: ${{ inputs.trivy-severity }}
+          exit-code: "0"
+          severity: ${{ inputs['trivy-severity'] }}
           ignore-unfixed: true
           cache: false
 
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
-        if: ${{ always() && inputs.upload-sarif }}
-        continue-on-error: true
+      - name: Upload deterministic scan reports
+        if: ${{ always() && steps.build.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.contract.outputs['scan-artifact'] }}
+          path: |
+            trivy-results.txt
+            trivy-results.sarif
+          if-no-files-found: error
+          retention-days: ${{ inputs['artifact-retention-days'] }}
+          compression-level: 9
+
+  upload-sarif:
+    needs: build-and-scan
+    if: ${{ always() && inputs['upload-sarif'] && needs['build-and-scan'].outputs['scan-artifact'] != '' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Download scan reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs['build-and-scan'].outputs['scan-artifact'] }}
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4.32.6
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -35,10 +35,10 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.2.0
         with:
           node-version: ${{ inputs['node-version'] }}
           cache: npm

--- a/.github/workflows/reusable-gate-baseline.yml
+++ b/.github/workflows/reusable-gate-baseline.yml
@@ -47,12 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout consumer repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           path: consumer
 
       - name: Checkout devops baseline support
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           repository: marcel-tuinstra/devops
           ref: ${{ inputs.devops-ref }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload baseline evidence
         if: ${{ always() && inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: gate-baseline-evidence
           path: gate-baseline-evidence/

--- a/.github/workflows/reusable-php-lint.yml
+++ b/.github/workflows/reusable-php-lint.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231

--- a/.github/workflows/reusable-php-security.yml
+++ b/.github/workflows/reusable-php-security.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{ inputs.workdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231

--- a/.github/workflows/reusable-php-test.yml
+++ b/.github/workflows/reusable-php-test.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-release-image.yml
+++ b/.github/workflows/reusable-release-image.yml
@@ -1,0 +1,176 @@
+name: Reusable Release Image
+
+on:
+  workflow_call:
+    inputs:
+      execution-class:
+        description: "Execution class: hosted or trusted-heavy"
+        required: false
+        default: hosted
+        type: string
+      registry:
+        description: OCI registry hostname
+        required: false
+        default: ghcr.io
+        type: string
+      image-name:
+        description: Lowercase repository path in the registry, without a tag
+        required: true
+        type: string
+      workdir:
+        description: Working directory used as Docker build context
+        required: false
+        default: "."
+        type: string
+      dockerfile:
+        description: Dockerfile path relative to workdir
+        required: false
+        default: Dockerfile
+        type: string
+      build-args:
+        description: "Explicit, newline-separated non-secret Docker build arguments"
+        required: false
+        default: ""
+        type: string
+      platforms:
+        description: "Comma-separated target platforms: linux/amd64 and/or linux/arm64"
+        required: false
+        default: linux/amd64
+        type: string
+      artifact-retention-days:
+        description: Number of days to retain the signed provenance bundle
+        required: false
+        default: 30
+        type: number
+    secrets:
+      registry-username:
+        description: Explicit registry username; defaults to github.actor for GHCR
+        required: false
+      registry-password:
+        description: Explicit registry token; defaults to github.token for GHCR
+        required: false
+    outputs:
+      image-ref:
+        description: Immutable registry reference in name@digest form
+        value: ${{ jobs['release-image'].outputs['image-ref'] }}
+      image-digest:
+        description: Immutable OCI manifest digest
+        value: ${{ jobs['release-image'].outputs['image-digest'] }}
+      provenance-artifact:
+        description: Deterministic artifact containing the signed provenance bundle
+        value: ${{ jobs['release-image'].outputs['provenance-artifact'] }}
+      provenance-url:
+        description: GitHub attestation URL for the released digest
+        value: ${{ jobs['release-image'].outputs['provenance-url'] }}
+
+jobs:
+  release-image:
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      image-ref: ${{ steps['contract-outputs'].outputs['image-ref'] }}
+      image-digest: ${{ steps.build.outputs.digest }}
+      provenance-artifact: ${{ steps.contract.outputs['provenance-artifact'] }}
+      provenance-url: ${{ steps.provenance.outputs['attestation-url'] }}
+    steps:
+      - name: Validate contract inputs
+        id: contract
+        shell: bash
+        env:
+          EXECUTION_CLASS: ${{ inputs['execution-class'] }}
+          EVENT_NAME: ${{ github.event_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          ACTOR: ${{ github.actor }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs['image-name'] }}
+          WORKDIR: ${{ inputs.workdir }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          PLATFORMS: ${{ inputs.platforms }}
+          RETENTION_DAYS: ${{ inputs['artifact-retention-days'] }}
+        run: |
+          set -euo pipefail
+          case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+            exit 2
+          fi
+          if [[ ! "$REGISTRY" =~ ^[a-z0-9.-]+(:[0-9]+)?$ ]]; then
+            echo "registry must be a hostname with an optional port" >&2
+            exit 2
+          fi
+          if [[ ! "$IMAGE_NAME" =~ ^[a-z0-9]+([._/-][a-z0-9]+)*$ ]]; then
+            echo "image-name must be a lowercase registry repository path without a tag" >&2
+            exit 2
+          fi
+          for path in "$WORKDIR" "$DOCKERFILE"; do
+            if [[ -z "$path" || "$path" = /* || "$path" =~ (^|/)\.\.(/|$) ]]; then
+              echo "workdir and dockerfile must be non-empty repository-relative paths without '..'" >&2
+              exit 2
+            fi
+          done
+          case "$PLATFORMS" in linux/amd64|linux/arm64|linux/amd64,linux/arm64|linux/arm64,linux/amd64) ;;
+            *) echo "platforms may contain only linux/amd64 and linux/arm64" >&2; exit 2 ;;
+          esac
+          if (( RETENTION_DAYS < 1 || RETENTION_DAYS > 90 )); then
+            echo "artifact-retention-days must be between 1 and 90" >&2
+            exit 2
+          fi
+          echo "provenance-artifact=release-provenance-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.0.0
+
+      - name: Log in to registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.0.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets['registry-username'] || github.actor }}
+          password: ${{ secrets['registry-password'] || github.token }}
+
+      - name: Build and push release image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
+        with:
+          context: ${{ inputs.workdir }}
+          file: ${{ inputs.workdir }}/${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ inputs.registry }}/${{ inputs['image-name'] }}:sha-${{ github.sha }}
+          build-args: ${{ inputs['build-args'] }}
+          provenance: false
+          sbom: true
+
+      - name: Attest immutable image digest
+        id: provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3.2.0
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs['image-name'] }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Publish immutable contract outputs
+        id: contract-outputs
+        shell: bash
+        env:
+          IMAGE_REPOSITORY: ${{ inputs.registry }}/${{ inputs['image-name'] }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: echo "image-ref=${IMAGE_REPOSITORY}@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload signed provenance bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.contract.outputs['provenance-artifact'] }}
+          path: ${{ steps.provenance.outputs['bundle-path'] }}
+          if-no-files-found: error
+          retention-days: ${{ inputs['artifact-retention-days'] }}
+          compression-level: 9

--- a/.github/workflows/reusable-release-pr.yml
+++ b/.github/workflows/reusable-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/reusable-release-tag.yml
+++ b/.github/workflows/reusable-release-tag.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/docs/security/pipeline-security-policy.md
+++ b/docs/security/pipeline-security-policy.md
@@ -45,6 +45,27 @@ the DevOps platform.
 - Reusable workflows must declare provenance expectations in docs.
 - Build artifacts should include SBOM generation for deployable images.
 
+### 6) Runner Trust Boundary
+
+- Public contracts expose only `hosted` and `trusted-heavy`; arbitrary labels, groups, and `runs-on` fragments are prohibited.
+- `hosted` is the default and the fallback whenever a caller omits or supplies an invalid class.
+- Fork pull requests, Dependabot, and `pull_request_target` must never schedule `trusted-heavy`. The runner-selection expression enforces this before a job is queued, and contract validation fails a forbidden request on a hosted runner.
+- Consumer repository variables may select the execution class only with an explicit hosted fallback. Manual inputs must be enumerated choices.
+
+### 7) Build and Release Integrity
+
+- Docker build arguments come only from the declared `build-args` input. Workflows do not merge arbitrary environment variables into builds.
+- Secrets in Docker build arguments are prohibited. Reusable callers declare individual secrets and never use `secrets: inherit`.
+- Release workflows publish and return immutable `name@sha256:digest` references.
+- Release provenance is signed through GitHub OIDC, pushed alongside the image, and retained as a deterministic artifact. Deployments consume the digest, not a mutable tag.
+- Browser and scan reports use commit-derived names, explicit retention, and fail when promised artifacts are absent.
+
+### 8) Immutable Workflow References
+
+- Every third-party action is pinned to a full 40-character commit SHA. A version comment records the reviewed upstream release.
+- Production reusable-workflow callers pin the approved v10 release commit by full SHA. Tags remain immutable discovery and audit markers.
+- Rollback changes caller SHAs and image digests through normal reviewed commits; it never rewrites a branch or moves a tag.
+
 ## Pilot Repository Baseline
 
 The pilot model for control validation is documented in

--- a/docs/workflows/contracts/README.md
+++ b/docs/workflows/contracts/README.md
@@ -12,12 +12,19 @@ Workflow contracts document the stable API surface of each reusable workflow:
 
 ## Available Contracts
 
-### Node.js / Nuxt
+### v10 CI and release contracts
+
+| Workflow | Version | Status |
+|----------|---------|--------|
+| [reusable-browser-quality.yml](reusable-browser-quality.md) | v10 | Stable |
+| [reusable-ci-docker.yml](reusable-ci-docker.md) | v10 | Stable |
+| [reusable-release-image.yml](reusable-release-image.md) | v10 | Stable |
+
+### Legacy application contracts
 
 | Workflow | Version | Status |
 |----------|---------|--------|
 | [reusable-ci.yml](reusable-ci.md) | v1 | Stable |
-| [reusable-ci-docker.yml](reusable-ci-docker.md) | v1 | Stable |
 | [reusable-cd-nuxt-ssg.yml](reusable-cd-nuxt-ssg.md) | v1 | Stable |
 
 ### Vite / SPA

--- a/docs/workflows/contracts/reusable-browser-quality.md
+++ b/docs/workflows/contracts/reusable-browser-quality.md
@@ -1,0 +1,42 @@
+# Workflow Contract: reusable-browser-quality.yml
+
+**Version:** v10  
+**Status:** Stable  
+**Last Updated:** 2026-07-20
+
+## Purpose
+
+Runs a locked npm install and one named Playwright package script on either a GitHub-hosted runner or the controlled `trusted-heavy` runner class. The workflow installs exactly one of Chromium, Firefox, or WebKit and publishes a predictably named report artifact.
+
+## Public interface
+
+| Input | Type | Required | Default |
+|---|---|---:|---|
+| `execution-class` | string | No | `hosted` |
+| `node-version` | string | No | `24` |
+| `workdir` | string | No | `.` |
+| `browser` | string | No | `chromium` |
+| `test-script` | string | No | `test:ui` |
+| `report-path` | string | No | `playwright-report` |
+| `artifact-retention-days` | number | No | `14` |
+
+Output `report-artifact` is `browser-quality-<github.sha>`. The workflow accepts no secrets and grants only `contents: read`.
+
+`test-script` is an npm script name, not a shell command. Paths must be repository-relative and may not traverse through `..`. Retention is limited to 1–90 days.
+
+## Execution trust boundary
+
+`execution-class` accepts only `hosted` or `trusted-heavy`. Omitted and invalid values select `ubuntu-24.04`; invalid values then fail validation. `trusted-heavy` resolves only to `[self-hosted, trusted-heavy]` and is rejected for fork pull requests, `pull_request_target`, and Dependabot. Callers must preserve a hosted path for untrusted changes.
+
+Consumer repositories can use a controlled repository variable while retaining the safe default:
+
+```yaml
+jobs:
+  browser:
+    uses: Tuinstra-DEV/devops/.github/workflows/reusable-browser-quality.yml@<full-v10-commit-sha>
+    with:
+      execution-class: ${{ vars.CI_EXECUTION_CLASS || 'hosted' }}
+```
+
+For manual callers, expose a `workflow_dispatch` choice containing only `hosted` and `trusted-heavy`. Never pass a free-form runner label.
+

--- a/docs/workflows/contracts/reusable-ci-docker.md
+++ b/docs/workflows/contracts/reusable-ci-docker.md
@@ -1,116 +1,48 @@
 # Workflow Contract: reusable-ci-docker.yml
 
-**Version:** v1  
+**Version:** v10
 **Status:** Stable  
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-20
 
 ## Purpose
 
-Reusable CI workflow for Docker-based projects. Builds the Docker image and scans it with Trivy for security vulnerabilities during pull requests. This enables developers to catch and fix vulnerabilities before merging.
+Builds a local Docker image, enforces a Trivy vulnerability policy, and publishes deterministic table and SARIF reports. SARIF upload is isolated in a second job so `security-events: write` is granted only when requested.
 
-## Trigger
+## Public interface
 
-```yaml
-on:
-  workflow_call:
-```
+| Input | Type | Required | Default |
+|---|---|---:|---|
+| `execution-class` | string | No | `hosted` |
+| `workdir` | string | No | `.` |
+| `dockerfile` | string | No | `Dockerfile` |
+| `build-args` | string | No | empty |
+| `trivy-severity` | string | No | `CRITICAL,HIGH` |
+| `trivy-exit-code` | string | No | `1` |
+| `upload-sarif` | boolean | No | `false` |
+| `artifact-retention-days` | number | No | `14` |
 
-## Inputs
+The existing v1 inputs remain valid. v10 adds `execution-class`, `artifact-retention-days`, and outputs without changing the default hosted behavior.
 
-| Input | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `workdir` | string | No | `.` | Working directory containing Dockerfile |
-| `dockerfile` | string | No | `Dockerfile` | Dockerfile path relative to workdir |
-| `build-args` | string | No | `""` | Newline-separated Docker build args |
-| `trivy-severity` | string | No | `"CRITICAL,HIGH"` | Comma-separated severity levels to scan |
-| `trivy-exit-code` | string | No | `"1"` | Exit code on findings (1 = fail, 0 = warn) |
+| Output | Guarantee |
+|---|---|
+| `image-digest` | Digest returned by the local BuildKit build |
+| `scan-artifact` | `docker-scan-<github.sha>` containing table and SARIF reports |
+| `sarif-artifact` | Alias of `scan-artifact` for code-scanning consumers |
 
-## Outputs
+The build/scan job grants only `contents: read`. The optional upload job grants `actions: read`, `contents: read`, and `security-events: write`. No secrets are accepted. `build-args` is the only build-argument source and is for non-secret values only.
 
-None.
+The execution trust boundary and repository-variable/manual fallback are documented in [reusable-browser-quality](reusable-browser-quality.md). Fork pull requests, `pull_request_target`, and Dependabot can never select a trusted runner.
 
-## Required Secrets
-
-None. This workflow does not push images or access external services.
-
-## Required Permissions
-
-```yaml
-permissions:
-  contents: read
-  security-events: write
-```
-
-## Jobs
-
-| Job | Description |
-|-----|-------------|
-| `build-and-scan` | Build Docker image locally and scan with Trivy |
-
-## Expected Behavior
-
-1. Checkout code
-2. Setup Docker Buildx
-3. Build image locally (no push)
-4. Run Trivy vulnerability scan
-5. Upload SARIF results to GitHub Security tab
-6. **Fail PR if CRITICAL/HIGH vulnerabilities found** (configurable)
-
-## Security Scanning
-
-The workflow uses [Trivy](https://trivy.dev/) to scan Docker images.
-
-**Default behavior:**
-- Scans for `CRITICAL` and `HIGH` severity vulnerabilities
-- Fails the pipeline if any are found (blocks merge)
-- Ignores unfixed vulnerabilities (only actionable findings)
-- Uploads results to GitHub Security tab (SARIF format)
-
-**Use cases:**
-- Shift security left: developers fix vulnerabilities in PRs
-- Consistent scanning across CI and CD pipelines
-- Visibility via GitHub Security tab
-
-## Breaking Change Policy
-
-See [versioning-policy.md](../versioning-policy.md) for major version upgrade procedures.
-
-Changes that require a major version bump:
-- Removing or renaming existing inputs
-- Changing default security scan behavior
-- Changing required permissions
-
-## Example Caller
+## Example
 
 ```yaml
-name: CI
-
-on:
-  pull_request:
-
 jobs:
-  docker-scan:
-    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+  image-quality:
+    permissions:
+      contents: read
+      security-events: write
+    uses: Tuinstra-DEV/devops/.github/workflows/reusable-ci-docker.yml@<full-v10-commit-sha>
     with:
-      dockerfile: Dockerfile
-```
-
-### Combined with Node.js CI
-
-```yaml
-name: CI
-
-on:
-  pull_request:
-
-jobs:
-  ci:
-    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
-    with:
-      node-version: "24"
-  
-  docker-scan:
-    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
-    with:
-      dockerfile: Dockerfile
+      execution-class: ${{ vars.CI_EXECUTION_CLASS || 'hosted' }}
+      upload-sarif: true
 ```

--- a/docs/workflows/contracts/reusable-release-image.md
+++ b/docs/workflows/contracts/reusable-release-image.md
@@ -1,0 +1,41 @@
+# Workflow Contract: reusable-release-image.yml
+
+**Version:** v10  
+**Status:** Stable  
+**Last Updated:** 2026-07-20
+
+## Purpose
+
+Builds and pushes an OCI image, generates an SBOM attestation, signs GitHub build provenance for the immutable manifest digest, pushes the provenance to the registry, and uploads the provenance bundle as a deterministic workflow artifact.
+
+## Public interface
+
+| Input | Type | Required | Default |
+|---|---|---:|---|
+| `execution-class` | string | No | `hosted` |
+| `registry` | string | No | `ghcr.io` |
+| `image-name` | string | Yes | — |
+| `workdir` | string | No | `.` |
+| `dockerfile` | string | No | `Dockerfile` |
+| `build-args` | string | No | empty |
+| `platforms` | string | No | `linux/amd64` |
+| `artifact-retention-days` | number | No | `30` |
+
+| Secret | Required | Purpose |
+|---|---:|---|
+| `registry-username` | No | Explicit non-GHCR registry username |
+| `registry-password` | No | Explicit non-GHCR registry token |
+
+GHCR uses `github.actor` and the job-scoped `github.token` by default. Callers must grant the reusable job `packages: write`, `id-token: write`, and `attestations: write`. External registries require the two explicitly named secrets; callers must not use `secrets: inherit`.
+
+| Output | Guarantee |
+|---|---|
+| `image-ref` | Immutable `<registry>/<name>@sha256:...` reference |
+| `image-digest` | OCI manifest digest returned by BuildKit |
+| `provenance-artifact` | `release-provenance-<github.sha>` |
+| `provenance-url` | GitHub attestation record URL |
+
+Only `linux/amd64` and `linux/arm64` are accepted. `build-args` are the sole build-argument source and must never contain credentials or sensitive values; use BuildKit secret mounts in a separately reviewed contract if a build truly requires secrets.
+
+The execution trust boundary and caller fallback are identical to [reusable-browser-quality](reusable-browser-quality.md). Release jobs should run from a protected branch or approved manual workflow, never from untrusted pull-request code.
+

--- a/docs/workflows/release-procedure.md
+++ b/docs/workflows/release-procedure.md
@@ -1,103 +1,51 @@
-# Release Procedure
+# Reusable Workflow v10 Release Procedure
 
-## Overview
+## Preconditions
 
-Reusable workflows in this repository are consumed by external repos via major version tags (e.g. `@v1`). This document describes how to create and manage those tags.
+- DEV-2 acceptance criteria and repository Definition of Done are met.
+- `make lint` and `make test` pass on the exact reviewed commit.
+- CODEOWNERS approval is recorded.
+- The commit is merged to `main` without rewriting history.
+- Canary consumers have validated the exact commit SHA on hosted runners.
 
-## Tag Convention
+No command in this procedure moves an existing tag or uses a force push.
 
-| Tag | Purpose |
-|---|---|
-| `v1` | Current stable major version |
-| `v2` | Next major (only after breaking changes) |
-| `@main` | Canary / bleeding edge (not recommended for production) |
+## Create the stable v10 release
 
-Consumer repos reference workflows like:
+Set the reviewed merge commit explicitly and verify it before tagging:
+
+```bash
+release_sha=<full-reviewed-main-commit-sha>
+git show --no-patch --format=fuller "$release_sha"
+git tag -a v10.0.0 "$release_sha" -m "Reusable workflow contracts v10.0.0"
+git tag -a v10 "$release_sha" -m "Stable reusable workflow contract v10"
+git push origin v10.0.0 v10
+```
+
+Both tags are immutable audit markers. If either tag already exists, stop and investigate; do not amend, delete, recreate, or force-push it.
+
+Verify the remote objects and record the resolved commit SHA in release notes:
+
+```bash
+git ls-remote --tags origin refs/tags/v10 refs/tags/v10^{} refs/tags/v10.0.0 refs/tags/v10.0.0^{}
+```
+
+Update production callers to the full resolved commit SHA, never to the tag name:
 
 ```yaml
-uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1
+uses: Tuinstra-DEV/devops/.github/workflows/reusable-release-image.yml@<full-v10-commit-sha>
 ```
 
-## Releasing a Patch or Minor Change
+## Patch and minor releases
 
-After merging a backward-compatible change to `main`:
-
-```bash
-make release-tag TAG=v1
-```
-
-This force-moves the `v1` tag to current `HEAD` and pushes it. All consumer repos using `@v1` automatically pick up the change on their next workflow run.
-
-## Releasing a Major Version
-
-When introducing breaking changes (input renames, removed inputs, behavior changes):
-
-1. Merge the breaking change to `main`.
-2. Create the new major tag:
-
-```bash
-git tag v2 HEAD
-git push origin v2
-```
-
-3. Announce the new version (see `versioning-policy.md` for deprecation rules).
-4. Keep `v1` pointed at its last compatible commit — do NOT move it forward.
-
-## Safety Rules
-
-- **Never force-push `main`.**
-- Only force-push version tags via `make release-tag`.
-- Always run `make lint && make test` before tagging.
-- After tagging, verify at least one consumer repo picks up the new version.
+Create a new immutable semantic tag such as `v10.0.1` or `v10.1.0`. Do not move `v10`. Validate and update consumer SHA pins through normal reviewed pull requests.
 
 ## Rollback
 
-If a tagged release causes issues in consumer repos:
+1. Identify the consumer's previously verified workflow commit SHA and image digest.
+2. Change the caller back to that full workflow SHA in a normal commit.
+3. Deploy the previous immutable `name@sha256:digest` image when deployment rollback is also required.
+4. Run the consumer's required checks and record the evidence.
+5. Correct the shared workflow through a new pull request and publish a new immutable release tag.
 
-1. Identify the last known-good commit on `main`.
-2. Move the tag back:
-
-```bash
-git tag -f v1 <good-commit-sha>
-git push origin v1 --force
-```
-
-3. Document the rollback and root cause.
-
-## Makefile Target
-
-```bash
-# Move existing tag to HEAD and push
-make release-tag TAG=v1
-
-# The target validates TAG is provided and runs:
-# git tag -f $TAG HEAD && git push origin $TAG --force
-```
-
----
-
-## Consumer Repo Releases
-
-Consumer repos (site-marcel, site-tuinstra, etc.) use a different release model from this repository.
-
-### How it works
-
-1. Code flows through feature branches → `main`.
-2. Merging to `main` triggers Deploy Production and, where configured, the release tag workflow.
-3. The release tag workflow creates tag `vX.Y.Z` from the merged release PR title.
-
-### Why lightweight version tags?
-
-- The release PR title is already a semantic release unit (`release: vX.Y.Z`).
-- The matching git tag gives a stable reference for diffs, rollbacks, and audit history.
-- The Docker image digest (pinned during CD) remains the deployment artifact and rollback unit.
-
-### Template
-
-See `templates/workflows/caller-release-pr.yml` and `templates/workflows/caller-release-tag.yml` for the workflow templates.
-
-### Future: product repos
-
-Product repos with external users (airporttoday, subtrack) may need proper semantic versioning, changelogs, and GitHub Releases. This will be implemented under SC-210 when those repos are onboarded.
-
-See `branching-strategy.md` for the full branching model.
+Never rewrite Git history or move a release tag during rollback. The existing legacy `make release-tag` target is not part of the v10 process because moving tags breaks auditability and the repository's no-force-push policy.

--- a/docs/workflows/versioning-policy.md
+++ b/docs/workflows/versioning-policy.md
@@ -1,96 +1,54 @@
 # Reusable Workflow Versioning Policy
 
-> See also: [Workflow Contracts](contracts/README.md) for detailed API specifications.
+> See [Workflow Contracts](contracts/README.md) for the public interfaces.
 
-## Goals
+## Stable v10 channel
 
-- Keep consumer repositories stable during workflow evolution.
-- Allow safe validation of upcoming changes.
-- Provide clear communication and migration guidance for breaking changes.
+The browser-quality, Docker build/scan, and immutable release-image contracts are the stable v10 interface. `v10` and `v10.0.0` are immutable annotated release tags created from the same reviewed commit. They are release markers, not moving branches.
 
-## Channels
+Production callers resolve the approved v10 tag once and pin the reusable workflow to its full 40-character commit SHA:
 
-- Stable channel:
-  - `@v1` for generally available workflows.
-- Next major channel:
-  - `@v2` after breaking-change rollout.
-- Canary channel:
-  - `@main` for rapid validation.
-  - Optional rolling preview tag `@v1-next` for controlled canary testing.
+```yaml
+uses: Tuinstra-DEV/devops/.github/workflows/reusable-ci-docker.yml@<full-v10-commit-sha>
+```
 
-## Release Semantics
+This prevents an upstream tag movement or compromised release from silently changing consumer CI. `@main`, floating major tags, and short SHAs are prohibited in production callers. Canary validation may pin a reviewed feature commit SHA.
 
-- Patch:
-  - Non-functional fixes, minor hardening, documentation updates.
-  - No input or behavior changes for callers.
-- Minor:
-  - Backward-compatible new inputs with defaults.
-  - Additional optional jobs or diagnostics.
-- Major:
-  - Input changes, output changes, job contract changes, or behavior shifts.
-  - Requires new major tag (`v2`, `v3`, ...).
+## Release semantics
 
-## Compatibility Rules
+- Patch: implementation hardening or documentation with no public-interface or default change. Publish an immutable `v10.0.x` tag and deliberately update consumer SHAs after canary validation.
+- Minor: backward-compatible optional inputs or outputs with safe defaults. Publish immutable `v10.x.0` and deliberately update consumer SHAs.
+- Major: removed/renamed inputs or outputs, changed defaults, changed permissions, runner trust changes, or other behavioral breaks. Publish the next immutable major contract.
 
-- Existing required inputs may not be removed in stable major versions.
-- New inputs must be optional or include safe defaults.
-- Deprecations require a written migration path.
+Existing required inputs are never removed within a major. New inputs must be optional or have safe defaults. Deprecations have a written migration path and at least 60 days' notice.
 
-## Deprecation Window
+## Security and compatibility rules
 
-- Minimum deprecation period: 60 days.
-- Breaking changes must be announced before release of a new major.
-- Stable major remains patched for critical fixes during deprecation window.
+- Every external `uses:` reference in a reusable workflow is pinned to a full commit SHA with a version comment.
+- Consumer reusable-workflow callers are pinned to a full commit SHA.
+- `execution-class` accepts only `hosted` and `trusted-heavy`, defaults to `hosted`, and cannot route fork, Dependabot, or `pull_request_target` work to a trusted runner.
+- Build arguments are supplied only through the explicit `build-args` input and must not contain secrets.
+- Reusable callers pass only explicitly declared secrets; `secrets: inherit` is prohibited.
+- Workflow and contract changes require CODEOWNERS review and the contract checks in `make lint` and `make test`.
 
-## Rollout Strategy
+## Rollout
 
-1. Ship change to canary (`@main` or `@v1-next`).
-2. Validate in designated canary repositories.
-3. Promote to stable major after validation.
-4. Monitor and keep rollback path available.
+1. Merge the reviewed workflow and contract changes.
+2. Create immutable v10 release tags using [the release procedure](release-procedure.md).
+3. Resolve the release tag to a full commit SHA and validate that SHA in designated canary repositories on hosted runners.
+4. Enable `trusted-heavy` only for trusted repository events after runner controls are verified.
+5. Update production callers deliberately to the approved SHA and monitor them.
 
-## Rollback and Fallback
+Repository variables may select the execution class with a safe fallback:
 
-- Rollback mechanism: switch caller workflow back to previous tag (`@v1`).
-- For urgent regressions, pin caller to known-good commit SHA temporarily.
-- Document every rollback in release notes.
+```yaml
+execution-class: ${{ vars.CI_EXECUTION_CLASS || 'hosted' }}
+```
 
-## Changelog Format
+Manual callers expose a choice with only `hosted` and `trusted-heavy`; they do not accept a free-form label.
 
-Each reusable workflow release includes:
+## Rollback
 
-- `Changed`: behavior and implementation updates.
-- `Impact`: consumer-facing effect.
-- `Action Required`: migration steps when needed.
-- `Rollback`: safe fallback instructions.
+Never move, delete, or force-push a release tag. Roll back a consumer by restoring its last known-good full workflow SHA, then make a normal reviewed commit. Keep image deployment rollback pinned to the previously verified `name@sha256:digest` reference. Publish a new immutable patch or major release for the correction.
 
-## Communication Template
-
-Release title example:
-
-`workflow-release: reusable-ci v1.4.0`
-
-Release message:
-
-- Scope and reason for the change.
-- Compatibility statement.
-- Effective date and rollout plan.
-- Link to migration checklist when applicable.
-
-## Migration Checklist (v1 -> v2)
-
-- Inventory repositories currently pinned to `@v1`.
-- Validate `@v2` in canary repositories.
-- Update caller workflow references from `@v1` to `@v2`.
-- Verify environment secrets and required permissions.
-- Run repository CI and deployment smoke tests.
-- Keep rollback instruction (`@v1`) prepared until stabilization.
-
-## Governance
-
-Workflow changes are governed by CODEOWNERS. Changes to:
-- `.github/workflows/reusable-*.yml`
-- `docs/workflows/contracts/`
-- `docs/workflows/versioning-policy.md`
-
-Require approval from platform owners before merge.
+Release notes record `Changed`, `Impact`, `Action Required`, verification evidence, and the exact rollback SHA/digest.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,11 +4,15 @@ set -euo pipefail
 required_paths=(
   ".github/workflows/reusable-ci.yml"
   ".github/workflows/reusable-gate-baseline.yml"
+  ".github/workflows/reusable-browser-quality.yml"
+  ".github/workflows/reusable-ci-docker.yml"
+  ".github/workflows/reusable-release-image.yml"
   "README.md"
   "docs/testing.md"
   "docs/standards/gate-baseline.md"
   "docs/workflows/contracts/reusable-gate-baseline.md"
   "scripts/gate-baseline-scan.sh"
+  "scripts/workflow-contract-test.sh"
   "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
@@ -19,5 +23,10 @@ for path in "${required_paths[@]}"; do
     exit 1
   fi
 done
+
+ruby -e '
+  require "yaml"
+  Dir[".github/workflows/*.{yml,yaml}"].sort.each { |file| YAML.safe_load(File.read(file), aliases: true) }
+'
 
 echo "lint passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,4 +20,6 @@ if ! grep -q "Auth0" "README.md"; then
   exit 1
 fi
 
+./scripts/workflow-contract-test.sh
+
 echo "test passed"

--- a/scripts/workflow-contract-test.sh
+++ b/scripts/workflow-contract-test.sh
@@ -34,9 +34,9 @@ while IFS= read -r use_line; do
   reference="${reference%%#*}"
   reference="${reference//[[:space:]]/}"
   [[ "$reference" =~ @([0-9a-f]{40})$ ]] || fail "external action is not full-SHA pinned: $use_line"
-done < <(rg --no-heading --line-number '^\s*uses:\s+[^.]' .github/workflows/reusable-*.yml)
+done < <(grep -nHE '^[[:space:]]*uses:[[:space:]]+[^.]' .github/workflows/reusable-*.yml)
 
-if rg --quiet --hidden '^\s*secrets:\s*inherit\s*$' .github/workflows; then
+if grep -ERq --include='*.yml' --include='*.yaml' '^[[:space:]]*secrets:[[:space:]]*inherit[[:space:]]*$' .github/workflows; then
   fail "secrets: inherit is prohibited"
 fi
 
@@ -47,37 +47,37 @@ contract_files=(
 )
 
 for file in "${contract_files[@]}"; do
-  rg --quiet 'execution-class:' "$file" || fail "$file does not declare execution-class"
-  rg --quiet 'default: hosted' "$file" || fail "$file does not default to hosted"
-  rg --quiet 'hosted\|trusted-heavy' "$file" || fail "$file does not reject arbitrary execution classes"
-  rg --quiet 'fromJSON\('\''\["self-hosted","trusted-heavy"\]\'\''\)' "$file" || fail "$file does not use the constrained trusted runner labels"
-  rg --quiet "\|\| 'ubuntu-24.04'" "$file" || fail "$file does not use the safe hosted fallback"
-  rg --quiet "github.event_name != 'pull_request_target'" "$file" || fail "$file does not keep pull_request_target off trusted runners"
-  rg --quiet '!github.event.pull_request.head.repo.fork' "$file" || fail "$file does not keep forks off trusted runners"
-  rg --quiet "github.actor != 'dependabot\[bot\]'" "$file" || fail "$file does not keep Dependabot off trusted runners"
+  grep -Fq 'execution-class:' "$file" || fail "$file does not declare execution-class"
+  grep -Fq 'default: hosted' "$file" || fail "$file does not default to hosted"
+  grep -Fq 'hosted|trusted-heavy' "$file" || fail "$file does not reject arbitrary execution classes"
+  grep -Fq "fromJSON('[\"self-hosted\",\"trusted-heavy\"]')" "$file" || fail "$file does not use the constrained trusted runner labels"
+  grep -Fq "|| 'ubuntu-24.04'" "$file" || fail "$file does not use the safe hosted fallback"
+  grep -Fq "github.event_name != 'pull_request_target'" "$file" || fail "$file does not keep pull_request_target off trusted runners"
+  grep -Fq '!github.event.pull_request.head.repo.fork' "$file" || fail "$file does not keep forks off trusted runners"
+  grep -Fq "github.actor != 'dependabot[bot]'" "$file" || fail "$file does not keep Dependabot off trusted runners"
 done
 
 docker_workflow=".github/workflows/reusable-ci-docker.yml"
 for legacy_input in workdir dockerfile build-args trivy-severity trivy-exit-code upload-sarif; do
-  rg --quiet "^      ${legacy_input}:" "$docker_workflow" || fail "Docker compatibility input missing: $legacy_input"
+  grep -Eq "^      ${legacy_input}:" "$docker_workflow" || fail "Docker compatibility input missing: $legacy_input"
 done
 for docker_output in image-digest scan-artifact sarif-artifact; do
-  rg --quiet "^      ${docker_output}:" "$docker_workflow" || fail "Docker output missing: $docker_output"
+  grep -Eq "^      ${docker_output}:" "$docker_workflow" || fail "Docker output missing: $docker_output"
 done
-rg --quiet 'security-events: write' "$docker_workflow" || fail "optional SARIF upload permission missing"
+grep -Fq 'security-events: write' "$docker_workflow" || fail "optional SARIF upload permission missing"
 
 browser_workflow=".github/workflows/reusable-browser-quality.yml"
-rg --quiet 'report-artifact:' "$browser_workflow" || fail "browser report output missing"
-rg --quiet 'if-no-files-found: error' "$browser_workflow" || fail "browser artifact is not enforced"
+grep -Fq 'report-artifact:' "$browser_workflow" || fail "browser report output missing"
+grep -Fq 'if-no-files-found: error' "$browser_workflow" || fail "browser artifact is not enforced"
 
 release_workflow=".github/workflows/reusable-release-image.yml"
 for release_output in image-ref image-digest provenance-artifact provenance-url; do
-  rg --quiet "^      ${release_output}:" "$release_workflow" || fail "release output missing: $release_output"
+  grep -Eq "^      ${release_output}:" "$release_workflow" || fail "release output missing: $release_output"
 done
 for permission in 'attestations: write' 'contents: read' 'id-token: write' 'packages: write'; do
-  rg --quiet "$permission" "$release_workflow" || fail "release permission missing: $permission"
+  grep -Fq "$permission" "$release_workflow" || fail "release permission missing: $permission"
 done
-rg --quiet 'subject-digest:.*steps.build.outputs.digest' "$release_workflow" || fail "provenance is not bound to the immutable digest"
-rg --quiet 'image-ref=.*@.*IMAGE_DIGEST' "$release_workflow" || fail "immutable image-ref output missing"
+grep -Eq 'subject-digest:.*steps.build.outputs.digest' "$release_workflow" || fail "provenance is not bound to the immutable digest"
+grep -Eq 'image-ref=.*@.*IMAGE_DIGEST' "$release_workflow" || fail "immutable image-ref output missing"
 
 echo "workflow contract test passed"

--- a/scripts/workflow-contract-test.sh
+++ b/scripts/workflow-contract-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "workflow contract test failed: $*" >&2
+  exit 1
+}
+
+required_paths=(
+  ".github/workflows/reusable-browser-quality.yml"
+  ".github/workflows/reusable-ci-docker.yml"
+  ".github/workflows/reusable-release-image.yml"
+  "docs/workflows/contracts/reusable-browser-quality.md"
+  "docs/workflows/contracts/reusable-ci-docker.md"
+  "docs/workflows/contracts/reusable-release-image.md"
+)
+
+for path in "${required_paths[@]}"; do
+  [[ -f "$path" ]] || fail "missing $path"
+done
+
+ruby -e '
+  require "yaml"
+  Dir[".github/workflows/*.{yml,yaml}"].sort.each do |file|
+    YAML.safe_load(File.read(file), aliases: true)
+  rescue Psych::SyntaxError => error
+    warn "#{file}: #{error.message}"
+    exit 1
+  end
+' || fail "workflow YAML is invalid"
+
+while IFS= read -r use_line; do
+  reference="${use_line#*uses:}"
+  reference="${reference%%#*}"
+  reference="${reference//[[:space:]]/}"
+  [[ "$reference" =~ @([0-9a-f]{40})$ ]] || fail "external action is not full-SHA pinned: $use_line"
+done < <(rg --no-heading --line-number '^\s*uses:\s+[^.]' .github/workflows/reusable-*.yml)
+
+if rg --quiet --hidden '^\s*secrets:\s*inherit\s*$' .github/workflows; then
+  fail "secrets: inherit is prohibited"
+fi
+
+contract_files=(
+  ".github/workflows/reusable-browser-quality.yml"
+  ".github/workflows/reusable-ci-docker.yml"
+  ".github/workflows/reusable-release-image.yml"
+)
+
+for file in "${contract_files[@]}"; do
+  rg --quiet 'execution-class:' "$file" || fail "$file does not declare execution-class"
+  rg --quiet 'default: hosted' "$file" || fail "$file does not default to hosted"
+  rg --quiet 'hosted\|trusted-heavy' "$file" || fail "$file does not reject arbitrary execution classes"
+  rg --quiet 'fromJSON\('\''\["self-hosted","trusted-heavy"\]\'\''\)' "$file" || fail "$file does not use the constrained trusted runner labels"
+  rg --quiet "\|\| 'ubuntu-24.04'" "$file" || fail "$file does not use the safe hosted fallback"
+  rg --quiet "github.event_name != 'pull_request_target'" "$file" || fail "$file does not keep pull_request_target off trusted runners"
+  rg --quiet '!github.event.pull_request.head.repo.fork' "$file" || fail "$file does not keep forks off trusted runners"
+  rg --quiet "github.actor != 'dependabot\[bot\]'" "$file" || fail "$file does not keep Dependabot off trusted runners"
+done
+
+docker_workflow=".github/workflows/reusable-ci-docker.yml"
+for legacy_input in workdir dockerfile build-args trivy-severity trivy-exit-code upload-sarif; do
+  rg --quiet "^      ${legacy_input}:" "$docker_workflow" || fail "Docker compatibility input missing: $legacy_input"
+done
+for docker_output in image-digest scan-artifact sarif-artifact; do
+  rg --quiet "^      ${docker_output}:" "$docker_workflow" || fail "Docker output missing: $docker_output"
+done
+rg --quiet 'security-events: write' "$docker_workflow" || fail "optional SARIF upload permission missing"
+
+browser_workflow=".github/workflows/reusable-browser-quality.yml"
+rg --quiet 'report-artifact:' "$browser_workflow" || fail "browser report output missing"
+rg --quiet 'if-no-files-found: error' "$browser_workflow" || fail "browser artifact is not enforced"
+
+release_workflow=".github/workflows/reusable-release-image.yml"
+for release_output in image-ref image-digest provenance-artifact provenance-url; do
+  rg --quiet "^      ${release_output}:" "$release_workflow" || fail "release output missing: $release_output"
+done
+for permission in 'attestations: write' 'contents: read' 'id-token: write' 'packages: write'; do
+  rg --quiet "$permission" "$release_workflow" || fail "release permission missing: $permission"
+done
+rg --quiet 'subject-digest:.*steps.build.outputs.digest' "$release_workflow" || fail "provenance is not bound to the immutable digest"
+rg --quiet 'image-ref=.*@.*IMAGE_DIGEST' "$release_workflow" || fail "immutable image-ref output missing"
+
+echo "workflow contract test passed"


### PR DESCRIPTION
## Summary
- add constrained hosted/trusted-heavy browser, Docker, and release-image contracts
- force fork, Dependabot, and pull_request_target work onto hosted runners
- pin reusable workflow actions to immutable SHAs and document v10 rollback
- add static contract tests and actionlint coverage

## Verification
- make lint
- make test
- actionlint 1.7.12 on all workflows
- git diff --check

Tracker: DEV-2