### PR TITLE
fix(runner): recover transient network state

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -196,10 +196,16 @@
   ansible.builtin.shell: |
     set -euo pipefail
     if virsh net-info sanctuary-ci >/dev/null 2>&1; then
+      runner_network_persistent=false
+      if virsh net-info sanctuary-ci | grep -q '^Persistent:.*yes'; then
+        runner_network_persistent=true
+      fi
       if virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
         virsh net-destroy sanctuary-ci
       fi
-      virsh net-undefine sanctuary-ci
+      if [ "$runner_network_persistent" = true ]; then
+        virsh net-undefine sanctuary-ci
+      fi
     fi
     virsh net-define /etc/ci-runner/sanctuary-ci.xml
     virsh net-autostart sanctuary-ci

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -31,6 +31,8 @@ grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra
 grep -q "src: runner/config/manager.toml.*group: ci-runner-manager.*mode: '0640'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'dest: /etc/ci-runner/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'runner_network_persistent=false' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'if \[ "$runner_network_persistent" = true \]' infra/ansible/roles/runner_host/tasks/main.yml
 ! grep -q 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl


### PR DESCRIPTION
## Summary

- detect whether the existing dedicated libvirt network is persistent before stopping it
- undefine only persistent networks; transient networks disappear when stopped
- cover transient recovery in the platform regression checks

## Verification

- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
