### PR TITLE
fix(runner): provision libexec directory

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -56,6 +56,7 @@
     mode: "{{ item.mode }}"
   loop:
     - { path: /etc/ci-runner, owner: root, group: ci-runner-manager, mode: '0750' }
+    - { path: /usr/local/libexec, owner: root, group: root, mode: '0755' }
     - { path: /var/lib/ci-runner/images, owner: root, group: root, mode: '0755' }
     - { path: /var/lib/ci-runner-manager/state, owner: ci-runner-manager, group: ci-runner-manager, mode: '0700' }
     - { path: /mnt/ssd1000-01/ci-runner, owner: root, group: root, mode: '0700' }

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -27,6 +27,7 @@ grep -q 'max_lease_seconds = 7200' runner/config/manager.toml
 grep -q '^RuntimeMaxSec=7200$' runner/systemd/ci-runner-job.service
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
 test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3


### PR DESCRIPTION
## Summary

- create `/usr/local/libexec` before installing the privileged host helper
- add a regression assertion for owner, group, and mode

## Verification

- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
