### PR TITLE
fix(runner): seal account during shutdown

### DIFF
--- a/infra/packer/sanctuary-runner.pkr.hcl
+++ b/infra/packer/sanctuary-runner.pkr.hcl
@@ -107,7 +107,7 @@ source "qemu" "ubuntu_runner" {
   ssh_username     = "packer"
   ssh_password     = "packer"
   ssh_timeout      = "30m"
-  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  shutdown_command = "echo 'packer' | sudo -S sh -c 'passwd --lock packer && systemctl poweroff'"
   http_directory   = "http"
   boot_wait        = "5s"
   boot_command = [

--- a/infra/packer/scripts/seal-image.sh
+++ b/infra/packer/scripts/seal-image.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 sudo systemctl disable ssh.service ssh.socket || true
-sudo passwd --lock packer
 sudo rm -f /etc/ssh/ssh_host_* /root/.ssh/authorized_keys /home/packer/.ssh/authorized_keys
 sudo cloud-init clean --logs --machine-id --seed
 sudo truncate -s 0 /etc/machine-id

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -30,6 +30,8 @@ grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
 test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3
+grep -q "shutdown_command.*passwd --lock packer.*systemctl poweroff" infra/packer/sanctuary-runner.pkr.hcl
+! grep -q 'passwd --lock packer' infra/packer/scripts/seal-image.sh
 grep -q 'packer_linux_amd64_sha256=15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1' infra/packer/toolchain.lock
 grep -q 'qemu_plugin_linux_amd64_sha256=3f735539fbdd0368785babda272b85738866f736415dce59d04b4cb550c4db87' infra/packer/toolchain.lock
 grep -q 'Tuinstra-DEV/tuinstra-site' runner/config/manager.toml


### PR DESCRIPTION
## Summary
- reproduce and fix the image shutdown failure after the build account was locked
- authenticate sudo first, then lock the temporary packer account and power off in one root shell
- keep the sealed qcow2 free of a usable build password
- add regression contract coverage

## Verification
- live build passed the complete immutable image contract before reproducing the shutdown failure
- Packer 1.15.4 fmt check
- make lint
- make test (29 tests)
- git diff --check

Tracker: DEV-1