### PR TITLE
fix(runner): update PHP signing key fingerprint

### DIFF
--- a/infra/packer/scripts/install-runner.sh
+++ b/infra/packer/scripts/install-runner.sh
@@ -39,7 +39,7 @@ sudo install -d -m 0755 /etc/apt/keyrings
 install_key https://download.docker.com/linux/ubuntu/gpg "$DOCKER_KEY_SHA256" /etc/apt/keyrings/docker.gpg
 install_key https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key "$NODE_KEY_SHA256" /etc/apt/keyrings/nodesource.gpg
 install_key https://aquasecurity.github.io/trivy-repo/deb/public.key "$TRIVY_KEY_SHA256" /etc/apt/keyrings/trivy.gpg
-install_key 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14AA40EC0831756F' "$PHP_KEY_SHA256" /etc/apt/keyrings/ondrej-php.gpg
+install_key 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' "$PHP_KEY_SHA256" /etc/apt/keyrings/ondrej-php.gpg
 
 sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null <<'EOF'
 Types: deb

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -39,6 +39,7 @@ grep -q 'docker buildx version' infra/packer/scripts/verify-image-contract.sh
 grep -q "node --version.*v24" infra/packer/scripts/verify-image-contract.sh
 grep -q 'php8.3' infra/packer/scripts/verify-image-contract.sh
 grep -q 'php8.4' infra/packer/scripts/verify-image-contract.sh
+grep -q '0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' infra/packer/scripts/install-runner.sh
 grep -q 'playwright install --with-deps chromium' infra/packer/scripts/install-runner.sh
 grep -q 'exec ./run.sh --jitconfig' runner/guest/run-jit-runner.sh
 grep -q 'ExecStopPost=+/usr/bin/systemctl poweroff' runner/systemd/ci-runner-job.service


### PR DESCRIPTION
## Summary
- replace the obsolete Ondrej PHP PPA key lookup with the current full Launchpad fingerprint
- add a regression contract test for the exact fingerprint

## Verification
- official key endpoint returns SHA-256 7258b1cb18300b87cd5668a6d64ce78184d9c0e129382879a0d79291c4ef463d
- make lint
- make test (29 tests)
- git diff --check

Tracker: DEV-1