### PR TITLE
fix(runner): harden DEV-1 lifecycle cleanup

### DIFF
--- a/docs/playbooks/ci-runner-host.md
+++ b/docs/playbooks/ci-runner-host.md
@@ -13,12 +13,19 @@
 6. Confirm the allowlisted repositories, `trusted-heavy` label, group ID 1, and
    120-minute lease limit in `/etc/ci-runner/manager.toml`.
 
+Image activation is fail-closed: Ansible stops new admission, refuses to switch
+the digest symlink while any `sanctuary-ci-*` domain or overlay entry exists,
+and retains prior digest-versioned images. Never bypass this drain assertion.
+
 Copy `infra/packer/sanctuary-runner.pkrvars.hcl.example` outside source control,
 replace every placeholder with an exact reviewed version or checksum, then run
 `packer build -var-file=/protected/path/sanctuary-runner.pkrvars.hcl
 sanctuary-runner.pkr.hcl` from `infra/packer`. The build fails unless Docker,
 Buildx, Compose, Node 24/Corepack, Playwright Chromium, Trivy, PHP 8.3/8.4,
 Composer, and the base CLI/build tools satisfy the image contract.
+Install Packer and the QEMU plugin only from the artifacts and SHA-256 values in
+`infra/packer/toolchain.lock`; retain the verified archives with the image build
+evidence.
 
 Validate the role locally before applying it, then execute check mode against
 the `sanctuary` inventory target. Check mode gathers host facts but does not
@@ -49,6 +56,12 @@ reachability while host, private and production ranges are blocked; one-job
 poweroff; complete reconciliation within 30 seconds; and audit events without
 the JIT payload.
 
+Repeat a failure canary with the manager stopped. Confirm the guest and host
+timer power the VM off at the configured upper bound, then restart the manager
+and confirm the local lease, overlay, seed and GitHub runner record are removed.
+Simulate one failed GitHub deletion and verify a private cleanup tombstone is
+retried without blocking the next VM admission.
+
 The Sanctuary production deny list must contain `88.159.77.149/32` plus every
 other public production CIDR. The dedicated firewall service must leave Docker
 and all non-`sanctuary_ci` nftables tables unchanged.
@@ -73,3 +86,7 @@ lease directory remains.
 
 Keep the checksum-pinned base image during rollback so restoration is
 reversible. Re-enable only after a canary passes the acceptance checks.
+To roll back an image, drain to zero domains and overlays, atomically repoint
+`ubuntu-24.04-runner.qcow2` to the digest recorded by
+`ubuntu-24.04-runner.previous.qcow2`, restart the manager, and pass the same
+non-production canary. Verify backing chains before deleting any retained image.

--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -120,9 +120,22 @@ clean host, retain the manifest, run the image contract, and pass a
 non-production canary before changing the Ansible image digest. Never update a
 package in place on Sanctuary; roll forward with a new immutable image.
 
+Images are stored by SHA-256 and activated through the fixed
+`ubuntu-24.04-runner.qcow2` symlink only after admission is stopped and both the
+libvirt domain list and overlay directory are empty. The helper resolves that
+link before creating an overlay and records the digest path as its backing file,
+so a later symlink switch cannot alter an active backing chain. Previous digest
+files remain local for reviewed rollback and must never be removed while
+referenced by `qemu-img info --backing-chain`.
+
 The guest unit invokes a fixed wrapper which reads the JIT value, removes its
 runtime file, and `exec`s `run.sh --jitconfig` exactly once. The service does not
 restart and powers the VM off after the runner exits, including failure paths.
+Both the guest unit and an independent host timer enforce the 120-minute upper
+bound. The manager persists the repository and GitHub runner ID before launch;
+completed and forced leases delete the runner record idempotently. Failed API
+cleanup is moved to a private retry tombstone with bounded exponential delay and
+does not masquerade as a live VM lease.
 
 ## Audit and retention
 

--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -75,14 +75,87 @@
       - (runner_github_credential.stat.mode | default('')) == '0600'
     fail_msg: Provision /etc/ci-runner/github.token as root mode 0600 outside Ansible source control.
 
-- name: Install pinned immutable base image
+- name: Inspect existing services before image activation
+  ansible.builtin.service_facts:
+
+- name: Stop runner admission before image activation
+  ansible.builtin.systemd:
+    name: ci-runner-manager.service
+    state: stopped
+  when: "'ci-runner-manager.service' in ansible_facts.services"
+
+- name: Inspect runner domains before image activation
+  ansible.builtin.command:
+    argv:
+      - virsh
+      - list
+      - --all
+      - --name
+  register: runner_existing_domains
+  changed_when: false
+
+- name: Require a fully drained runner before image activation
+  ansible.builtin.assert:
+    that:
+      - runner_existing_domains.stdout_lines | select('match', '^sanctuary-ci-') | list | length == 0
+    fail_msg: Refusing to switch the base image while a Sanctuary CI domain exists.
+
+- name: Inspect runner overlay directory before image activation
+  ansible.builtin.find:
+    paths: /mnt/ssd1000-01/ci-runner
+    file_type: any
+    hidden: true
+    recurse: false
+  register: runner_overlay_entries
+
+- name: Require no runner overlays before image activation
+  ansible.builtin.assert:
+    that:
+      - runner_overlay_entries.matched == 0
+    fail_msg: Refusing to switch the base image while a runner overlay or seed remains.
+
+- name: Install digest-versioned immutable base image
   ansible.builtin.get_url:
     url: "{{ runner_base_image_source }}"
-    dest: /var/lib/ci-runner/images/ubuntu-24.04-runner.qcow2
+    dest: "/var/lib/ci-runner/images/ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2"
     checksum: "sha256:{{ runner_base_image_sha256 }}"
     owner: root
     group: root
     mode: '0444'
+
+- name: Atomically activate image and retain the previous target
+  ansible.builtin.shell: |
+    set -euo pipefail
+    image_root=/var/lib/ci-runner/images
+    current="$image_root/ubuntu-24.04-runner.qcow2"
+    previous="$image_root/ubuntu-24.04-runner.previous.qcow2"
+    target="$image_root/ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2"
+    old=""
+    if [ -L "$current" ]; then
+      old="$(readlink -f "$current")"
+      if [[ ! "$old" =~ ^$image_root/ubuntu-24\.04-runner-[a-f0-9]{64}\.qcow2$ ]]; then
+        echo "refusing unexpected current image target" >&2
+        exit 1
+      fi
+    elif [ -e "$current" ]; then
+      echo "refusing to replace a non-symlink current image" >&2
+      exit 1
+    fi
+    if [ "$old" = "$target" ]; then
+      exit 0
+    fi
+    if [ -n "$old" ]; then
+      ln -sfn "$old" "$previous.new"
+      mv -Tf "$previous.new" "$previous"
+    fi
+    ln -sfn "$target" "$current.new"
+    mv -Tf "$current.new" "$current"
+    echo changed
+  args:
+    executable: /bin/bash
+  register: runner_image_activation
+  changed_when: "'changed' in runner_image_activation.stdout_lines"
+  notify: Restart runner manager
 
 - name: Install manager platform files
   ansible.builtin.copy:

--- a/infra/packer/sanctuary-runner.pkr.hcl
+++ b/infra/packer/sanctuary-runner.pkr.hcl
@@ -1,7 +1,9 @@
 packer {
+  required_version = "= 1.15.4"
+
   required_plugins {
     qemu = {
-      version = "~> 1.1"
+      version = "= 1.1.6"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/infra/packer/toolchain.lock
+++ b/infra/packer/toolchain.lock
@@ -1,0 +1,14 @@
+# Reviewed HashiCorp release artifacts used by this image build.
+# Verify the downloaded zip with sha256sum before extraction.
+
+packer_version=1.15.4
+packer_linux_amd64_url=https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_linux_amd64.zip
+packer_linux_amd64_sha256=15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1
+packer_darwin_arm64_url=https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_darwin_arm64.zip
+packer_darwin_arm64_sha256=d95ba177dd2ebb84d7d155493b4188ec2a519d2c3b041528db5b63a6aff9da80
+
+qemu_plugin_version=1.1.6
+qemu_plugin_linux_amd64_url=https://releases.hashicorp.com/packer-plugin-qemu/1.1.6/packer-plugin-qemu_1.1.6_linux_amd64.zip
+qemu_plugin_linux_amd64_sha256=3f735539fbdd0368785babda272b85738866f736415dce59d04b4cb550c4db87
+qemu_plugin_darwin_arm64_url=https://releases.hashicorp.com/packer-plugin-qemu/1.1.6/packer-plugin-qemu_1.1.6_darwin_arm64.zip
+qemu_plugin_darwin_arm64_sha256=3fce2e8b5c3fce0aac5f47f59b81b7ecfffd397532ecd4021ba7b6dfd2935ba6

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -18,12 +18,16 @@ import tempfile
 LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 PREFIX = "sanctuary-ci-"
 OVERLAY_ROOT = Path("/mnt/ssd1000-01/ci-runner")
-BASE_IMAGE = Path("/var/lib/ci-runner/images/ubuntu-24.04-runner.qcow2")
+IMAGE_ROOT = Path("/var/lib/ci-runner/images")
+BASE_IMAGE = IMAGE_ROOT / "ubuntu-24.04-runner.qcow2"
+IMAGE_RE = re.compile(r"^ubuntu-24\.04-runner-[a-f0-9]{64}\.qcow2$")
 NETWORK = "sanctuary-ci"
 VCPUS = "8"
 MEMORY_MIB = "12288"
 DISK_GIB = "120G"
+MAX_LEASE_SECONDS = "7200"
 HELPER_LOCK = Path("/run/lock/ci-runner-host-helper.lock")
+HELPER_PATH = "/usr/local/libexec/ci-runner-host-helper"
 
 
 def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -48,11 +52,17 @@ def lease_dir(lease: str) -> Path:
     return directory
 
 
+def resolved_base_image() -> Path:
+    image = BASE_IMAGE.resolve(strict=True)
+    if image.parent != IMAGE_ROOT or not IMAGE_RE.fullmatch(image.name) or not image.is_file():
+        raise ValueError("base image link does not target a digest-versioned runner image")
+    return image
+
+
 def launch(lease: str) -> None:
     if os.geteuid() != 0:
         raise PermissionError("helper must run as root")
-    if not BASE_IMAGE.is_file():
-        raise FileNotFoundError(f"base image missing: {BASE_IMAGE}")
+    base_image = resolved_base_image()
     existing = run(["virsh", "list", "--all", "--name"])
     if any(line.startswith(PREFIX) for line in existing.stdout.splitlines()):
         raise RuntimeError("a sanctuary CI domain already exists")
@@ -67,7 +77,7 @@ def launch(lease: str) -> None:
     overlay = directory / "root.qcow2"
     seed = directory / "seed.iso"
     try:
-        run(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", str(BASE_IMAGE), str(overlay), DISK_GIB])
+        run(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", str(base_image), str(overlay), DISK_GIB])
         user_data = """#cloud-config
 bootcmd:
   - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
@@ -93,6 +103,9 @@ runcmd:
              "--disk", f"path={seed},device=cdrom,readonly=on",
              "--network", f"network={NETWORK},model=virtio", "--graphics", "none",
              "--rng", "/dev/urandom", "--controller", "type=scsi,model=virtio-scsi"])
+        run(["systemd-run", "--unit", f"{PREFIX}expire-{lease}",
+             "--on-active", f"{MAX_LEASE_SECONDS}s", "--timer-property", "AccuracySec=30s",
+             HELPER_PATH, "destroy", lease])
     except Exception:
         destroy(lease)
         raise
@@ -100,6 +113,7 @@ runcmd:
 
 def destroy(lease: str) -> None:
     domain = name(lease)
+    run(["systemctl", "stop", f"{PREFIX}expire-{lease}.timer"], check=False)
     run(["virsh", "destroy", domain], check=False)
     run(["virsh", "undefine", domain, "--nvram"], check=False)
     directory = lease_dir(lease)

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import fcntl
+import hashlib
 import json
 import logging
 import os
@@ -23,6 +24,7 @@ import urllib.request
 
 LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 LOG = logging.getLogger("ci-runner-manager")
+REGISTRATION_GRACE_SECONDS = 300
 
 
 class RunnerError(RuntimeError):
@@ -33,6 +35,10 @@ class RateLimited(RunnerError):
     def __init__(self, retry_after: int) -> None:
         super().__init__("GitHub API rate limit reached")
         self.retry_after = max(5, min(retry_after, 3600))
+
+
+class NotFound(RunnerError):
+    pass
 
 
 def load_config(path: Path) -> dict[str, Any]:
@@ -100,6 +106,15 @@ class StateStore:
                 LOG.error("invalid state file %s: %s", path.name, exc)
         return result
 
+    def cleanup_items(self) -> list[dict[str, Any]]:
+        result = []
+        for path in sorted(self.directory.glob("cleanup-*.json")):
+            try:
+                result.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as exc:
+                LOG.error("invalid cleanup state file %s: %s", path.name, exc)
+        return result
+
     def write(self, lease: str, state: dict[str, Any]) -> None:
         destination = self.directory / f"lease-{lease}.json"
         temporary = destination.with_suffix(".tmp")
@@ -109,6 +124,46 @@ class StateStore:
 
     def remove(self, lease: str) -> None:
         (self.directory / f"lease-{lease}.json").unlink(missing_ok=True)
+
+    @staticmethod
+    def cleanup_key(state: dict[str, Any]) -> str:
+        repo = state.get("repo")
+        runner_id = state.get("runner_id")
+        if not isinstance(repo, str) or not isinstance(runner_id, int):
+            raise RunnerError("cleanup obligation requires a GitHub runner identity")
+        return hashlib.sha256(f"{repo}:{runner_id}".encode("utf-8")).hexdigest()
+
+    def cleanup_path(self, state: dict[str, Any]) -> Path:
+        return self.directory / f"cleanup-{self.cleanup_key(state)}.json"
+
+    def write_cleanup_obligation(self, lease: str, state: dict[str, Any], now: int) -> None:
+        pending = dict(state)
+        pending.update({"lease": lease, "phase": "registration_pending",
+                        "created_at": now, "cleanup_attempts": 0,
+                        "next_retry_at": now + REGISTRATION_GRACE_SECONDS})
+        destination = self.cleanup_path(pending)
+        temporary = destination.with_suffix(".tmp")
+        temporary.write_text(json.dumps(pending, sort_keys=True) + "\n", encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+
+    def defer_cleanup(self, lease: str, state: dict[str, Any], now: int) -> None:
+        attempts = int(state.get("cleanup_attempts", 0)) + 1
+        pending = dict(state)
+        pending.update({
+            "phase": "cleanup_pending",
+            "cleanup_attempts": attempts,
+            "next_retry_at": now + min(30 * (2 ** min(attempts - 1, 7)), 3600),
+        })
+        destination = self.cleanup_path(pending)
+        temporary = destination.with_suffix(".tmp")
+        temporary.write_text(json.dumps(pending, sort_keys=True) + "\n", encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+        self.remove(lease)
+
+    def remove_cleanup(self, state: dict[str, Any]) -> None:
+        self.cleanup_path(state).unlink(missing_ok=True)
 
 
 class DispatchHistory:
@@ -154,6 +209,8 @@ class GitHubClient:
                 raw = response.read()
                 return json.loads(raw) if raw else None
         except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise NotFound("GitHub resource was already removed") from exc
             remaining = exc.headers.get("X-RateLimit-Remaining")
             if exc.code == 429 or (exc.code == 403 and (exc.headers.get("Retry-After") or remaining == "0")):
                 retry = exc.headers.get("Retry-After")
@@ -188,7 +245,10 @@ class GitHubClient:
         })
 
     def delete_runner(self, repo: str, runner_id: int) -> None:
-        self.request("DELETE", f"{self.repo_path(repo)}/actions/runners/{runner_id}")
+        try:
+            self.request("DELETE", f"{self.repo_path(repo)}/actions/runners/{runner_id}")
+        except NotFound:
+            return
 
 
 def validate_repositories(cfg: dict[str, Any]) -> list[str]:
@@ -222,7 +282,7 @@ def with_lock(path: Path):
     return handle
 
 
-def launch(cfg: dict[str, Any], lease: str, jit_path: Path) -> None:
+def launch(cfg: dict[str, Any], lease: str, jit_path: Path, *, metadata: dict[str, Any] | None = None) -> None:
     lease = validate_lease_id(lease)
     jit = read_jit_config(jit_path)
     store = StateStore(Path(cfg["state_dir"]))
@@ -237,23 +297,73 @@ def launch(cfg: dict[str, Any], lease: str, jit_path: Path) -> None:
         failures = capacity_errors(cfg)
         if failures:
             raise RunnerError("; ".join(failures))
+        state = {"lease": lease, "phase": "provisioning", "launched_at": int(time.time())}
+        if metadata:
+            state.update(metadata)
+        store.write(lease, state)
         LOG.info("launch requested lease=%s", lease)
-        helper(cfg, "launch", lease, stdin=jit)
-        store.write(lease, {"lease": lease, "launched_at": int(time.time())})
+        try:
+            helper(cfg, "launch", lease, stdin=jit)
+        except Exception:
+            store.remove(lease)
+            raise
+        state["phase"] = "running"
+        store.write(lease, state)
         LOG.info("launch completed lease=%s", lease)
 
 
-def destroy(cfg: dict[str, Any], lease: str) -> None:
+def cleanup_github_runner(client: GitHubClient | None, state: dict[str, Any]) -> None:
+    repo = state.get("repo")
+    runner_id = state.get("runner_id")
+    if repo is None and runner_id is None:
+        return
+    if client is None:
+        raise RunnerError("GitHub client is required to clean a registered runner")
+    if not isinstance(repo, str) or not isinstance(runner_id, int):
+        raise RunnerError("lease contains invalid GitHub runner identity")
+    client.delete_runner(repo, runner_id)
+
+
+def destroy(cfg: dict[str, Any], lease: str, client: GitHubClient | None = None) -> None:
     lease = validate_lease_id(lease)
     store = StateStore(Path(cfg["state_dir"]))
     with with_lock(Path(cfg["lock_file"])):
         LOG.info("destroy requested lease=%s", lease)
+        state = next((item for item in store.leases() if item.get("lease") == lease), {"lease": lease})
         helper(cfg, "destroy", lease)
-        store.remove(lease)
+        try:
+            cleanup_github_runner(client, state)
+        except RunnerError:
+            store.defer_cleanup(lease, state, int(time.time()))
+            raise
+        else:
+            store.remove(lease)
         LOG.info("destroy completed lease=%s", lease)
 
 
-def reconcile(cfg: dict[str, Any]) -> None:
+def retry_pending_cleanup(store: StateStore, client: GitHubClient | None, now: int,
+                          active_states: list[dict[str, Any]] | None = None) -> None:
+    active_keys = {store.cleanup_key(state) for state in (active_states or [])
+                   if isinstance(state.get("repo"), str) and isinstance(state.get("runner_id"), int)}
+    for state in store.cleanup_items():
+        lease = validate_lease_id(str(state.get("lease", "")))
+        if state.get("phase") == "registration_pending" and store.cleanup_key(state) in active_keys:
+            store.remove_cleanup(state)
+            LOG.info("GitHub cleanup obligation transferred to active lease=%s", lease)
+            continue
+        if int(state.get("next_retry_at", 0)) > now:
+            continue
+        try:
+            cleanup_github_runner(client, state)
+        except RunnerError as exc:
+            LOG.warning("GitHub runner cleanup deferred lease=%s error=%s", lease, exc)
+            store.defer_cleanup(lease, state, now)
+        else:
+            store.remove_cleanup(state)
+            LOG.info("GitHub runner cleanup completed lease=%s", lease)
+
+
+def reconcile(cfg: dict[str, Any], client: GitHubClient | None = None) -> None:
     store = StateStore(Path(cfg["state_dir"]))
     with with_lock(Path(cfg["lock_file"])):
         result = helper(cfg, "list", check=True)
@@ -269,10 +379,17 @@ def reconcile(cfg: dict[str, Any]) -> None:
         for lease in sorted(known - running):
             LOG.warning("cleaning completed or missing domain lease=%s", lease)
             helper(cfg, "destroy", lease)
-            store.remove(lease)
+            try:
+                cleanup_github_runner(client, states[lease])
+            except RunnerError as exc:
+                LOG.warning("GitHub runner cleanup deferred lease=%s error=%s", lease, exc)
+                store.defer_cleanup(lease, states[lease], now)
+            else:
+                store.remove(lease)
         for lease in sorted(set(domains) - known):
             LOG.warning("destroying orphan domain lease=%s", lease)
             helper(cfg, "destroy", lease)
+        retry_pending_cleanup(store, client, now, store.leases())
 
 
 def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
@@ -290,27 +407,56 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
             response = client.generate_jit(repo, job["job_id"], int(cfg.get("runner_group_id", 1)), label)
             encoded = response.get("encoded_jit_config")
             runner_id = response.get("runner", {}).get("id")
+            lease = f"gh-{job['job_id']}"
+            registration = {
+                "lease": lease,
+                "repo": repo,
+                "runner_id": runner_id,
+                "run_id": job["run_id"],
+                "job_id": job["job_id"],
+            }
+            if isinstance(runner_id, int):
+                store.write_cleanup_obligation(lease, registration, int(time.time()))
             if not isinstance(encoded, str) or not isinstance(runner_id, int):
                 if isinstance(runner_id, int):
                     try:
                         client.delete_runner(repo, runner_id)
-                    except RunnerError:
-                        LOG.error("failed to remove malformed GitHub runner repo=%s runner_id=%s", repo, runner_id)
+                    except RunnerError as exc:
+                        LOG.error("deferring malformed GitHub runner cleanup repo=%s runner_id=%s error=%s",
+                                  repo, runner_id, exc)
+                        store.defer_cleanup(lease, registration, int(time.time()))
+                    else:
+                        store.remove_cleanup(registration)
                 raise RunnerError("GitHub returned an invalid JIT response")
-            lease = f"gh-{job['job_id']}"
             jit_path = Path(cfg.get("runtime_dir", "/run/ci-runner-manager")) / f"{lease}.jit"
             try:
                 jit_path.write_text(encoded, encoding="utf-8")
                 os.chmod(jit_path, 0o600)
-                launch(cfg, lease, jit_path)
+                launch(cfg, lease, jit_path, metadata={
+                    "repo": repo,
+                    "runner_id": runner_id,
+                    "run_id": job["run_id"],
+                    "job_id": job["job_id"],
+                })
+                store.remove_cleanup(registration)
                 history.add(key, now)
                 LOG.info("dispatched repo=%s run_id=%s job_id=%s", repo, job["run_id"], job["job_id"])
                 return True
             except Exception:
                 try:
                     client.delete_runner(repo, runner_id)
-                except RunnerError:
-                    LOG.error("failed to remove unused GitHub runner repo=%s runner_id=%s", repo, runner_id)
+                except RunnerError as exc:
+                    LOG.error("deferring unused GitHub runner cleanup repo=%s runner_id=%s error=%s",
+                              repo, runner_id, exc)
+                    store.defer_cleanup(lease, {
+                        "lease": lease,
+                        "repo": repo,
+                        "runner_id": runner_id,
+                        "run_id": job["run_id"],
+                        "job_id": job["job_id"],
+                    }, int(time.time()))
+                else:
+                    store.remove_cleanup(registration)
                 raise
             finally:
                 jit_path.unlink(missing_ok=True)
@@ -342,16 +488,18 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "launch":
             launch(cfg, args.lease, args.jit_config_file)
         elif args.command == "destroy":
-            destroy(cfg, args.lease)
+            client = GitHubClient(read_token(Path(cfg["github_token_file"])), str(cfg.get("github_api_url", "https://api.github.com")))
+            destroy(cfg, args.lease, client)
         elif args.command == "reconcile":
-            reconcile(cfg)
+            client = GitHubClient(read_token(Path(cfg["github_token_file"])), str(cfg.get("github_api_url", "https://api.github.com")))
+            reconcile(cfg, client)
         else:
             if args.interval < 5:
                 raise RunnerError("daemon interval must be at least 5 seconds")
             client = GitHubClient(read_token(Path(cfg["github_token_file"])), str(cfg.get("github_api_url", "https://api.github.com")))
             while True:
                 try:
-                    reconcile(cfg)
+                    reconcile(cfg, client)
                     dispatch_once(cfg, client)
                 except RateLimited as exc:
                     LOG.warning("GitHub rate limited; retrying later")

--- a/runner/systemd/ci-runner-job.service
+++ b/runner/systemd/ci-runner-job.service
@@ -14,6 +14,7 @@ ExecStartPre=/usr/bin/test -s /run/ci-runner/jit.config
 ExecStart=/usr/local/bin/run-jit-runner
 ExecStopPost=-/usr/bin/rm -f /run/ci-runner/jit.config
 ExecStopPost=+/usr/bin/systemctl poweroff
+RuntimeMaxSec=7200
 Restart=no
 NoNewPrivileges=yes
 PrivateTmp=yes

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+import tempfile
 import unittest
 from unittest import mock
 
@@ -14,13 +16,42 @@ class HostHelperTests(unittest.TestCase):
                 helper.lease_dir(value)
 
     @mock.patch.object(helper, "run")
-    @mock.patch.object(helper, "BASE_IMAGE")
+    @mock.patch.object(helper, "resolved_base_image")
     @mock.patch.object(helper.os, "geteuid", return_value=0)
     def test_launch_rejects_existing_domain_before_reading_secret(self, _euid, image, run):
-        image.is_file.return_value = True
+        image.return_value = mock.Mock()
         run.return_value = mock.Mock(stdout="sanctuary-ci-existing\n")
         with self.assertRaisesRegex(RuntimeError, "domain already exists"):
             helper.launch("new")
+
+    @mock.patch.object(helper.Path, "is_file", return_value=True)
+    @mock.patch.object(helper.Path, "resolve")
+    def test_base_image_must_resolve_to_digest_versioned_file(self, resolve, _is_file):
+        resolve.return_value = helper.IMAGE_ROOT / ("ubuntu-24.04-runner-" + "a" * 64 + ".qcow2")
+        self.assertEqual(helper.resolved_base_image(), resolve.return_value)
+
+        resolve.return_value = helper.IMAGE_ROOT / "ubuntu-24.04-runner.qcow2"
+        with self.assertRaisesRegex(ValueError, "digest-versioned"):
+            helper.resolved_base_image()
+
+    @mock.patch.object(helper.os, "geteuid", return_value=0)
+    @mock.patch.object(helper, "resolved_base_image")
+    @mock.patch.object(helper, "run")
+    def test_launch_schedules_independent_host_expiry_timer(self, run, image, _euid):
+        with tempfile.TemporaryDirectory() as directory:
+            stdin = mock.Mock()
+            stdin.buffer.read.return_value = b"aml0"
+            image.return_value = helper.IMAGE_ROOT / ("ubuntu-24.04-runner-" + "a" * 64 + ".qcow2")
+            run.return_value = mock.Mock(stdout="")
+            with mock.patch.object(helper, "lease_dir", return_value=Path(directory) / "lease"), \
+                    mock.patch.object(helper.sys, "stdin", stdin):
+                helper.launch("lease")
+
+        self.assertIn(mock.call([
+            "systemd-run", "--unit", "sanctuary-ci-expire-lease",
+            "--on-active", "7200s", "--timer-property", "AccuracySec=30s",
+            "/usr/local/libexec/ci-runner-host-helper", "destroy", "lease",
+        ]), run.call_args_list)
 
 
 if __name__ == "__main__":

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -105,6 +105,11 @@ class ManagerTests(unittest.TestCase):
         self.assertNotIn("top-secret-token", str(raised.exception))
         self.assertNotIn("body may be sensitive", str(raised.exception))
 
+    def test_delete_runner_treats_not_found_as_already_clean(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=manager.NotFound("gone"))
+        client.delete_runner("Tuinstra-DEV/gate", 30)
+
     def test_dispatch_history_deduplicates_job(self):
         with tempfile.TemporaryDirectory() as directory:
             history = manager.DispatchHistory(Path(directory))
@@ -126,6 +131,89 @@ class ManagerTests(unittest.TestCase):
                 manager.dispatch_once(cfg, client)
             client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
             self.assertEqual(list((root / "run").iterdir()), [])
+
+    @mock.patch.object(manager, "launch")
+    def test_dispatch_persists_github_runner_identity_with_lease(self, launch):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            client.generate_jit.return_value = {
+                "encoded_jit_config": base64.b64encode(b"jit").decode(),
+                "runner": {"id": 30},
+            }
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+            (root / "run").mkdir()
+
+            self.assertTrue(manager.dispatch_once(cfg, client))
+
+            launch.assert_called_once_with(
+                cfg,
+                "gh-20",
+                mock.ANY,
+                metadata={"repo": "Tuinstra-DEV/gate", "runner_id": 30, "run_id": 10, "job_id": 20},
+            )
+
+    @mock.patch.object(manager, "launch", side_effect=manager.RunnerError("launch failed"))
+    def test_dispatch_defers_runner_cleanup_when_launch_and_delete_fail(self, _launch):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            client.generate_jit.return_value = {
+                "encoded_jit_config": base64.b64encode(b"jit").decode(),
+                "runner": {"id": 30},
+            }
+            client.delete_runner.side_effect = manager.RunnerError("cleanup unavailable")
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+            (root / "run").mkdir()
+
+            with self.assertRaisesRegex(manager.RunnerError, "launch failed"):
+                manager.dispatch_once(cfg, client)
+
+            cleanup = manager.StateStore(root / "state").cleanup_items()
+            self.assertEqual(cleanup[0]["repo"], "Tuinstra-DEV/gate")
+            self.assertEqual(cleanup[0]["runner_id"], 30)
+
+    @mock.patch.object(manager, "launch", side_effect=manager.RunnerError("launch failed"))
+    def test_repeated_failed_job_registrations_keep_distinct_cleanup_obligations(self, _launch):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            client.generate_jit.side_effect = [
+                {"encoded_jit_config": base64.b64encode(b"jit").decode(), "runner": {"id": 30}},
+                {"encoded_jit_config": base64.b64encode(b"jit").decode(), "runner": {"id": 31}},
+            ]
+            client.delete_runner.side_effect = manager.RunnerError("cleanup unavailable")
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+            (root / "run").mkdir()
+
+            for _ in range(2):
+                with self.assertRaisesRegex(manager.RunnerError, "launch failed"):
+                    manager.dispatch_once(cfg, client)
+
+            cleanup = manager.StateStore(root / "state").cleanup_items()
+            self.assertEqual({item["runner_id"] for item in cleanup}, {30, 31})
+
+    def test_malformed_jit_cleanup_failure_is_durable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
+            client.generate_jit.return_value = {"encoded_jit_config": None, "runner": {"id": 30}}
+            client.delete_runner.side_effect = manager.RunnerError("cleanup unavailable")
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
+
+            with self.assertRaisesRegex(manager.RunnerError, "invalid JIT"):
+                manager.dispatch_once(cfg, client)
+
+            cleanup = manager.StateStore(root / "state").cleanup_items()
+            self.assertEqual(cleanup[0]["runner_id"], 30)
 
     @mock.patch.object(manager.time, "time", return_value=1001)
     def test_dispatch_skips_job_in_history(self, _time):
@@ -150,6 +238,84 @@ class ManagerTests(unittest.TestCase):
             helper.side_effect = [mock.Mock(stdout=b'{"expired":"running"}'), mock.Mock()]
             manager.reconcile(cfg)
             self.assertIn(("destroy", "expired"), [call.args[1:] for call in helper.call_args_list])
+
+    @mock.patch.object(manager, "helper")
+    def test_reconcile_deletes_persisted_github_runner_before_state(self, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock", "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("finished", {
+                "lease": "finished", "launched_at": 1,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+            })
+            helper.side_effect = [mock.Mock(stdout=b'{"finished":"shut off"}'), mock.Mock()]
+            client = mock.Mock()
+
+            manager.reconcile(cfg, client)
+
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            self.assertEqual(store.leases(), [])
+
+    @mock.patch.object(manager, "helper")
+    def test_reconcile_moves_failed_github_cleanup_to_tombstone(self, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock", "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("finished", {
+                "lease": "finished", "launched_at": 1,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+            })
+            helper.side_effect = [mock.Mock(stdout=b'{"finished":"shut off"}'), mock.Mock()]
+            client = mock.Mock()
+            client.delete_runner.side_effect = manager.RunnerError("cleanup unavailable")
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual(store.leases(), [])
+            self.assertEqual(store.cleanup_items()[0]["runner_id"], 30)
+            self.assertGreater(store.cleanup_items()[0]["next_retry_at"], 0)
+
+    def test_due_cleanup_tombstone_is_retried_and_removed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = manager.StateStore(Path(directory))
+            store.defer_cleanup("finished", {
+                "lease": "finished", "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+            }, 1)
+            client = mock.Mock()
+
+            manager.retry_pending_cleanup(store, client, 100)
+
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            self.assertEqual(store.cleanup_items(), [])
+
+    def test_registration_obligation_transfers_to_matching_active_lease(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = manager.StateStore(Path(directory))
+            state = {"lease": "running", "repo": "Tuinstra-DEV/gate", "runner_id": 30}
+            store.write_cleanup_obligation("running", state, 100)
+            client = mock.Mock()
+
+            manager.retry_pending_cleanup(store, client, 100, [state])
+
+            client.delete_runner.assert_not_called()
+            self.assertEqual(store.cleanup_items(), [])
+
+    def test_registration_obligation_waits_for_launch_grace_then_cleans(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = manager.StateStore(Path(directory))
+            state = {"lease": "pending", "repo": "Tuinstra-DEV/gate", "runner_id": 30}
+            store.write_cleanup_obligation("pending", state, 100)
+            client = mock.Mock()
+
+            manager.retry_pending_cleanup(store, client, 399)
+            client.delete_runner.assert_not_called()
+            self.assertEqual(len(store.cleanup_items()), 1)
+
+            manager.retry_pending_cleanup(store, client, 400)
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            self.assertEqual(store.cleanup_items(), [])
 
 
 if __name__ == "__main__":

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -24,6 +24,13 @@ grep -q 'VCPUS = "8"' runner/host-helper/ci_runner_host_helper.py
 grep -q 'DISK_GIB = "120G"' runner/host-helper/ci_runner_host_helper.py
 grep -q 'concurrency is 1' runner/manager/ci_runner_manager.py
 grep -q 'max_lease_seconds = 7200' runner/config/manager.toml
+grep -q '^RuntimeMaxSec=7200$' runner/systemd/ci-runner-job.service
+grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
+grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
+grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
+grep -q 'packer_linux_amd64_sha256=15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1' infra/packer/toolchain.lock
+grep -q 'qemu_plugin_linux_amd64_sha256=3f735539fbdd0368785babda272b85738866f736415dce59d04b4cb550c4db87' infra/packer/toolchain.lock
 grep -q 'Tuinstra-DEV/tuinstra-site' runner/config/manager.toml
 ! grep -q 'Tuinstra-DEV/devops' runner/config/manager.toml
 grep -q '88.159.77.149/32' infra/ansible/inventory/hosts.example.yml


### PR DESCRIPTION
## Summary
- make base-image activation drained, digest-versioned, atomic, and rollbackable
- persist GitHub runner cleanup obligations before launch and retry failed cleanup safely
- enforce independent guest and host runtime ceilings
- pin Packer/QEMU toolchain versions and reviewed release checksums

## Verification
- make lint
- make test (29 tests)
- Ansible 2.19 syntax check
- Packer 1.15.4 fmt and validate
- git diff --check

## Activation boundary
The repository variables remain on hosted. Live Sanctuary provisioning and canaries are intentionally performed only after this PR is merged and the least-privilege credential is installed outside source control.

Tracker: DEV-1