### PR TITLE
fix(runner): provision image through sudo

### DIFF
--- a/infra/packer/sanctuary-runner.pkr.hcl
+++ b/infra/packer/sanctuary-runner.pkr.hcl
@@ -137,6 +137,7 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; echo 'packer' | sudo -S env {{ .Vars }} bash '{{ .Path }}'"
     environment_vars = [
       "RUNNER_VERSION=${var.runner_version}",
       "RUNNER_SHA256=${var.runner_sha256}",
@@ -161,11 +162,13 @@ build {
   }
 
   provisioner "shell" {
-    inline = ["sudo bash /tmp/verify-image-contract.sh"]
+    execute_command = "chmod +x {{ .Path }}; echo 'packer' | sudo -S env {{ .Vars }} bash '{{ .Path }}'"
+    inline          = ["bash /tmp/verify-image-contract.sh"]
   }
 
   provisioner "shell" {
-    script = "scripts/seal-image.sh"
+    execute_command = "chmod +x {{ .Path }}; echo 'packer' | sudo -S env {{ .Vars }} bash '{{ .Path }}'"
+    script          = "scripts/seal-image.sh"
   }
 
   post-processor "checksum" {

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -29,6 +29,7 @@ grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
+test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3
 grep -q 'packer_linux_amd64_sha256=15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1' infra/packer/toolchain.lock
 grep -q 'qemu_plugin_linux_amd64_sha256=3f735539fbdd0368785babda272b85738866f736415dce59d04b4cb550c4db87' infra/packer/toolchain.lock
 grep -q 'Tuinstra-DEV/tuinstra-site' runner/config/manager.toml


### PR DESCRIPTION
## Summary
- execute all Packer shell provisioners through authenticated sudo
- inject pinned build variables after privilege elevation
- avoid leaving passwordless sudo configuration in the sealed image
- add a regression contract for all three provisioners

## Reproduction
The live Sanctuary build completed Ubuntu autoinstall and SSH, then failed at the first sudo call because no TTY was available.

## Verification
- Packer 1.15.4 fmt check
- make lint
- make test (29 tests)
- git diff --check

Tracker: DEV-1