### PR TITLE
fix(runner): make network provisioning idempotent

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -186,7 +186,7 @@
 - name: Install isolated network definition
   ansible.builtin.template:
     src: sanctuary-ci.xml.j2
-    dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml
+    dest: /etc/ci-runner/sanctuary-ci.xml
     owner: root
     group: root
     mode: '0600'
@@ -195,7 +195,13 @@
 - name: Define and start runner network
   ansible.builtin.shell: |
     set -euo pipefail
-    virsh net-define /etc/libvirt/qemu/networks/sanctuary-ci.xml
+    if virsh net-info sanctuary-ci >/dev/null 2>&1; then
+      if virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
+        virsh net-destroy sanctuary-ci
+      fi
+      virsh net-undefine sanctuary-ci
+    fi
+    virsh net-define /etc/ci-runner/sanctuary-ci.xml
     virsh net-autostart sanctuary-ci
     if ! virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
       virsh net-start sanctuary-ci

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -29,6 +29,9 @@ grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "src: runner/config/manager.toml.*group: ci-runner-manager.*mode: '0640'" infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'dest: /etc/ci-runner/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+! grep -q 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
 test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3


### PR DESCRIPTION
## Summary

- keep the desired libvirt network XML under `/etc/ci-runner` instead of the libvirt-managed state path
- redefine the dedicated network only when that stable source definition actually changes
- destroy and undefine only after the existing runner drain assertions have passed
- add regression assertions for repeated playbook runs

## Verification

- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
