### PR TITLE
fix(runner): upsert network by UUID

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -195,23 +195,32 @@
 - name: Define and start runner network
   ansible.builtin.shell: |
     set -euo pipefail
-    if virsh net-info sanctuary-ci >/dev/null 2>&1; then
-      runner_network_persistent=false
-      if virsh net-info sanctuary-ci | grep -q '^Persistent:.*yes'; then
-        runner_network_persistent=true
+    runner_libvirt_uri=qemu:///system
+    runner_network_xml=/etc/ci-runner/sanctuary-ci.xml
+    runner_network_effective_xml="$(mktemp)"
+    trap 'rm -f "$runner_network_effective_xml"' EXIT
+    if runner_network_uuid="$(virsh --connect "$runner_libvirt_uri" net-uuid sanctuary-ci 2>/dev/null)"; then
+      if [[ ! "$runner_network_uuid" =~ ^[a-f0-9-]{36}$ ]]; then
+        echo "refusing invalid existing runner network UUID" >&2
+        exit 1
       fi
-      if virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
-        virsh net-destroy sanctuary-ci
-      fi
-      if [ "$runner_network_persistent" = true ]; then
-        virsh net-undefine sanctuary-ci
-      fi
+      awk -v runner_network_uuid="$runner_network_uuid" '
+        /<name>sanctuary-ci<\/name>/ {
+          print
+          print "  <uuid>" runner_network_uuid "</uuid>"
+          next
+        }
+        { print }
+      ' "$runner_network_xml" > "$runner_network_effective_xml"
+    else
+      cp "$runner_network_xml" "$runner_network_effective_xml"
     fi
-    virsh net-define /etc/ci-runner/sanctuary-ci.xml
-    virsh net-autostart sanctuary-ci
-    if ! virsh net-info sanctuary-ci | grep -q '^Active:.*yes'; then
-      virsh net-start sanctuary-ci
+    virsh --connect "$runner_libvirt_uri" net-define "$runner_network_effective_xml"
+    virsh --connect "$runner_libvirt_uri" net-autostart sanctuary-ci
+    if virsh --connect "$runner_libvirt_uri" net-list --name | grep -Fxq sanctuary-ci; then
+      virsh --connect "$runner_libvirt_uri" net-destroy sanctuary-ci
     fi
+    virsh --connect "$runner_libvirt_uri" net-start sanctuary-ci
   args:
     executable: /bin/bash
   when: runner_network_definition.changed

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -30,9 +30,11 @@ grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible
 grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "src: runner/config/manager.toml.*group: ci-runner-manager.*mode: '0640'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'dest: /etc/ci-runner/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
-grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
-grep -q 'runner_network_persistent=false' infra/ansible/roles/runner_host/tasks/main.yml
-grep -q 'if \[ "$runner_network_persistent" = true \]' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'runner_libvirt_uri=qemu:///system' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'net-uuid sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'net-list --name.*grep -Fxq sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q '<uuid>.*runner_network_uuid.*</uuid>' infra/ansible/roles/runner_host/tasks/main.yml
+! grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
 ! grep -q 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl


### PR DESCRIPTION
## Summary

- address libvirt explicitly through `qemu:///system`
- preserve and inject the existing network UUID before `net-define`
- convert transient state to persistent state without name/UUID conflicts
- restart only the drained, dedicated runner network to activate desired XML
- use locale-independent active-network detection

## Verification

- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
