### PR TITLE
fix(runner): converge live activation state

### DIFF
--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -198,7 +198,20 @@
     runner_libvirt_uri=qemu:///system
     runner_network_xml=/etc/ci-runner/sanctuary-ci.xml
     runner_network_effective_xml="$(mktemp)"
+    runner_network_restart={{ runner_network_definition.changed | ternary('true', 'false') }}
     trap 'rm -f "$runner_network_effective_xml"' EXIT
+    runner_network_was_active=false
+    runner_network_was_persistent=false
+    runner_network_was_autostart=false
+    if virsh --connect "$runner_libvirt_uri" net-list --name | grep -Fxq sanctuary-ci; then
+      runner_network_was_active=true
+    fi
+    if virsh --connect "$runner_libvirt_uri" net-list --all --persistent --name | grep -Fxq sanctuary-ci; then
+      runner_network_was_persistent=true
+    fi
+    if virsh --connect "$runner_libvirt_uri" net-list --all --autostart --name | grep -Fxq sanctuary-ci; then
+      runner_network_was_autostart=true
+    fi
     if runner_network_uuid="$(virsh --connect "$runner_libvirt_uri" net-uuid sanctuary-ci 2>/dev/null)"; then
       if [[ ! "$runner_network_uuid" =~ ^[a-f0-9-]{36}$ ]]; then
         echo "refusing invalid existing runner network UUID" >&2
@@ -217,14 +230,22 @@
     fi
     virsh --connect "$runner_libvirt_uri" net-define "$runner_network_effective_xml"
     virsh --connect "$runner_libvirt_uri" net-autostart sanctuary-ci
-    if virsh --connect "$runner_libvirt_uri" net-list --name | grep -Fxq sanctuary-ci; then
+    if [ "$runner_network_restart" = true ] && [ "$runner_network_was_active" = true ]; then
       virsh --connect "$runner_libvirt_uri" net-destroy sanctuary-ci
     fi
-    virsh --connect "$runner_libvirt_uri" net-start sanctuary-ci
+    if ! virsh --connect "$runner_libvirt_uri" net-list --name | grep -Fxq sanctuary-ci; then
+      virsh --connect "$runner_libvirt_uri" net-start sanctuary-ci
+    fi
+    if [ "$runner_network_restart" = true ] ||
+       [ "$runner_network_was_active" = false ] ||
+       [ "$runner_network_was_persistent" = false ] ||
+       [ "$runner_network_was_autostart" = false ]; then
+      echo changed
+    fi
   args:
     executable: /bin/bash
-  when: runner_network_definition.changed
-  changed_when: true
+  changed_when: "'changed' in runner_network_activation.stdout_lines"
+  register: runner_network_activation
 
 - name: Install runner egress guard
   ansible.builtin.template:

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -264,7 +264,14 @@ def validate_repositories(cfg: dict[str, Any]) -> list[str]:
 
 def read_token(path: Path) -> str:
     stat = path.stat()
-    if stat.st_mode & 0o077:
+    credential_directory = os.environ.get("CREDENTIALS_DIRECTORY")
+    inside_systemd_credentials = False
+    if credential_directory:
+        try:
+            inside_systemd_credentials = path.resolve(strict=True).parent == Path(credential_directory).resolve(strict=True)
+        except OSError:
+            inside_systemd_credentials = False
+    if not inside_systemd_credentials and stat.st_mode & 0o077:
         raise RunnerError("GitHub credential must not be accessible by group or others")
     return path.read_text(encoding="utf-8").strip()
 

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -12,6 +12,35 @@ import ci_runner_manager as manager
 
 
 class ManagerTests(unittest.TestCase):
+    def test_token_file_requires_private_permissions_outside_systemd_credentials(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "github.token"
+            path.write_text("opaque-token\n", encoding="utf-8")
+            os.chmod(path, 0o640)
+            with mock.patch.dict(os.environ, {}, clear=True), self.assertRaises(manager.RunnerError):
+                manager.read_token(path)
+
+    def test_token_file_accepts_systemd_credential_boundary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            credential_directory = Path(directory) / "credentials"
+            credential_directory.mkdir(mode=0o700)
+            path = credential_directory / "github_token"
+            path.write_text("opaque-token\n", encoding="utf-8")
+            os.chmod(path, 0o440)
+            with mock.patch.dict(os.environ, {"CREDENTIALS_DIRECTORY": str(credential_directory)}, clear=True):
+                self.assertEqual(manager.read_token(path), "opaque-token")
+
+    def test_systemd_credential_boundary_does_not_cover_sibling_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            credential_directory = root / "credentials"
+            credential_directory.mkdir(mode=0o700)
+            path = root / "github.token"
+            path.write_text("opaque-token\n", encoding="utf-8")
+            os.chmod(path, 0o640)
+            with mock.patch.dict(os.environ, {"CREDENTIALS_DIRECTORY": str(credential_directory)}, clear=True), self.assertRaises(manager.RunnerError):
+                manager.read_token(path)
+
     def test_lease_validation_accepts_expected_identifier(self):
         self.assertEqual(manager.validate_lease_id("job-123_abc.1"), "job-123_abc.1")
 

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -33,6 +33,9 @@ grep -q 'dest: /etc/ci-runner/sanctuary-ci.xml' infra/ansible/roles/runner_host/
 grep -q 'runner_libvirt_uri=qemu:///system' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'net-uuid sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'net-list --name.*grep -Fxq sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'net-list --all --persistent --name' infra/ansible/roles/runner_host/tasks/main.yml
+grep -q 'net-list --all --autostart --name' infra/ansible/roles/runner_host/tasks/main.yml
+! grep -q 'when: runner_network_definition.changed' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q '<uuid>.*runner_network_uuid.*</uuid>' infra/ansible/roles/runner_host/tasks/main.yml
 ! grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
 ! grep -q 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml


### PR DESCRIPTION
## Summary

- trust only the exact systemd `CREDENTIALS_DIRECTORY` boundary for runtime credential copies
- retain strict private-mode enforcement for token files outside that boundary
- converge active, persistent, and autostart libvirt state even when the desired XML file is unchanged
- restart the drained dedicated network only when its desired XML changed
- add credential-boundary and live-state regression coverage

## Verification

- 32 runner platform tests
- `bash scripts/test-runner-platform.sh`
- `make lint`
- `make test`

Tracker: DEV-1
