### PR TITLE
DEV-1: add ephemeral KVM trusted-heavy runner platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: lint test release-tag
+.PHONY: lint test test-runner release-tag
 
 lint:
 	./scripts/lint.sh
 
 test:
 	./scripts/test.sh
+
+test-runner:
+	./scripts/test-runner-platform.sh
 
 # Usage: make release-tag TAG=v1
 # Moves an existing tag to current HEAD and force-pushes it.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ Shared deployment script documentation is available at
 
 Reusable Nuxt SSG CD workflow documentation is available at
 `docs/workflows/reusable-cd-nuxt-ssg.md`.
+
+## Ephemeral heavy CI
+
+The production design and host automation for the single-concurrency Sanctuary
+KVM runner are documented in `docs/runner/sanctuary-kvm-runner.md`.

--- a/docs/playbooks/ci-runner-host.md
+++ b/docs/playbooks/ci-runner-host.md
@@ -1,0 +1,75 @@
+# CI runner host operations
+
+## Provision
+
+1. Confirm Ubuntu 24.04, `/dev/kvm`, and persistent SSD/HDD mounts.
+2. Build the Packer image with pinned Ubuntu ISO and runner checksums.
+3. Publish the image to an access-controlled artifact source.
+4. Provision the repository runner token directly on the host as root-owned
+   mode `0600` `/etc/ci-runner/github.token`; do not place it in inventory.
+5. Set `runner_base_image_source`, `runner_base_image_sha256`, production IPv4
+   and IPv6 deny lists, and `runner_production_networks_reviewed=true` in
+   protected Ansible inventory, then run `ansible-playbook infra/ansible/site.yml`.
+6. Confirm the allowlisted repositories, `trusted-heavy` label, group ID 1, and
+   120-minute lease limit in `/etc/ci-runner/manager.toml`.
+
+Copy `infra/packer/sanctuary-runner.pkrvars.hcl.example` outside source control,
+replace every placeholder with an exact reviewed version or checksum, then run
+`packer build -var-file=/protected/path/sanctuary-runner.pkrvars.hcl
+sanctuary-runner.pkr.hcl` from `infra/packer`. The build fails unless Docker,
+Buildx, Compose, Node 24/Corepack, Playwright Chromium, Trivy, PHP 8.3/8.4,
+Composer, and the base CLI/build tools satisfy the image contract.
+
+Validate the role locally before applying it, then execute check mode against
+the `sanctuary` inventory target. Check mode gathers host facts but does not
+change the server:
+
+```sh
+cd infra/ansible
+ansible-playbook --syntax-check site.yml
+ansible-playbook --check --diff --limit sanctuary site.yml \
+  -e runner_base_image_source=https://ARTIFACT/runner.qcow2 \
+  -e runner_base_image_sha256=REPLACE_WITH_64_HEX_DIGEST \
+  -e runner_production_networks_reviewed=true
+```
+
+## Acceptance checks
+
+```sh
+sudo kvm-ok
+sudo virsh net-info sanctuary-ci
+sudo nft list table inet sanctuary_ci
+sudo systemctl status ci-runner-manager libvirtd sanctuary-ci-firewall
+sudo -u ci-runner-manager /usr/local/bin/ci-runner-manager reconcile
+```
+
+Launch a non-production canary and verify: exact `trusted-heavy` routing; 8
+vCPU, 12 GiB RAM and 120 GiB disk; rejection of a second launch; public GitHub
+reachability while host, private and production ranges are blocked; one-job
+poweroff; complete reconciliation within 30 seconds; and audit events without
+the JIT payload.
+
+The Sanctuary production deny list must contain `88.159.77.149/32` plus every
+other public production CIDR. The dedicated firewall service must leave Docker
+and all non-`sanctuary_ci` nftables tables unchanged.
+
+## Incidents and orphan cleanup
+
+Disable the runner group first. Preserve the audit log and job identifiers, but
+never copy a seed ISO or JIT value into a ticket. Stop the listener, allow the
+current job to finish unless containment requires termination, run
+`ci-runner-manager reconcile`, and confirm that no `sanctuary-ci-*` domain or
+lease directory remains.
+
+## Hosted rollback
+
+1. Disable repository access to the trusted-heavy runner group.
+2. Route jobs back to GitHub-hosted labels through the normal reviewed workflow
+   change; do not broaden which untrusted jobs can execute.
+3. Allow the current single job to finish, or cancel it for containment.
+4. Stop the listener and `ci-runner-manager.service`.
+5. Run one reconciliation and verify no domain, overlay, seed, or state remains.
+6. Retain audit logs for 30 days and record the rollback evidence.
+
+Keep the checksum-pinned base image during rollback so restoration is
+reversible. Re-enable only after a canary passes the acceptance checks.

--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -1,0 +1,138 @@
+# Sanctuary KVM runner platform
+
+## Decision
+
+Sanctuary runs at most one untrusted CI job in an ephemeral Ubuntu 24.04 KVM
+guest. The host is provisioned with Ansible, the guest root disk is a qcow2
+overlay backed by a checksum-pinned immutable Packer image, and the VM is
+deleted after its single JIT job.
+
+The manager includes a small GitHub REST polling adapter because an organization
+scale-set listener is not available with repository-scoped administration. It
+polls queued/in-progress workflow runs in an explicit `Tuinstra-DEV` repository
+allowlist, selects only queued jobs whose labels include `trusted-heavy`, and
+requests a repository JIT configuration. `runner_group_id` is configurable and
+defaults to the verified repository runner group ID `1`.
+
+The deployed allowlist is Gate, WODIQ, Tracker, Notify, Console, wodiq-site,
+marcel-site, and tuinstra-site. This DevOps repository remains hosted-only and
+is intentionally excluded to prevent the runner control plane from executing
+its own changes.
+
+The adapter deduplicates job IDs for 24 hours. It launches at most one VM and
+removes the offline GitHub runner record if VM launch fails. Any malformed API
+response, permission error, transport failure, or rate limit fails closed;
+rate-limit responses honor a bounded retry interval.
+
+For manual break-glass operation, a single-use JIT value can still be supplied
+to the manager using a mode `0600` file. Delete that host-side file immediately
+after `launch` returns:
+
+```sh
+sudo -u ci-runner-manager /usr/local/bin/ci-runner-manager launch \
+  --lease JOB_ID --jit-config-file /run/ci-runner-manager/JOB_ID.jit
+```
+
+The manager passes the value to the root helper over stdin; neither layer logs
+it or includes it in a host process argument. The guest uses the JIT value for
+one job, powers off after the runner exits, and the reconciler removes the
+domain, seed ISO, and overlay.
+
+The polling adapter uses only documented GitHub REST endpoints and is not a
+replacement for GitHub's scale-set client. Migrate to the official client when
+organization administration becomes available.
+
+## Runner routing contract
+
+The runner must register with the exact custom label `trusted-heavy` in the
+restricted runner group. Reusable workflows target `[self-hosted,
+trusted-heavy]`. Do not add a generic route that lets arbitrary workflows or
+fork pull requests select this machine.
+
+## Resource and admission policy
+
+- Maximum concurrency is 1, enforced under a filesystem lock.
+- Each guest receives 8 vCPU, 12 GiB RAM, and a 120 GiB grow-on-write disk.
+- Admission requires at least 8 host logical CPUs, 14 GiB available memory,
+  140 GiB free on `/mnt/ssd1000-01/ci-runner`, and one-minute load no higher
+  than 8. Thresholds are configurable; VM dimensions are root-helper constants.
+- The base image is root-owned and mode `0444`. Per-job files live in a mode
+  `0700` lease directory.
+- A running lease older than `max_lease_seconds` (default 7,200 seconds) is
+  destroyed by reconciliation even if libvirt still reports it running.
+
+## Network boundary
+
+The `sanctuary-ci` libvirt NAT network uses documentation prefix
+`192.0.2.0/24`. The nftables guard permits only DHCP and the libvirt DNS proxy
+to the host, blocks every other guest-to-host packet, and denies RFC1918, loopback,
+link-local, carrier-grade NAT, ULA, and multicast destinations. Public internet
+egress remains available for GitHub and package registries. No inbound port or
+route is exposed.
+
+If production uses public IP space, add those CIDRs to the deny set before
+enabling the runner. Provisioning requires the explicit
+`runner_production_networks_reviewed=true` acknowledgement and accepts separate
+IPv4 and IPv6 production deny lists. Sanctuary's required list includes its
+public host address `88.159.77.149/32`. Validate the effective ruleset from a guest; cloud-provider
+and upstream routing policy remain separate controls.
+
+The runner policy is loaded as its own `inet sanctuary_ci` table by a dedicated
+oneshot service. Ansible validates the candidate batch with `nft -c`; applying
+the batch atomically replaces only that table. It never enables, flushes, or
+restarts the global nftables service, preserving Docker and unrelated host rules.
+
+## Image supply chain
+
+Build `infra/packer/sanctuary-runner.pkr.hcl` only with SHA-256 values copied
+from the authoritative Ubuntu and GitHub Actions runner releases. Store the
+qcow2 in an access-controlled artifact location, record its digest in change
+evidence, and deploy it through the Ansible checksum assertion.
+
+The image contains no registration token or SSH key. Packer's temporary account
+is locked, SSH is disabled, machine identity and cloud-init state are removed,
+and the runtime JIT configuration arrives only through the per-lease seed.
+
+### Guest toolchain contract
+
+Every image contains the x86-64 toolchain required by migrated heavy workflows:
+
+- Docker Engine and CLI with Buildx and Compose v2 plugins;
+- Node.js 24, npm, and Corepack;
+- a pinned Playwright package plus its checksum-validated Chromium download and
+  signed Ubuntu system dependencies, cached under `/opt/ms-playwright`;
+- Trivy;
+- PHP 8.3 and 8.4 CLI, curl, mbstring, XML, and ZIP extensions, plus Composer;
+- Git, curl, jq, GNU build tools, and the GitHub Actions runner.
+
+All third-party APT repositories use dedicated `Signed-By` keyrings. Packer
+requires a reviewed SHA-256 for each downloaded repository key and exact APT
+versions for Docker, Node, Trivy, and PHP. The runner archive, Ubuntu ISO, and
+Composer installer are independently checksum-pinned. No downloaded content is
+piped into a shell. `verify-image-contract.sh` runs before the image is sealed,
+and the resulting qcow2 SHA-256 is the deployment input.
+
+Rebuild at least monthly and within the security response SLA for critical
+runner, kernel, container, browser, Node, PHP, Composer, or Trivy advisories.
+For every rebuild, resolve exact versions from the signed repositories, review
+repository-key changes separately, update the Packer variables, build from a
+clean host, retain the manifest, run the image contract, and pass a
+non-production canary before changing the Ansible image digest. Never update a
+package in place on Sanctuary; roll forward with a new immutable image.
+
+The guest unit invokes a fixed wrapper which reads the JIT value, removes its
+runtime file, and `exec`s `run.sh --jitconfig` exactly once. The service does not
+restart and powers the VM off after the runner exits, including failure paths.
+
+## Audit and retention
+
+Lifecycle events are written to `/mnt/hdd1000-01/ci-audit/manager.log` without
+job payloads or credentials. Logrotate retains daily compressed logs for 30
+days and removes older files. Restrict the mount to administrators and the
+manager account, monitor rotation, and include the mount in capacity alerts.
+
+The GitHub token is provisioned separately at `/etc/ci-runner/github.token` as
+root mode `0600`. systemd exposes it to the unprivileged service through
+`LoadCredential`; it never appears in TOML, argv, logs, or repository content.
+Grant only repository-level Actions read and self-hosted-runner write access for
+allowlisted repositories and rotate it through the normal secret-management process.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventory/hosts.example.yml
+roles_path = roles
+interpreter_python = auto_silent
+retry_files_enabled = false
+
+[privilege_escalation]
+become = true

--- a/infra/ansible/inventory/hosts.example.yml
+++ b/infra/ansible/inventory/hosts.example.yml
@@ -1,0 +1,9 @@
+all:
+  hosts:
+    sanctuary:
+      ansible_host: REPLACE_WITH_HOST
+      ansible_user: REPLACE_WITH_ADMIN_USER
+      runner_production_networks_reviewed: true
+      runner_blocked_production_ipv4_cidrs:
+        - 88.159.77.149/32
+      runner_blocked_production_ipv6_cidrs: []

--- a/infra/ansible/roles/runner_host/defaults/main.yml
+++ b/infra/ansible/roles/runner_host/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+runner_base_image_source: ""
+runner_base_image_sha256: ""
+runner_manager_source_root: "{{ playbook_dir }}/../.."
+runner_bridge_name: virbr-ci
+runner_network_cidr: 192.0.2.0/24
+runner_production_networks_reviewed: false
+runner_blocked_production_ipv4_cidrs: []
+runner_blocked_production_ipv6_cidrs: []

--- a/infra/ansible/roles/runner_host/handlers/main.yml
+++ b/infra/ansible/roles/runner_host/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Restart runner manager
+  ansible.builtin.systemd:
+    name: ci-runner-manager.service
+    state: restarted
+    daemon_reload: true
+
+- name: Apply sanctuary firewall transaction
+  ansible.builtin.shell: |
+    set -euo pipefail
+    /usr/sbin/nft -c -f /etc/ci-runner/sanctuary-ci.nft
+    /usr/sbin/nft -f /etc/ci-runner/sanctuary-ci.nft
+  args:
+    executable: /bin/bash

--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -1,0 +1,153 @@
+---
+- name: Assert immutable image inputs are pinned
+  ansible.builtin.assert:
+    that:
+      - runner_base_image_source | length > 0
+      - runner_base_image_sha256 is match('^[a-f0-9]{64}$')
+      - runner_production_networks_reviewed | bool
+      - (runner_blocked_production_ipv4_cidrs | length) + (runner_blocked_production_ipv6_cidrs | length) > 0
+    fail_msg: Pin the image and explicitly configure at least one production deny CIDR.
+
+- name: Check KVM device
+  ansible.builtin.stat:
+    path: /dev/kvm
+  register: runner_kvm_device
+
+- name: Require hardware virtualization
+  ansible.builtin.assert:
+    that:
+      - runner_kvm_device.stat.exists
+      - runner_kvm_device.stat.ischr
+    fail_msg: /dev/kvm is required; enable virtualization before provisioning.
+
+- name: Require dedicated runner filesystems
+  ansible.builtin.assert:
+    that:
+      - "'/mnt/ssd1000-01' in (ansible_mounts | map(attribute='mount') | list)"
+      - "'/mnt/hdd1000-01' in (ansible_mounts | map(attribute='mount') | list)"
+    fail_msg: Refusing to place overlays or audit logs on the host root filesystem.
+
+- name: Install virtualization and policy packages
+  ansible.builtin.apt:
+    name:
+      - cloud-image-utils
+      - libvirt-daemon-system
+      - nftables
+      - python3
+      - qemu-kvm
+      - qemu-utils
+      - virtinst
+    state: present
+    update_cache: true
+
+- name: Create dedicated manager account
+  ansible.builtin.user:
+    name: ci-runner-manager
+    system: true
+    create_home: false
+    shell: /usr/sbin/nologin
+
+- name: Create runner directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: /etc/ci-runner, owner: root, group: ci-runner-manager, mode: '0750' }
+    - { path: /var/lib/ci-runner/images, owner: root, group: root, mode: '0755' }
+    - { path: /var/lib/ci-runner-manager/state, owner: ci-runner-manager, group: ci-runner-manager, mode: '0700' }
+    - { path: /mnt/ssd1000-01/ci-runner, owner: root, group: root, mode: '0700' }
+    - { path: /mnt/hdd1000-01/ci-audit, owner: ci-runner-manager, group: ci-runner-manager, mode: '0750' }
+
+- name: Inspect root-provisioned GitHub credential
+  ansible.builtin.stat:
+    path: /etc/ci-runner/github.token
+  register: runner_github_credential
+
+- name: Require private GitHub credential
+  ansible.builtin.assert:
+    that:
+      - runner_github_credential.stat.exists
+      - runner_github_credential.stat.isreg
+      - (runner_github_credential.stat.pw_name | default('')) == 'root'
+      - (runner_github_credential.stat.mode | default('')) == '0600'
+    fail_msg: Provision /etc/ci-runner/github.token as root mode 0600 outside Ansible source control.
+
+- name: Install pinned immutable base image
+  ansible.builtin.get_url:
+    url: "{{ runner_base_image_source }}"
+    dest: /var/lib/ci-runner/images/ubuntu-24.04-runner.qcow2
+    checksum: "sha256:{{ runner_base_image_sha256 }}"
+    owner: root
+    group: root
+    mode: '0444'
+
+- name: Install manager platform files
+  ansible.builtin.copy:
+    src: "{{ runner_manager_source_root }}/{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - { src: runner/manager/ci_runner_manager.py, dest: /usr/local/bin/ci-runner-manager, mode: '0755' }
+    - { src: runner/host-helper/ci_runner_host_helper.py, dest: /usr/local/libexec/ci-runner-host-helper, mode: '0755' }
+    - { src: runner/config/manager.toml, dest: /etc/ci-runner/manager.toml, mode: '0640' }
+    - { src: runner/systemd/ci-runner-manager.service, dest: /etc/systemd/system/ci-runner-manager.service, mode: '0644' }
+    - { src: runner/systemd/sanctuary-ci-firewall.service, dest: /etc/systemd/system/sanctuary-ci-firewall.service, mode: '0644' }
+    - { src: runner/logrotate/ci-runner-audit, dest: /etc/logrotate.d/ci-runner-audit, mode: '0644' }
+  notify: Restart runner manager
+
+- name: Install validated sudo policy
+  ansible.builtin.template:
+    src: ci-runner-manager.sudoers.j2
+    dest: /etc/sudoers.d/ci-runner-manager
+    owner: root
+    group: root
+    mode: '0440'
+    validate: /usr/sbin/visudo -cf %s
+
+- name: Install isolated network definition
+  ansible.builtin.template:
+    src: sanctuary-ci.xml.j2
+    dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml
+    owner: root
+    group: root
+    mode: '0600'
+  register: runner_network_definition
+
+- name: Define and start runner network
+  ansible.builtin.shell: |
+    set -euo pipefail
+    virsh net-define /etc/libvirt/qemu/networks/sanctuary-ci.xml
+    virsh net-autostart sanctuary-ci
+    if ! virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
+      virsh net-start sanctuary-ci
+    fi
+  args:
+    executable: /bin/bash
+  when: runner_network_definition.changed
+  changed_when: true
+
+- name: Install runner egress guard
+  ansible.builtin.template:
+    src: sanctuary-ci.nft.j2
+    dest: /etc/ci-runner/sanctuary-ci.nft
+    owner: root
+    group: root
+    mode: '0644'
+    validate: /usr/sbin/nft -c -f %s
+  notify: Apply sanctuary firewall transaction
+
+- name: Enable runner services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  loop:
+    - libvirtd.service
+    - sanctuary-ci-firewall.service
+    - ci-runner-manager.service

--- a/infra/ansible/roles/runner_host/templates/ci-runner-manager.sudoers.j2
+++ b/infra/ansible/roles/runner_host/templates/ci-runner-manager.sudoers.j2
@@ -1,0 +1,2 @@
+Defaults:ci-runner-manager env_reset,secure_path=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/libexec
+ci-runner-manager ALL=(root) NOPASSWD: /usr/local/libexec/ci-runner-host-helper *

--- a/infra/ansible/roles/runner_host/templates/sanctuary-ci.nft.j2
+++ b/infra/ansible/roles/runner_host/templates/sanctuary-ci.nft.j2
@@ -1,0 +1,22 @@
+destroy table inet sanctuary_ci
+table inet sanctuary_ci {
+  chain input_guard {
+    type filter hook input priority -5; policy accept;
+    iifname "{{ runner_bridge_name }}" udp dport 67 accept
+    iifname "{{ runner_bridge_name }}" udp dport 53 accept
+    iifname "{{ runner_bridge_name }}" tcp dport 53 accept
+    iifname "{{ runner_bridge_name }}" drop
+  }
+
+  chain forward_guard {
+    type filter hook forward priority -5; policy accept;
+    iifname "{{ runner_bridge_name }}" ip daddr { 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, 224.0.0.0/4 } drop
+    iifname "{{ runner_bridge_name }}" ip6 daddr { ::1/128, fc00::/7, fe80::/10, ff00::/8 } drop
+{% for cidr in runner_blocked_production_ipv4_cidrs %}
+    iifname "{{ runner_bridge_name }}" ip daddr {{ cidr }} drop
+{% endfor %}
+{% for cidr in runner_blocked_production_ipv6_cidrs %}
+    iifname "{{ runner_bridge_name }}" ip6 daddr {{ cidr }} drop
+{% endfor %}
+  }
+}

--- a/infra/ansible/roles/runner_host/templates/sanctuary-ci.xml.j2
+++ b/infra/ansible/roles/runner_host/templates/sanctuary-ci.xml.j2
@@ -1,0 +1,11 @@
+<network>
+  <name>sanctuary-ci</name>
+  <forward mode='nat'/>
+  <bridge name='{{ runner_bridge_name }}' stp='on' delay='0'/>
+  <dns enable='yes' forwardPlainNames='no'/>
+  <ip address='192.0.2.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.0.2.10' end='192.0.2.20'/>
+    </dhcp>
+  </ip>
+</network>

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure the sanctuary ephemeral runner host
+  hosts: sanctuary
+  become: true
+  roles:
+    - runner_host

--- a/infra/packer/http/meta-data
+++ b/infra/packer/http/meta-data
@@ -1,0 +1,2 @@
+instance-id: packer-sanctuary-runner
+local-hostname: packer-runner

--- a/infra/packer/http/user-data
+++ b/infra/packer/http/user-data
@@ -1,0 +1,27 @@
+#cloud-config
+autoinstall:
+  version: 1
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  identity:
+    hostname: packer-runner
+    username: packer
+    # Development-only password "packer"; removed when the image is sealed.
+    password: "$6$packer-temporary$rde/FyQL8FGNT0aOWZHiS1.R14cYRbH8n/v3U/urUz1gn1ztjWTZu9T0T668kUX1/.HTBPNXD4F3SZrio0/KT0"
+  ssh:
+    install-server: true
+    allow-pw: true
+  storage:
+    layout:
+      name: direct
+  packages:
+    - build-essential
+    - cloud-init
+    - curl
+    - git
+    - gnupg
+    - jq
+    - software-properties-common
+  late-commands:
+    - curtin in-target --target=/target -- systemctl enable cloud-init

--- a/infra/packer/sanctuary-runner.pkr.hcl
+++ b/infra/packer/sanctuary-runner.pkr.hcl
@@ -1,0 +1,173 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.1"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "ubuntu_iso_url" {
+  type        = string
+  description = "Pinned Ubuntu 24.04.x live-server ISO URL"
+}
+
+variable "ubuntu_iso_checksum" {
+  type        = string
+  description = "Pinned sha256 checksum from releases.ubuntu.com; required at build time"
+}
+
+variable "runner_version" {
+  type        = string
+  description = "Pinned GitHub Actions runner version"
+}
+
+variable "runner_sha256" {
+  type        = string
+  description = "Pinned sha256 for actions-runner-linux-x64 archive"
+}
+
+variable "docker_key_sha256" {
+  type = string
+}
+
+variable "docker_ce_version" {
+  type = string
+}
+
+variable "docker_cli_version" {
+  type = string
+}
+
+variable "containerd_version" {
+  type = string
+}
+
+variable "buildx_version" {
+  type = string
+}
+
+variable "compose_version" {
+  type = string
+}
+
+variable "node_key_sha256" {
+  type = string
+}
+
+variable "node_version" {
+  type = string
+}
+
+variable "trivy_key_sha256" {
+  type = string
+}
+
+variable "trivy_version" {
+  type = string
+}
+
+variable "php_key_sha256" {
+  type = string
+}
+
+variable "php83_version" {
+  type = string
+}
+
+variable "php84_version" {
+  type = string
+}
+
+variable "composer_version" {
+  type = string
+}
+
+variable "composer_sha384" {
+  type = string
+}
+
+variable "playwright_version" {
+  type = string
+}
+
+source "qemu" "ubuntu_runner" {
+  iso_url          = var.ubuntu_iso_url
+  iso_checksum     = "sha256:${var.ubuntu_iso_checksum}"
+  output_directory = "output-sanctuary-runner"
+  vm_name          = "ubuntu-24.04-runner.qcow2"
+  format           = "qcow2"
+  disk_size        = "16384"
+  memory           = 4096
+  cpus             = 2
+  accelerator      = "kvm"
+  headless         = true
+  ssh_username     = "packer"
+  ssh_password     = "packer"
+  ssh_timeout      = "30m"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  http_directory   = "http"
+  boot_wait        = "5s"
+  boot_command = [
+    "e<wait>",
+    "<down><down><down><end>",
+    " autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---<wait>",
+    "<f10>"
+  ]
+}
+
+build {
+  sources = ["source.qemu.ubuntu_runner"]
+
+  provisioner "file" {
+    source      = "../../runner/systemd/ci-runner-job.service"
+    destination = "/tmp/ci-runner-job.service"
+  }
+
+  provisioner "file" {
+    source      = "../../runner/guest/run-jit-runner.sh"
+    destination = "/tmp/run-jit-runner.sh"
+  }
+
+  provisioner "file" {
+    source      = "scripts/verify-image-contract.sh"
+    destination = "/tmp/verify-image-contract.sh"
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "RUNNER_VERSION=${var.runner_version}",
+      "RUNNER_SHA256=${var.runner_sha256}",
+      "DOCKER_KEY_SHA256=${var.docker_key_sha256}",
+      "DOCKER_CE_VERSION=${var.docker_ce_version}",
+      "DOCKER_CLI_VERSION=${var.docker_cli_version}",
+      "CONTAINERD_VERSION=${var.containerd_version}",
+      "BUILDX_VERSION=${var.buildx_version}",
+      "COMPOSE_VERSION=${var.compose_version}",
+      "NODE_KEY_SHA256=${var.node_key_sha256}",
+      "NODE_VERSION=${var.node_version}",
+      "TRIVY_KEY_SHA256=${var.trivy_key_sha256}",
+      "TRIVY_VERSION=${var.trivy_version}",
+      "PHP_KEY_SHA256=${var.php_key_sha256}",
+      "PHP83_VERSION=${var.php83_version}",
+      "PHP84_VERSION=${var.php84_version}",
+      "COMPOSER_VERSION=${var.composer_version}",
+      "COMPOSER_SHA384=${var.composer_sha384}",
+      "PLAYWRIGHT_VERSION=${var.playwright_version}"
+    ]
+    script = "scripts/install-runner.sh"
+  }
+
+  provisioner "shell" {
+    inline = ["sudo bash /tmp/verify-image-contract.sh"]
+  }
+
+  provisioner "shell" {
+    script = "scripts/seal-image.sh"
+  }
+
+  post-processor "checksum" {
+    checksum_types = ["sha256"]
+    output         = "output-sanctuary-runner/SHA256SUMS"
+  }
+}

--- a/infra/packer/sanctuary-runner.pkrvars.hcl.example
+++ b/infra/packer/sanctuary-runner.pkrvars.hcl.example
@@ -1,0 +1,27 @@
+# Resolve exact versions from the signed repositories immediately before a
+# reviewed image build. Never use "latest", wildcards, or an unpinned key.
+ubuntu_iso_url      = "https://releases.ubuntu.com/24.04/REPLACE.iso"
+ubuntu_iso_checksum = "REPLACE_64_HEX"
+runner_version      = "REPLACE"
+runner_sha256       = "REPLACE_64_HEX"
+
+docker_key_sha256 = "REPLACE_64_HEX"
+docker_ce_version  = "REPLACE_EXACT_APT_VERSION"
+docker_cli_version = "REPLACE_EXACT_APT_VERSION"
+containerd_version = "REPLACE_EXACT_APT_VERSION"
+buildx_version     = "REPLACE_EXACT_APT_VERSION"
+compose_version    = "REPLACE_EXACT_APT_VERSION"
+
+node_key_sha256 = "REPLACE_64_HEX"
+node_version     = "REPLACE_EXACT_NODE_24_APT_VERSION"
+
+trivy_key_sha256 = "REPLACE_64_HEX"
+trivy_version     = "REPLACE_EXACT_APT_VERSION"
+
+php_key_sha256 = "REPLACE_64_HEX"
+php83_version   = "REPLACE_EXACT_APT_VERSION"
+php84_version   = "REPLACE_EXACT_APT_VERSION"
+
+composer_version = "REPLACE_EXACT_VERSION"
+composer_sha384   = "REPLACE_96_HEX"
+playwright_version = "REPLACE_EXACT_VERSION"

--- a/infra/packer/scripts/install-runner.sh
+++ b/infra/packer/scripts/install-runner.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUNNER_VERSION:?RUNNER_VERSION is required}"
+: "${RUNNER_SHA256:?RUNNER_SHA256 is required}"
+: "${DOCKER_KEY_SHA256:?DOCKER_KEY_SHA256 is required}"
+: "${DOCKER_CE_VERSION:?DOCKER_CE_VERSION is required}"
+: "${DOCKER_CLI_VERSION:?DOCKER_CLI_VERSION is required}"
+: "${CONTAINERD_VERSION:?CONTAINERD_VERSION is required}"
+: "${BUILDX_VERSION:?BUILDX_VERSION is required}"
+: "${COMPOSE_VERSION:?COMPOSE_VERSION is required}"
+: "${NODE_KEY_SHA256:?NODE_KEY_SHA256 is required}"
+: "${NODE_VERSION:?NODE_VERSION is required}"
+: "${TRIVY_KEY_SHA256:?TRIVY_KEY_SHA256 is required}"
+: "${TRIVY_VERSION:?TRIVY_VERSION is required}"
+: "${PHP_KEY_SHA256:?PHP_KEY_SHA256 is required}"
+: "${PHP83_VERSION:?PHP83_VERSION is required}"
+: "${PHP84_VERSION:?PHP84_VERSION is required}"
+: "${COMPOSER_VERSION:?COMPOSER_VERSION is required}"
+: "${COMPOSER_SHA384:?COMPOSER_SHA384 is required}"
+: "${PLAYWRIGHT_VERSION:?PLAYWRIGHT_VERSION is required}"
+
+if [[ "$(dpkg --print-architecture)" != amd64 ]]; then
+  echo "This image contract supports Ubuntu 24.04 amd64 only" >&2
+  exit 1
+fi
+
+install_key() {
+  local url=$1 expected=$2 destination=$3 temporary
+  temporary=$(mktemp)
+  curl --fail --silent --show-error --location "$url" --output "$temporary"
+  printf '%s  %s\n' "$expected" "$temporary" | sha256sum --check --strict
+  sudo gpg --batch --yes --dearmor --output "$destination" "$temporary"
+  sudo chmod 0644 "$destination"
+  rm -f "$temporary"
+}
+
+sudo install -d -m 0755 /etc/apt/keyrings
+install_key https://download.docker.com/linux/ubuntu/gpg "$DOCKER_KEY_SHA256" /etc/apt/keyrings/docker.gpg
+install_key https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key "$NODE_KEY_SHA256" /etc/apt/keyrings/nodesource.gpg
+install_key https://aquasecurity.github.io/trivy-repo/deb/public.key "$TRIVY_KEY_SHA256" /etc/apt/keyrings/trivy.gpg
+install_key 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14AA40EC0831756F' "$PHP_KEY_SHA256" /etc/apt/keyrings/ondrej-php.gpg
+
+sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: noble
+Components: stable
+Architectures: amd64
+Signed-By: /etc/apt/keyrings/docker.gpg
+EOF
+sudo tee /etc/apt/sources.list.d/nodesource.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://deb.nodesource.com/node_24.x
+Suites: nodistro
+Components: main
+Architectures: amd64
+Signed-By: /etc/apt/keyrings/nodesource.gpg
+EOF
+sudo tee /etc/apt/sources.list.d/trivy.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://aquasecurity.github.io/trivy-repo/deb
+Suites: generic
+Components: main
+Architectures: amd64
+Signed-By: /etc/apt/keyrings/trivy.gpg
+EOF
+sudo tee /etc/apt/sources.list.d/ondrej-php.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://ppa.launchpadcontent.net/ondrej/php/ubuntu
+Suites: noble
+Components: main
+Architectures: amd64
+Signed-By: /etc/apt/keyrings/ondrej-php.gpg
+EOF
+
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends \
+  "docker-ce=${DOCKER_CE_VERSION}" \
+  "docker-ce-cli=${DOCKER_CLI_VERSION}" \
+  "containerd.io=${CONTAINERD_VERSION}" \
+  "docker-buildx-plugin=${BUILDX_VERSION}" \
+  "docker-compose-plugin=${COMPOSE_VERSION}" \
+  "nodejs=${NODE_VERSION}" \
+  "trivy=${TRIVY_VERSION}" \
+  "php8.3-cli=${PHP83_VERSION}" "php8.3-curl=${PHP83_VERSION}" \
+  "php8.3-mbstring=${PHP83_VERSION}" "php8.3-xml=${PHP83_VERSION}" "php8.3-zip=${PHP83_VERSION}" \
+  "php8.4-cli=${PHP84_VERSION}" "php8.4-curl=${PHP84_VERSION}" \
+  "php8.4-mbstring=${PHP84_VERSION}" "php8.4-xml=${PHP84_VERSION}" "php8.4-zip=${PHP84_VERSION}"
+
+sudo corepack enable
+sudo npm install --global --ignore-scripts "playwright@${PLAYWRIGHT_VERSION}"
+sudo /usr/bin/env PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright playwright install --with-deps chromium
+sudo chmod -R a+rX /opt/ms-playwright
+
+composer_installer=/tmp/composer-setup.php
+curl --fail --silent --show-error --location https://getcomposer.org/installer --output "$composer_installer"
+printf '%s  %s\n' "$COMPOSER_SHA384" "$composer_installer" | sha384sum --check --strict
+sudo php "$composer_installer" --version="$COMPOSER_VERSION" --install-dir=/usr/local/bin --filename=composer
+rm -f "$composer_installer"
+
+archive="/tmp/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+curl --fail --silent --show-error --location \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+  --output "$archive"
+printf '%s  %s\n' "$RUNNER_SHA256" "$archive" | sha256sum --check --strict
+
+sudo useradd --system --user-group --create-home --home-dir /opt/actions-runner --shell /usr/sbin/nologin ci-runner
+sudo usermod --append --groups docker ci-runner
+sudo tar --extract --gzip --file "$archive" --directory /opt/actions-runner
+sudo /opt/actions-runner/bin/installdependencies.sh
+sudo install -d -o ci-runner -g ci-runner -m 0700 /opt/actions-runner/_diag /opt/actions-runner/_work /run/ci-runner
+sudo chown -R root:root /opt/actions-runner
+sudo chown ci-runner:ci-runner /opt/actions-runner/_diag /opt/actions-runner/_work
+sudo install -o root -g root -m 0644 /tmp/ci-runner-job.service /etc/systemd/system/ci-runner-job.service
+sudo install -o root -g root -m 0755 /tmp/run-jit-runner.sh /usr/local/bin/run-jit-runner
+sudo systemctl daemon-reload
+sudo systemctl enable docker.service
+
+sudo tee /etc/ci-runner-image-manifest >/dev/null <<EOF
+runner=${RUNNER_VERSION}
+docker_ce=${DOCKER_CE_VERSION}
+docker_cli=${DOCKER_CLI_VERSION}
+containerd=${CONTAINERD_VERSION}
+buildx=${BUILDX_VERSION}
+compose=${COMPOSE_VERSION}
+node=${NODE_VERSION}
+trivy=${TRIVY_VERSION}
+php83=${PHP83_VERSION}
+php84=${PHP84_VERSION}
+composer=${COMPOSER_VERSION}
+playwright=${PLAYWRIGHT_VERSION}
+EOF
+sudo chmod 0444 /etc/ci-runner-image-manifest
+
+rm -f "$archive"

--- a/infra/packer/scripts/seal-image.sh
+++ b/infra/packer/scripts/seal-image.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo systemctl disable ssh.service ssh.socket || true
+sudo passwd --lock packer
+sudo rm -f /etc/ssh/ssh_host_* /root/.ssh/authorized_keys /home/packer/.ssh/authorized_keys
+sudo cloud-init clean --logs --machine-id --seed
+sudo truncate -s 0 /etc/machine-id
+sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+history -c || true

--- a/infra/packer/scripts/verify-image-contract.sh
+++ b/infra/packer/scripts/verify-image-contract.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_commands=(
+  composer
+  corepack
+  curl
+  docker
+  git
+  jq
+  node
+  npm
+  npx
+  php8.3
+  php8.4
+  trivy
+)
+
+for command in "${required_commands[@]}"; do
+  command -v "$command" >/dev/null || {
+    echo "image contract missing command: $command" >&2
+    exit 1
+  }
+done
+
+docker buildx version
+docker compose version
+node --version | grep -Eq '^v24\.'
+php8.3 --version | grep -Eq '^PHP 8\.3\.'
+php8.4 --version | grep -Eq '^PHP 8\.4\.'
+composer --version
+playwright --version
+trivy --version
+test -x /opt/actions-runner/run.sh
+test -x /usr/local/bin/run-jit-runner
+test -d /opt/ms-playwright
+test -s /etc/ci-runner-image-manifest
+
+echo "immutable runner image contract passed"

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,0 +1,18 @@
+# Sanctuary ephemeral CI runner
+
+This directory contains the host-side boundary for one ephemeral GitHub Actions
+runner. It is intentionally smaller than a runner scale-set client: the
+official GitHub client owns job acquisition and JIT configuration, while
+`ci-runner-manager` owns local admission, VM launch, and cleanup.
+
+See [the platform design](../docs/runner/sanctuary-kvm-runner.md) and
+[the operations runbook](../docs/playbooks/ci-runner-host.md) before deployment.
+
+## Local checks
+
+```sh
+./scripts/test-runner-platform.sh
+```
+
+No credential, token, private key, or runner registration response belongs in
+this repository.

--- a/runner/config/manager.toml
+++ b/runner/config/manager.toml
@@ -1,0 +1,25 @@
+state_dir = "/var/lib/ci-runner-manager/state"
+lock_file = "/run/lock/ci-runner-manager.lock"
+audit_log = "/mnt/hdd1000-01/ci-audit/manager.log"
+helper = "/usr/local/libexec/ci-runner-host-helper"
+overlay_root = "/mnt/ssd1000-01/ci-runner"
+min_free_memory_mib = 14336
+min_free_disk_gib = 140
+max_load_1m = 8.0
+max_lease_seconds = 7200
+runtime_dir = "/run/ci-runner-manager"
+github_token_file = "/run/credentials/ci-runner-manager.service/github_token"
+github_api_url = "https://api.github.com"
+allowed_owner = "Tuinstra-DEV"
+repositories = [
+  "Tuinstra-DEV/gate",
+  "Tuinstra-DEV/WODIQ",
+  "Tuinstra-DEV/tracker",
+  "Tuinstra-DEV/notify",
+  "Tuinstra-DEV/console",
+  "Tuinstra-DEV/wodiq-site",
+  "Tuinstra-DEV/marcel-site",
+  "Tuinstra-DEV/tuinstra-site",
+]
+runner_label = "trusted-heavy"
+runner_group_id = 1

--- a/runner/guest/run-jit-runner.sh
+++ b/runner/guest/run-jit-runner.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+jit_file=/run/ci-runner/jit.config
+runner_root=/opt/actions-runner
+
+if [[ ! -s "$jit_file" ]]; then
+  echo "JIT configuration is missing" >&2
+  exit 1
+fi
+
+jit_config=$(<"$jit_file")
+rm -f -- "$jit_file"
+cd "$runner_root"
+exec ./run.sh --jitconfig "$jit_config"

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Root-only, narrow libvirt helper for sanctuary CI VMs."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+PREFIX = "sanctuary-ci-"
+OVERLAY_ROOT = Path("/mnt/ssd1000-01/ci-runner")
+BASE_IMAGE = Path("/var/lib/ci-runner/images/ubuntu-24.04-runner.qcow2")
+NETWORK = "sanctuary-ci"
+VCPUS = "8"
+MEMORY_MIB = "12288"
+DISK_GIB = "120G"
+HELPER_LOCK = Path("/run/lock/ci-runner-host-helper.lock")
+
+
+def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=check, text=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, timeout=90)
+
+
+def validate_lease(value: str) -> str:
+    if not LEASE_RE.fullmatch(value):
+        raise ValueError("invalid lease id")
+    return value
+
+
+def name(lease: str) -> str:
+    return PREFIX + validate_lease(lease)
+
+
+def lease_dir(lease: str) -> Path:
+    directory = OVERLAY_ROOT / validate_lease(lease)
+    if directory.parent != OVERLAY_ROOT:
+        raise ValueError("invalid lease path")
+    return directory
+
+
+def launch(lease: str) -> None:
+    if os.geteuid() != 0:
+        raise PermissionError("helper must run as root")
+    if not BASE_IMAGE.is_file():
+        raise FileNotFoundError(f"base image missing: {BASE_IMAGE}")
+    existing = run(["virsh", "list", "--all", "--name"])
+    if any(line.startswith(PREFIX) for line in existing.stdout.splitlines()):
+        raise RuntimeError("a sanctuary CI domain already exists")
+    encoded_jit = sys.stdin.buffer.read(131073).strip()
+    if not encoded_jit or len(encoded_jit) > 131072:
+        raise ValueError("invalid JIT configuration size")
+    base64.b64decode(encoded_jit, validate=True)
+    directory = lease_dir(lease)
+    if directory.exists():
+        raise FileExistsError("lease directory already exists")
+    directory.mkdir(mode=0o700)
+    overlay = directory / "root.qcow2"
+    seed = directory / "seed.iso"
+    try:
+        run(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", str(BASE_IMAGE), str(overlay), DISK_GIB])
+        user_data = """#cloud-config
+bootcmd:
+  - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
+write_files:
+  - path: /run/ci-runner/jit.config
+    owner: ci-runner:ci-runner
+    permissions: '0600'
+    encoding: b64
+    content: %s
+runcmd:
+  - [systemctl, start, ci-runner-job.service]
+""" % base64.b64encode(encoded_jit).decode("ascii")
+        meta_data = f"instance-id: {name(lease)}\nlocal-hostname: ci-worker\n"
+        with tempfile.TemporaryDirectory(dir=directory) as temporary:
+            temp = Path(temporary)
+            (temp / "user-data").write_text(user_data, encoding="utf-8")
+            (temp / "meta-data").write_text(meta_data, encoding="utf-8")
+            os.chmod(temp / "user-data", 0o600)
+            run(["cloud-localds", str(seed), str(temp / "user-data"), str(temp / "meta-data")])
+        run(["virt-install", "--name", name(lease), "--memory", MEMORY_MIB, "--vcpus", VCPUS,
+             "--cpu", "host-passthrough", "--import", "--noautoconsole", "--os-variant", "ubuntu24.04",
+             "--disk", f"path={overlay},format=qcow2,bus=virtio,cache=none,discard=unmap",
+             "--disk", f"path={seed},device=cdrom,readonly=on",
+             "--network", f"network={NETWORK},model=virtio", "--graphics", "none",
+             "--rng", "/dev/urandom", "--controller", "type=scsi,model=virtio-scsi"])
+    except Exception:
+        destroy(lease)
+        raise
+
+
+def destroy(lease: str) -> None:
+    domain = name(lease)
+    run(["virsh", "destroy", domain], check=False)
+    run(["virsh", "undefine", domain, "--nvram"], check=False)
+    directory = lease_dir(lease)
+    if directory.exists():
+        shutil.rmtree(directory)
+
+
+def list_leases() -> None:
+    result = run(["virsh", "list", "--all", "--name"])
+    leases = {}
+    for domain in sorted(line for line in result.stdout.splitlines() if line.startswith(PREFIX)):
+        state = run(["virsh", "domstate", domain]).stdout.strip().lower()
+        leases[domain[len(PREFIX):]] = state
+    print(json.dumps(leases, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    for command in ("launch", "destroy"):
+        child = sub.add_parser(command)
+        child.add_argument("lease")
+    sub.add_parser("list")
+    args = parser.parse_args()
+    try:
+        with HELPER_LOCK.open("a+", encoding="utf-8") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            if args.command == "launch":
+                launch(args.lease)
+            elif args.command == "destroy":
+                destroy(args.lease)
+            else:
+                list_leases()
+        return 0
+    except Exception as exc:
+        print(f"ci-runner-host-helper: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runner/logrotate/ci-runner-audit
+++ b/runner/logrotate/ci-runner-audit
@@ -1,0 +1,11 @@
+/mnt/hdd1000-01/ci-audit/*.log {
+    daily
+    rotate 30
+    maxage 30
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    su ci-runner-manager ci-runner-manager
+}

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Admission and lifecycle boundary for the single sanctuary CI worker."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import time
+import tomllib
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+LOG = logging.getLogger("ci-runner-manager")
+
+
+class RunnerError(RuntimeError):
+    pass
+
+
+class RateLimited(RunnerError):
+    def __init__(self, retry_after: int) -> None:
+        super().__init__("GitHub API rate limit reached")
+        self.retry_after = max(5, min(retry_after, 3600))
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        cfg = tomllib.load(handle)
+    required = {"state_dir", "lock_file", "audit_log", "helper", "min_free_memory_mib", "min_free_disk_gib", "max_load_1m", "max_lease_seconds", "github_token_file", "repositories", "runner_label"}
+    missing = required.difference(cfg)
+    if missing:
+        raise RunnerError(f"missing configuration keys: {', '.join(sorted(missing))}")
+    return cfg
+
+
+def validate_lease_id(value: str) -> str:
+    if not LEASE_RE.fullmatch(value):
+        raise RunnerError("lease id must contain only letters, digits, dot, underscore, or dash")
+    return value
+
+
+def read_jit_config(path: Path) -> bytes:
+    stat = path.stat()
+    if stat.st_mode & 0o077:
+        raise RunnerError("JIT configuration file must not be accessible by group or others")
+    raw = path.read_bytes().strip()
+    if not raw or len(raw) > 131072:
+        raise RunnerError("JIT configuration is empty or exceeds 128 KiB")
+    try:
+        base64.b64decode(raw, validate=True)
+    except ValueError as exc:
+        raise RunnerError("JIT configuration is not valid base64") from exc
+    return raw
+
+
+def memory_available_mib() -> int:
+    for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+        if line.startswith("MemAvailable:"):
+            return int(line.split()[1]) // 1024
+    raise RunnerError("cannot determine available memory")
+
+
+def capacity_errors(cfg: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if (os.cpu_count() or 0) < 8:
+        errors.append("host has fewer than 8 logical CPUs")
+    if memory_available_mib() < int(cfg["min_free_memory_mib"]):
+        errors.append("host free memory is below admission threshold")
+    disk = shutil.disk_usage(str(cfg.get("overlay_root", "/mnt/ssd1000-01/ci-runner")))
+    if disk.free < int(cfg["min_free_disk_gib"]) * 1024**3:
+        errors.append("overlay filesystem free space is below admission threshold")
+    if os.getloadavg()[0] > float(cfg["max_load_1m"]):
+        errors.append("host one-minute load is above admission threshold")
+    return errors
+
+
+class StateStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+        self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    def leases(self) -> list[dict[str, Any]]:
+        result = []
+        for path in sorted(self.directory.glob("lease-*.json")):
+            try:
+                result.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as exc:
+                LOG.error("invalid state file %s: %s", path.name, exc)
+        return result
+
+    def write(self, lease: str, state: dict[str, Any]) -> None:
+        destination = self.directory / f"lease-{lease}.json"
+        temporary = destination.with_suffix(".tmp")
+        temporary.write_text(json.dumps(state, sort_keys=True) + "\n", encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+
+    def remove(self, lease: str) -> None:
+        (self.directory / f"lease-{lease}.json").unlink(missing_ok=True)
+
+
+class DispatchHistory:
+    def __init__(self, state_dir: Path) -> None:
+        self.path = state_dir / "dispatch-history.json"
+
+    def load(self) -> dict[str, int]:
+        if not self.path.exists():
+            return {}
+        value = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise RunnerError("invalid dispatch history")
+        return {str(key): int(timestamp) for key, timestamp in value.items()}
+
+    def contains(self, key: str, now: int) -> bool:
+        return key in {item for item, seen in self.load().items() if seen > now - 86400}
+
+    def add(self, key: str, now: int) -> None:
+        values = {item: seen for item, seen in self.load().items() if seen > now - 86400}
+        values[key] = now
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(values, sort_keys=True) + "\n", encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, self.path)
+
+
+class GitHubClient:
+    def __init__(self, token: str, api_url: str = "https://api.github.com") -> None:
+        if not token or "\n" in token:
+            raise RunnerError("invalid GitHub credential")
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+
+    def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            self._api_url + path, method=method, data=data,
+            headers={"Accept": "application/vnd.github+json", "Authorization": f"Bearer {self._token}",
+                     "X-GitHub-Api-Version": "2022-11-28", "User-Agent": "sanctuary-ci-manager"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                raw = response.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as exc:
+            remaining = exc.headers.get("X-RateLimit-Remaining")
+            if exc.code == 429 or (exc.code == 403 and (exc.headers.get("Retry-After") or remaining == "0")):
+                retry = exc.headers.get("Retry-After")
+                reset = exc.headers.get("X-RateLimit-Reset")
+                delay = int(retry) if retry and retry.isdigit() else max(5, int(reset) - int(time.time()) if reset and reset.isdigit() else 60)
+                raise RateLimited(delay) from exc
+            raise RunnerError(f"GitHub API returned HTTP {exc.code}") from exc
+        except urllib.error.URLError as exc:
+            raise RunnerError("GitHub API request failed") from exc
+
+    @staticmethod
+    def repo_path(repo: str) -> str:
+        owner, name = repo.split("/", 1)
+        return f"/repos/{urllib.parse.quote(owner, safe='')}/{urllib.parse.quote(name, safe='')}"
+
+    def candidate_jobs(self, repo: str, required_label: str) -> list[dict[str, Any]]:
+        candidates = []
+        for status in ("queued", "in_progress"):
+            runs = self.request("GET", f"{self.repo_path(repo)}/actions/runs?status={status}&per_page=100")
+            for run in runs.get("workflow_runs", []):
+                jobs = self.request("GET", f"{self.repo_path(repo)}/actions/runs/{int(run['id'])}/jobs?filter=latest&per_page=100")
+                for job in jobs.get("jobs", []):
+                    labels = job.get("labels", [])
+                    if job.get("status") == "queued" and required_label in labels:
+                        candidates.append({"repo": repo, "run_id": int(run["id"]), "job_id": int(job["id"])})
+        return candidates
+
+    def generate_jit(self, repo: str, job_id: int, group_id: int, label: str) -> dict[str, Any]:
+        return self.request("POST", f"{self.repo_path(repo)}/actions/runners/generate-jitconfig", {
+            "name": f"sanctuary-{job_id}", "runner_group_id": group_id,
+            "labels": ["self-hosted", "linux", "x64", label], "work_folder": "_work",
+        })
+
+    def delete_runner(self, repo: str, runner_id: int) -> None:
+        self.request("DELETE", f"{self.repo_path(repo)}/actions/runners/{runner_id}")
+
+
+def validate_repositories(cfg: dict[str, Any]) -> list[str]:
+    repos = cfg.get("repositories", [])
+    owner = str(cfg.get("allowed_owner", "Tuinstra-DEV"))
+    if not isinstance(repos, list) or not repos:
+        raise RunnerError("repository allowlist must not be empty")
+    pattern = re.compile(rf"^{re.escape(owner)}/[A-Za-z0-9_.-]+$")
+    if any(not isinstance(repo, str) or not pattern.fullmatch(repo) for repo in repos):
+        raise RunnerError("repository allowlist contains an invalid repository")
+    return repos
+
+
+def read_token(path: Path) -> str:
+    stat = path.stat()
+    if stat.st_mode & 0o077:
+        raise RunnerError("GitHub credential must not be accessible by group or others")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def helper(cfg: dict[str, Any], *args: str, stdin: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = ["sudo", "--non-interactive", str(cfg["helper"]), *args]
+    return subprocess.run(command, input=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          check=check, timeout=120, text=False)
+
+
+def with_lock(path: Path):
+    path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+    handle = path.open("a+", encoding="utf-8")
+    fcntl.flock(handle, fcntl.LOCK_EX)
+    return handle
+
+
+def launch(cfg: dict[str, Any], lease: str, jit_path: Path) -> None:
+    lease = validate_lease_id(lease)
+    jit = read_jit_config(jit_path)
+    store = StateStore(Path(cfg["state_dir"]))
+    with with_lock(Path(cfg["lock_file"])):
+        if store.leases():
+            raise RunnerError("maximum concurrency is 1; an active lease already exists")
+        inventory = json.loads(helper(cfg, "list").stdout.decode("utf-8"))
+        if not isinstance(inventory, dict):
+            raise RunnerError("helper returned invalid domain inventory")
+        if inventory:
+            raise RunnerError("maximum concurrency is 1; a runner domain already exists")
+        failures = capacity_errors(cfg)
+        if failures:
+            raise RunnerError("; ".join(failures))
+        LOG.info("launch requested lease=%s", lease)
+        helper(cfg, "launch", lease, stdin=jit)
+        store.write(lease, {"lease": lease, "launched_at": int(time.time())})
+        LOG.info("launch completed lease=%s", lease)
+
+
+def destroy(cfg: dict[str, Any], lease: str) -> None:
+    lease = validate_lease_id(lease)
+    store = StateStore(Path(cfg["state_dir"]))
+    with with_lock(Path(cfg["lock_file"])):
+        LOG.info("destroy requested lease=%s", lease)
+        helper(cfg, "destroy", lease)
+        store.remove(lease)
+        LOG.info("destroy completed lease=%s", lease)
+
+
+def reconcile(cfg: dict[str, Any]) -> None:
+    store = StateStore(Path(cfg["state_dir"]))
+    with with_lock(Path(cfg["lock_file"])):
+        result = helper(cfg, "list", check=True)
+        domains = json.loads(result.stdout.decode("utf-8"))
+        if not isinstance(domains, dict):
+            raise RunnerError("helper returned invalid domain inventory")
+        known = {item["lease"] for item in store.leases() if "lease" in item}
+        now = int(time.time())
+        states = {item["lease"]: item for item in store.leases() if "lease" in item}
+        expired = {lease for lease, state in states.items()
+                   if int(state.get("launched_at", 0)) + int(cfg["max_lease_seconds"]) < now}
+        running = {lease for lease, state in domains.items() if state == "running"} - expired
+        for lease in sorted(known - running):
+            LOG.warning("cleaning completed or missing domain lease=%s", lease)
+            helper(cfg, "destroy", lease)
+            store.remove(lease)
+        for lease in sorted(set(domains) - known):
+            LOG.warning("destroying orphan domain lease=%s", lease)
+            helper(cfg, "destroy", lease)
+
+
+def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
+    store = StateStore(Path(cfg["state_dir"]))
+    if store.leases():
+        return False
+    now = int(time.time())
+    history = DispatchHistory(Path(cfg["state_dir"]))
+    label = str(cfg.get("runner_label", "trusted-heavy"))
+    for repo in validate_repositories(cfg):
+        for job in client.candidate_jobs(repo, label):
+            key = f"{repo}:{job['job_id']}"
+            if history.contains(key, now):
+                continue
+            response = client.generate_jit(repo, job["job_id"], int(cfg.get("runner_group_id", 1)), label)
+            encoded = response.get("encoded_jit_config")
+            runner_id = response.get("runner", {}).get("id")
+            if not isinstance(encoded, str) or not isinstance(runner_id, int):
+                if isinstance(runner_id, int):
+                    try:
+                        client.delete_runner(repo, runner_id)
+                    except RunnerError:
+                        LOG.error("failed to remove malformed GitHub runner repo=%s runner_id=%s", repo, runner_id)
+                raise RunnerError("GitHub returned an invalid JIT response")
+            lease = f"gh-{job['job_id']}"
+            jit_path = Path(cfg.get("runtime_dir", "/run/ci-runner-manager")) / f"{lease}.jit"
+            try:
+                jit_path.write_text(encoded, encoding="utf-8")
+                os.chmod(jit_path, 0o600)
+                launch(cfg, lease, jit_path)
+                history.add(key, now)
+                LOG.info("dispatched repo=%s run_id=%s job_id=%s", repo, job["run_id"], job["job_id"])
+                return True
+            except Exception:
+                try:
+                    client.delete_runner(repo, runner_id)
+                except RunnerError:
+                    LOG.error("failed to remove unused GitHub runner repo=%s runner_id=%s", repo, runner_id)
+                raise
+            finally:
+                jit_path.unlink(missing_ok=True)
+    return False
+
+
+def configure_logging(path: Path) -> None:
+    path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+                        handlers=[logging.FileHandler(path, encoding="utf-8"), logging.StreamHandler()])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=Path("/etc/ci-runner/manager.toml"))
+    sub = parser.add_subparsers(dest="command", required=True)
+    launch_parser = sub.add_parser("launch")
+    launch_parser.add_argument("--lease", required=True)
+    launch_parser.add_argument("--jit-config-file", required=True, type=Path)
+    destroy_parser = sub.add_parser("destroy")
+    destroy_parser.add_argument("--lease", required=True)
+    sub.add_parser("reconcile")
+    daemon_parser = sub.add_parser("daemon")
+    daemon_parser.add_argument("--interval", type=int, default=30)
+    args = parser.parse_args(argv)
+    try:
+        cfg = load_config(args.config)
+        configure_logging(Path(cfg["audit_log"]))
+        if args.command == "launch":
+            launch(cfg, args.lease, args.jit_config_file)
+        elif args.command == "destroy":
+            destroy(cfg, args.lease)
+        elif args.command == "reconcile":
+            reconcile(cfg)
+        else:
+            if args.interval < 5:
+                raise RunnerError("daemon interval must be at least 5 seconds")
+            client = GitHubClient(read_token(Path(cfg["github_token_file"])), str(cfg.get("github_api_url", "https://api.github.com")))
+            while True:
+                try:
+                    reconcile(cfg)
+                    dispatch_once(cfg, client)
+                except RateLimited as exc:
+                    LOG.warning("GitHub rate limited; retrying later")
+                    time.sleep(exc.retry_after)
+                    continue
+                except Exception:
+                    LOG.exception("poll or reconciliation failed")
+                time.sleep(args.interval)
+        return 0
+    except (RunnerError, OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        LOG.error("%s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runner/sudoers/ci-runner-manager
+++ b/runner/sudoers/ci-runner-manager
@@ -1,0 +1,2 @@
+Defaults:ci-runner-manager env_reset,secure_path=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/libexec
+ci-runner-manager ALL=(root) NOPASSWD: /usr/local/libexec/ci-runner-host-helper *

--- a/runner/systemd/ci-runner-job.service
+++ b/runner/systemd/ci-runner-job.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=One-shot GitHub Actions JIT runner
+After=network-online.target cloud-final.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ci-runner
+Group=ci-runner
+WorkingDirectory=/opt/actions-runner
+Environment=PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+Environment=RUNNER_DISABLEUPDATE=1
+ExecStartPre=/usr/bin/test -s /run/ci-runner/jit.config
+ExecStart=/usr/local/bin/run-jit-runner
+ExecStopPost=-/usr/bin/rm -f /run/ci-runner/jit.config
+ExecStopPost=+/usr/bin/systemctl poweroff
+Restart=no
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/opt/actions-runner/_diag /opt/actions-runner/_work /run/ci-runner
+
+[Install]
+WantedBy=multi-user.target

--- a/runner/systemd/ci-runner-manager.service
+++ b/runner/systemd/ci-runner-manager.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Sanctuary CI runner reconciler
+After=network-online.target libvirtd.service sanctuary-ci-firewall.service
+Wants=network-online.target
+Requires=libvirtd.service sanctuary-ci-firewall.service
+ConditionPathExists=/etc/ci-runner/github.token
+
+[Service]
+Type=simple
+User=ci-runner-manager
+Group=ci-runner-manager
+ExecStart=/usr/local/bin/ci-runner-manager --config /etc/ci-runner/manager.toml daemon --interval 30
+LoadCredential=github_token:/etc/ci-runner/github.token
+Restart=always
+RestartSec=5
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/ci-runner-manager /run/lock /mnt/hdd1000-01/ci-audit
+RuntimeDirectory=ci-runner-manager
+RuntimeDirectoryMode=0700
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/runner/systemd/sanctuary-ci-firewall.service
+++ b/runner/systemd/sanctuary-ci-firewall.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sanctuary CI isolated nftables policy
+Before=ci-runner-manager.service
+After=network-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/sbin/nft -c -f /etc/ci-runner/sanctuary-ci.nft
+ExecStart=/usr/sbin/nft -f /etc/ci-runner/sanctuary-ci.nft
+ExecStop=-/usr/sbin/nft delete table inet sanctuary_ci
+
+[Install]
+WantedBy=multi-user.target

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest import mock
+
+import ci_runner_host_helper as helper
+
+
+class HostHelperTests(unittest.TestCase):
+    def test_domain_name_is_namespaced(self):
+        self.assertEqual(helper.name("job-9"), "sanctuary-ci-job-9")
+
+    def test_lease_directory_cannot_escape_overlay_root(self):
+        for value in ("../etc", "a/b", "white space", ""):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                helper.lease_dir(value)
+
+    @mock.patch.object(helper, "run")
+    @mock.patch.object(helper, "BASE_IMAGE")
+    @mock.patch.object(helper.os, "geteuid", return_value=0)
+    def test_launch_rejects_existing_domain_before_reading_secret(self, _euid, image, run):
+        image.is_file.return_value = True
+        run.return_value = mock.Mock(stdout="sanctuary-ci-existing\n")
+        with self.assertRaisesRegex(RuntimeError, "domain already exists"):
+            helper.launch("new")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -1,0 +1,156 @@
+import base64
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+import json
+import io
+import urllib.error
+
+import ci_runner_manager as manager
+
+
+class ManagerTests(unittest.TestCase):
+    def test_lease_validation_accepts_expected_identifier(self):
+        self.assertEqual(manager.validate_lease_id("job-123_abc.1"), "job-123_abc.1")
+
+    def test_lease_validation_rejects_path_traversal(self):
+        for value in ("../job", "/tmp/job", "job name", "", "a" * 65):
+            with self.subTest(value=value), self.assertRaises(manager.RunnerError):
+                manager.validate_lease_id(value)
+
+    def test_jit_file_requires_private_permissions_and_base64(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "jit"
+            path.write_bytes(base64.b64encode(b"opaque-jit-payload"))
+            os.chmod(path, 0o600)
+            self.assertEqual(manager.read_jit_config(path), path.read_bytes())
+            os.chmod(path, 0o640)
+            with self.assertRaises(manager.RunnerError):
+                manager.read_jit_config(path)
+
+    def test_jit_file_rejects_invalid_base64(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "jit"
+            path.write_text("not base64!", encoding="utf-8")
+            os.chmod(path, 0o600)
+            with self.assertRaises(manager.RunnerError):
+                manager.read_jit_config(path)
+
+    @mock.patch.object(manager.os, "getloadavg", return_value=(1.0, 1.0, 1.0))
+    @mock.patch.object(manager.os, "cpu_count", return_value=4)
+    @mock.patch.object(manager, "memory_available_mib", return_value=20000)
+    @mock.patch.object(manager.shutil, "disk_usage")
+    def test_capacity_rejects_small_cpu_host(self, disk, _memory, _cpu, _load):
+        disk.return_value = mock.Mock(free=200 * 1024**3)
+        cfg = {"min_free_memory_mib": 14000, "min_free_disk_gib": 140, "max_load_1m": 8, "overlay_root": "/x"}
+        self.assertIn("host has fewer than 8 logical CPUs", manager.capacity_errors(cfg))
+
+    @mock.patch.object(manager, "helper")
+    def test_reconcile_destroys_powered_off_and_orphan_domains(self, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock", "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("finished", {"lease": "finished"})
+            helper.side_effect = [mock.Mock(stdout=json.dumps({"finished": "shut off", "orphan": "running"}).encode()),
+                                  mock.Mock(), mock.Mock()]
+            manager.reconcile(cfg)
+            calls = [call.args[1:] for call in helper.call_args_list]
+            self.assertIn(("destroy", "finished"), calls)
+            self.assertIn(("destroy", "orphan"), calls)
+            self.assertEqual(store.leases(), [])
+
+    @mock.patch.object(manager, "capacity_errors", return_value=[])
+    @mock.patch.object(manager, "helper")
+    def test_launch_rejects_untracked_existing_domain(self, helper, _capacity):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            jit = root / "jit"
+            jit.write_bytes(base64.b64encode(b"opaque"))
+            os.chmod(jit, 0o600)
+            helper.return_value = mock.Mock(stdout=b'{"orphan":"running"}')
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock"}
+            with self.assertRaisesRegex(manager.RunnerError, "domain already exists"):
+                manager.launch(cfg, "new-job", jit)
+
+    def test_candidate_jobs_filter_status_and_label(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": [{"id": 10}]},
+            {"jobs": [{"id": 1, "status": "queued", "labels": ["self-hosted", "trusted-heavy"]},
+                      {"id": 2, "status": "queued", "labels": ["self-hosted"]},
+                      {"id": 3, "status": "in_progress", "labels": ["trusted-heavy"]}]},
+            {"workflow_runs": []},
+        ])
+        self.assertEqual(client.candidate_jobs("Tuinstra-DEV/gate", "trusted-heavy"),
+                         [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 1}])
+
+    @mock.patch.object(manager.urllib.request, "urlopen")
+    def test_rate_limit_is_fail_closed_and_does_not_expose_token(self, urlopen):
+        headers = {"Retry-After": "60"}
+        urlopen.side_effect = urllib.error.HTTPError("https://api.github.com", 429, "limited", headers, io.BytesIO())
+        client = manager.GitHubClient("top-secret-token")
+        with self.assertRaises(manager.RateLimited) as raised:
+            client.request("GET", "/rate-limited")
+        self.assertEqual(raised.exception.retry_after, 60)
+        self.assertNotIn("top-secret-token", str(raised.exception))
+
+    @mock.patch.object(manager.urllib.request, "urlopen")
+    def test_api_error_is_sanitized(self, urlopen):
+        urlopen.side_effect = urllib.error.HTTPError("https://api.github.com", 500, "body may be sensitive", {}, io.BytesIO())
+        with self.assertRaisesRegex(manager.RunnerError, "HTTP 500") as raised:
+            manager.GitHubClient("top-secret-token").request("GET", "/failure")
+        self.assertNotIn("top-secret-token", str(raised.exception))
+        self.assertNotIn("body may be sensitive", str(raised.exception))
+
+    def test_dispatch_history_deduplicates_job(self):
+        with tempfile.TemporaryDirectory() as directory:
+            history = manager.DispatchHistory(Path(directory))
+            history.add("Tuinstra-DEV/gate:123", 1000)
+            self.assertTrue(history.contains("Tuinstra-DEV/gate:123", 1001))
+            self.assertFalse(history.contains("Tuinstra-DEV/gate:123", 90000))
+
+    @mock.patch.object(manager, "launch", side_effect=manager.RunnerError("launch failed"))
+    def test_dispatch_deletes_generated_runner_when_launch_fails(self, _launch):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            client.generate_jit.return_value = {"encoded_jit_config": base64.b64encode(b"jit").decode(), "runner": {"id": 30}}
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+            (root / "run").mkdir()
+            with self.assertRaisesRegex(manager.RunnerError, "launch failed"):
+                manager.dispatch_once(cfg, client)
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            self.assertEqual(list((root / "run").iterdir()), [])
+
+    @mock.patch.object(manager.time, "time", return_value=1001)
+    def test_dispatch_skips_job_in_history(self, _time):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / "state"
+            manager.StateStore(state)
+            manager.DispatchHistory(state).add("Tuinstra-DEV/gate:20", 1000)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            cfg = {"state_dir": state, "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+            self.assertFalse(manager.dispatch_once(cfg, client))
+            client.generate_jit.assert_not_called()
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=10000)
+    def test_reconcile_destroys_expired_running_lease(self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock", "max_lease_seconds": 7200}
+            manager.StateStore(cfg["state_dir"]).write("expired", {"lease": "expired", "launched_at": 1})
+            helper.side_effect = [mock.Mock(stdout=b'{"expired":"running"}'), mock.Mock()]
+            manager.reconcile(cfg)
+            self.assertIn(("destroy", "expired"), [call.args[1:] for call in helper.call_args_list])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -c 'import ast,pathlib; [ast.parse(p.read_text()) for root in ("runner/manager", "runner/host-helper", "runner/tests") for p in pathlib.Path(root).glob("*.py")]'
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="runner/manager:runner/host-helper" python3 -B -m unittest discover -s runner/tests -v
+bash -n infra/packer/scripts/install-runner.sh infra/packer/scripts/seal-image.sh \
+  infra/packer/scripts/verify-image-contract.sh runner/guest/run-jit-runner.sh
+
+if command -v ruby >/dev/null 2>&1; then
+  ruby -e 'require "yaml"; ARGV.each { |p| YAML.safe_load(File.read(p), aliases: true) }' \
+    infra/ansible/site.yml infra/ansible/inventory/hosts.example.yml \
+    infra/ansible/roles/runner_host/defaults/main.yml \
+    infra/ansible/roles/runner_host/handlers/main.yml \
+    infra/ansible/roles/runner_host/tasks/main.yml infra/packer/http/user-data
+fi
+
+for file in infra/packer/sanctuary-runner.pkr.hcl infra/ansible/site.yml; do
+  test -s "$file"
+done
+
+grep -q 'rotate 30' runner/logrotate/ci-runner-audit
+grep -q 'MEMORY_MIB = "12288"' runner/host-helper/ci_runner_host_helper.py
+grep -q 'VCPUS = "8"' runner/host-helper/ci_runner_host_helper.py
+grep -q 'DISK_GIB = "120G"' runner/host-helper/ci_runner_host_helper.py
+grep -q 'concurrency is 1' runner/manager/ci_runner_manager.py
+grep -q 'max_lease_seconds = 7200' runner/config/manager.toml
+grep -q 'Tuinstra-DEV/tuinstra-site' runner/config/manager.toml
+! grep -q 'Tuinstra-DEV/devops' runner/config/manager.toml
+grep -q '88.159.77.149/32' infra/ansible/inventory/hosts.example.yml
+! grep -q 'nftables.service' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'docker buildx version' infra/packer/scripts/verify-image-contract.sh
+grep -q "node --version.*v24" infra/packer/scripts/verify-image-contract.sh
+grep -q 'php8.3' infra/packer/scripts/verify-image-contract.sh
+grep -q 'php8.4' infra/packer/scripts/verify-image-contract.sh
+grep -q 'playwright install --with-deps chromium' infra/packer/scripts/install-runner.sh
+grep -q 'exec ./run.sh --jitconfig' runner/guest/run-jit-runner.sh
+grep -q 'ExecStopPost=+/usr/bin/systemctl poweroff' runner/systemd/ci-runner-job.service
+grep -q '^Restart=no$' runner/systemd/ci-runner-job.service
+! grep -q 'run.sh --jitconfig' runner/systemd/ci-runner-job.service
+if grep -Eq 'curl[^|]*\|[[:space:]]*(ba)?sh' infra/packer/scripts/install-runner.sh; then
+  echo "image install must not pipe downloads to a shell" >&2
+  exit 1
+fi
+
+if command -v packer >/dev/null 2>&1; then
+  packer fmt -check infra/packer/sanctuary-runner.pkr.hcl
+else
+  echo "packer not installed; skipped packer fmt check"
+fi
+
+if command -v ansible-playbook >/dev/null 2>&1; then
+  (cd infra/ansible && ansible-playbook -i 'sanctuary,' --syntax-check site.yml)
+else
+  echo "ansible-playbook not installed; skipped Ansible syntax check"
+fi
+
+echo "runner platform tests passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,6 +15,8 @@ for dir in "${required_dirs[@]}"; do
   fi
 done
 
+./scripts/test-runner-platform.sh
+
 if ! grep -q "Auth0" "README.md"; then
   echo "README must document Auth0 direction"
   exit 1


### PR DESCRIPTION
## Summary
- add single-concurrency per-job KVM runners with repository JIT polling and 120-minute TTL
- isolate guests from Sanctuary, private networks, and production public CIDRs with a runner-only nftables table
- bake a checksum-pinned Ubuntu image with Docker, Node 24, Playwright, Trivy, PHP, Composer, and the Actions runner
- load a least-privilege GitHub credential through systemd credentials and retain lifecycle audit logs for 30 days
- document provisioning, canary, rollback, CVE rebuilds, and incident cleanup

## Verification
- make lint
- make test
- 17 runner unit/static tests
- Packer 1.15.4 fmt check and validate with QEMU plugin 1.1.6
- ansible-core 2.19.7 syntax check
- git diff --check

## Activation prerequisite
A repository-scoped token with Actions read and self-hosted runners write for the explicit allowlist must be provisioned as root mode 0600; no broad CLI token is copied to Sanctuary.

Tracker: DEV-1