### PR TITLE
fix(runner): grant manager config access

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -163,12 +163,12 @@
     src: "{{ runner_manager_source_root }}/{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: root
-    group: root
+    group: "{{ item.group | default('root') }}"
     mode: "{{ item.mode }}"
   loop:
     - { src: runner/manager/ci_runner_manager.py, dest: /usr/local/bin/ci-runner-manager, mode: '0755' }
     - { src: runner/host-helper/ci_runner_host_helper.py, dest: /usr/local/libexec/ci-runner-host-helper, mode: '0755' }
-    - { src: runner/config/manager.toml, dest: /etc/ci-runner/manager.toml, mode: '0640' }
+    - { src: runner/config/manager.toml, dest: /etc/ci-runner/manager.toml, group: ci-runner-manager, mode: '0640' }
     - { src: runner/systemd/ci-runner-manager.service, dest: /etc/systemd/system/ci-runner-manager.service, mode: '0644' }
     - { src: runner/systemd/sanctuary-ci-firewall.service, dest: /etc/systemd/system/sanctuary-ci-firewall.service, mode: '0644' }
     - { src: runner/logrotate/ci-runner-audit, dest: /etc/logrotate.d/ci-runner-audit, mode: '0644' }

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -28,6 +28,7 @@ grep -q '^RuntimeMaxSec=7200$' runner/systemd/ci-runner-job.service
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml
+grep -q "src: runner/config/manager.toml.*group: ci-runner-manager.*mode: '0640'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
 test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3


### PR DESCRIPTION
## Summary

- install `manager.toml` as `root:ci-runner-manager` with mode `0640`
- retain `root:root` as the default ownership for all other platform files
- add a regression assertion for the least-privilege readable config

## Verification

- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
