### PR TITLE
fix(runner): isolate host helper behind socket

### DIFF
--- a/docs/playbooks/ci-runner-host.md
+++ b/docs/playbooks/ci-runner-host.md
@@ -46,9 +46,16 @@ ansible-playbook --check --diff --limit sanctuary site.yml \
 sudo kvm-ok
 sudo virsh net-info sanctuary-ci
 sudo nft list table inet sanctuary_ci
-sudo systemctl status ci-runner-manager libvirtd sanctuary-ci-firewall
-sudo -u ci-runner-manager /usr/local/bin/ci-runner-manager reconcile
+sudo systemctl status ci-runner-manager ci-runner-host-helper.socket libvirtd sanctuary-ci-firewall
+sudo systemctl show ci-runner-manager -p NoNewPrivileges
+sudo stat -c '%U:%G %a %n' /run/ci-runner-host-helper.sock
+sudo journalctl -u ci-runner-manager -u 'ci-runner-host-helper@*' --since '-5 minutes'
 ```
+
+The manager must report `NoNewPrivileges=yes`; `/etc/sudoers.d/ci-runner-manager`
+must not exist. The helper socket must be owned by `ci-runner-manager`, mode
+`0600`, and the broker must reject every other peer UID. Do not weaken this
+boundary to a group-writable socket or a wildcard sudo rule.
 
 Launch a non-production canary and verify: exact `trusted-heavy` routing; 8
 vCPU, 12 GiB RAM and 120 GiB disk; rejection of a second launch; public GitHub
@@ -58,7 +65,8 @@ the JIT payload.
 
 Repeat a failure canary with the manager stopped. Confirm the guest and host
 timer power the VM off at the configured upper bound, then restart the manager
-and confirm the local lease, overlay, seed and GitHub runner record are removed.
+and confirm its normal reconciliation removes the local lease, overlay, seed
+and GitHub runner record.
 Simulate one failed GitHub deletion and verify a private cleanup tombstone is
 retried without blocking the next VM admission.
 
@@ -70,9 +78,10 @@ and all non-`sanctuary_ci` nftables tables unchanged.
 
 Disable the runner group first. Preserve the audit log and job identifiers, but
 never copy a seed ISO or JIT value into a ticket. Stop the listener, allow the
-current job to finish unless containment requires termination, run
-`ci-runner-manager reconcile`, and confirm that no `sanctuary-ci-*` domain or
-lease directory remains.
+current job to finish unless containment requires termination, restart the
+manager to run reconciliation through its systemd credential and socket
+boundaries, and confirm that no `sanctuary-ci-*` domain or lease directory
+remains.
 
 ## Hosted rollback
 

--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -33,10 +33,19 @@ sudo -u ci-runner-manager /usr/local/bin/ci-runner-manager launch \
   --lease JOB_ID --jit-config-file /run/ci-runner-manager/JOB_ID.jit
 ```
 
-The manager passes the value to the root helper over stdin; neither layer logs
-it or includes it in a host process argument. The guest uses the JIT value for
-one job, powers off after the runner exits, and the reconciler removes the
-domain, seed ISO, and overlay.
+The manager keeps `NoNewPrivileges=yes` and sends the value as a separate,
+bounded packet to a root-owned systemd socket-activated helper. The helper
+accepts only the exact manager UID (socket mode plus `SO_PEERCRED`) and a strict
+`list`, `launch`, or `destroy` protocol. Neither layer logs the JIT value or
+includes it in a host process argument. Normal GitHub dispatch sends the value
+directly from memory without a manager-side temporary file. The guest uses the
+JIT value for one job, powers off after the runner exits, and the reconciler
+removes the domain, seed ISO, and overlay.
+
+The root helper never receives the GitHub API credential. Its detailed security
+events go only to journald; responses expose allowlisted error codes rather than
+subprocess output. The JIT value remains in the root-only seed ISO until lease
+cleanup, so seed and overlay files must never be copied into tickets or logs.
 
 The polling adapter uses only documented GitHub REST endpoints and is not a
 replacement for GitHub's scale-set client. Migrate to the official client when

--- a/infra/ansible/roles/runner_host/handlers/main.yml
+++ b/infra/ansible/roles/runner_host/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Restart runner host helper socket
+  ansible.builtin.systemd:
+    name: ci-runner-host-helper.socket
+    state: restarted
+    daemon_reload: true
+
 - name: Restart runner manager
   ansible.builtin.systemd:
     name: ci-runner-manager.service

--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -170,18 +170,18 @@
     - { src: runner/host-helper/ci_runner_host_helper.py, dest: /usr/local/libexec/ci-runner-host-helper, mode: '0755' }
     - { src: runner/config/manager.toml, dest: /etc/ci-runner/manager.toml, group: ci-runner-manager, mode: '0640' }
     - { src: runner/systemd/ci-runner-manager.service, dest: /etc/systemd/system/ci-runner-manager.service, mode: '0644' }
+    - { src: runner/systemd/ci-runner-host-helper.socket, dest: /etc/systemd/system/ci-runner-host-helper.socket, mode: '0644' }
+    - { src: runner/systemd/ci-runner-host-helper@.service, dest: /etc/systemd/system/ci-runner-host-helper@.service, mode: '0644' }
     - { src: runner/systemd/sanctuary-ci-firewall.service, dest: /etc/systemd/system/sanctuary-ci-firewall.service, mode: '0644' }
     - { src: runner/logrotate/ci-runner-audit, dest: /etc/logrotate.d/ci-runner-audit, mode: '0644' }
-  notify: Restart runner manager
+  notify:
+    - Restart runner host helper socket
+    - Restart runner manager
 
-- name: Install validated sudo policy
-  ansible.builtin.template:
-    src: ci-runner-manager.sudoers.j2
+- name: Remove obsolete runner manager sudo policy
+  ansible.builtin.file:
     dest: /etc/sudoers.d/ci-runner-manager
-    owner: root
-    group: root
-    mode: '0440'
-    validate: /usr/sbin/visudo -cf %s
+    state: absent
 
 - name: Install isolated network definition
   ansible.builtin.template:
@@ -278,4 +278,5 @@
   loop:
     - libvirtd.service
     - sanctuary-ci-firewall.service
+    - ci-runner-host-helper.socket
     - ci-runner-manager.service

--- a/infra/ansible/roles/runner_host/templates/ci-runner-manager.sudoers.j2
+++ b/infra/ansible/roles/runner_host/templates/ci-runner-manager.sudoers.j2
@@ -1,2 +1,0 @@
-Defaults:ci-runner-manager env_reset,secure_path=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/libexec
-ci-runner-manager ALL=(root) NOPASSWD: /usr/local/libexec/ci-runner-host-helper *

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,9 +1,11 @@
 # Sanctuary ephemeral CI runner
 
 This directory contains the host-side boundary for one ephemeral GitHub Actions
-runner. It is intentionally smaller than a runner scale-set client: the
-official GitHub client owns job acquisition and JIT configuration, while
-`ci-runner-manager` owns local admission, VM launch, and cleanup.
+runner. It is intentionally smaller than a runner scale-set client: a
+repository-scoped polling adapter owns job acquisition and JIT configuration,
+while `ci-runner-manager` owns local admission, VM launch, and cleanup.
+It remains unprivileged and communicates with the root-only lifecycle helper
+through a bounded systemd `SOCK_SEQPACKET` socket guarded by exact peer UID.
 
 See [the platform design](../docs/runner/sanctuary-kvm-runner.md) and
 [the operations runbook](../docs/playbooks/ci-runner-host.md) before deployment.

--- a/runner/config/manager.toml
+++ b/runner/config/manager.toml
@@ -1,7 +1,7 @@
 state_dir = "/var/lib/ci-runner-manager/state"
-lock_file = "/run/lock/ci-runner-manager.lock"
+lock_file = "/run/ci-runner-manager/manager.lock"
 audit_log = "/mnt/hdd1000-01/ci-audit/manager.log"
-helper = "/usr/local/libexec/ci-runner-host-helper"
+helper_socket = "/run/ci-runner-host-helper.sock"
 overlay_root = "/mnt/ssd1000-01/ci-runner"
 min_free_memory_mib = 14336
 min_free_disk_gib = 140

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import fcntl
 import json
 import os
 from pathlib import Path
 import re
 import shutil
+import socket
+import struct
 import subprocess
 import sys
 import tempfile
+from typing import Any
 
 LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 PREFIX = "sanctuary-ci-"
@@ -22,12 +26,35 @@ IMAGE_ROOT = Path("/var/lib/ci-runner/images")
 BASE_IMAGE = IMAGE_ROOT / "ubuntu-24.04-runner.qcow2"
 IMAGE_RE = re.compile(r"^ubuntu-24\.04-runner-[a-f0-9]{64}\.qcow2$")
 NETWORK = "sanctuary-ci"
+LIBVIRT_URI = "qemu:///system"
 VCPUS = "8"
 MEMORY_MIB = "12288"
 DISK_GIB = "120G"
 MAX_LEASE_SECONDS = "7200"
 HELPER_LOCK = Path("/run/lock/ci-runner-host-helper.lock")
 HELPER_PATH = "/usr/local/libexec/ci-runner-host-helper"
+MANAGER_USER = "ci-runner-manager"
+PROTOCOL_VERSION = 1
+MAX_REQUEST_BYTES = 4096
+MAX_JIT_BYTES = 131072
+MAX_RESPONSE_BYTES = 65536
+REQUEST_ID_RE = re.compile(r"^[a-f0-9]{32}$")
+ERROR_CODES = frozenset({"invalid_request", "unauthorized", "operation_failed", "busy"})
+UNKNOWN_REQUEST_ID = "0" * 32
+SO_PEERCRED = getattr(socket, "SO_PEERCRED", 17)
+
+
+class ProtocolError(ValueError):
+    """A request error that is safe to represent with a generic code."""
+
+
+def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ProtocolError("duplicate JSON member")
+        result[key] = value
+    return result
 
 
 def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -59,17 +86,27 @@ def resolved_base_image() -> Path:
     return image
 
 
-def launch(lease: str) -> None:
+def validate_jit_payload(encoded_jit: bytes) -> bytes:
+    if not encoded_jit or len(encoded_jit) > MAX_JIT_BYTES:
+        raise ProtocolError("invalid JIT configuration size")
+    try:
+        base64.b64decode(encoded_jit, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ProtocolError("invalid JIT configuration encoding") from exc
+    return encoded_jit
+
+
+def launch(lease: str, encoded_jit: bytes | None = None) -> None:
     if os.geteuid() != 0:
         raise PermissionError("helper must run as root")
+    validate_lease(lease)
+    if encoded_jit is None:
+        encoded_jit = sys.stdin.buffer.read(MAX_JIT_BYTES + 1).strip()
+    encoded_jit = validate_jit_payload(encoded_jit)
     base_image = resolved_base_image()
-    existing = run(["virsh", "list", "--all", "--name"])
+    existing = run(["virsh", "--connect", LIBVIRT_URI, "list", "--all", "--name"])
     if any(line.startswith(PREFIX) for line in existing.stdout.splitlines()):
         raise RuntimeError("a sanctuary CI domain already exists")
-    encoded_jit = sys.stdin.buffer.read(131073).strip()
-    if not encoded_jit or len(encoded_jit) > 131072:
-        raise ValueError("invalid JIT configuration size")
-    base64.b64decode(encoded_jit, validate=True)
     directory = lease_dir(lease)
     if directory.exists():
         raise FileExistsError("lease directory already exists")
@@ -97,7 +134,8 @@ runcmd:
             (temp / "meta-data").write_text(meta_data, encoding="utf-8")
             os.chmod(temp / "user-data", 0o600)
             run(["cloud-localds", str(seed), str(temp / "user-data"), str(temp / "meta-data")])
-        run(["virt-install", "--name", name(lease), "--memory", MEMORY_MIB, "--vcpus", VCPUS,
+        run(["virt-install", "--connect", LIBVIRT_URI,
+             "--name", name(lease), "--memory", MEMORY_MIB, "--vcpus", VCPUS,
              "--cpu", "host-passthrough", "--import", "--noautoconsole", "--os-variant", "ubuntu24.04",
              "--disk", f"path={overlay},format=qcow2,bus=virtio,cache=none,discard=unmap",
              "--disk", f"path={seed},device=cdrom,readonly=on",
@@ -105,6 +143,10 @@ runcmd:
              "--rng", "/dev/urandom", "--controller", "type=scsi,model=virtio-scsi"])
         run(["systemd-run", "--unit", f"{PREFIX}expire-{lease}",
              "--on-active", f"{MAX_LEASE_SECONDS}s", "--timer-property", "AccuracySec=30s",
+             "--property=NoNewPrivileges=yes", "--property=ProtectSystem=strict",
+             "--property=ProtectHome=yes", "--property=PrivateTmp=yes",
+             f"--property=ReadWritePaths={OVERLAY_ROOT} /run/lock",
+             "--property=RestrictAddressFamilies=AF_UNIX",
              HELPER_PATH, "destroy", lease])
     except Exception:
         destroy(lease)
@@ -114,20 +156,146 @@ runcmd:
 def destroy(lease: str) -> None:
     domain = name(lease)
     run(["systemctl", "stop", f"{PREFIX}expire-{lease}.timer"], check=False)
-    run(["virsh", "destroy", domain], check=False)
-    run(["virsh", "undefine", domain, "--nvram"], check=False)
+    run(["virsh", "--connect", LIBVIRT_URI, "destroy", domain], check=False)
+    run(["virsh", "--connect", LIBVIRT_URI, "undefine", domain, "--nvram"], check=False)
     directory = lease_dir(lease)
     if directory.exists():
         shutil.rmtree(directory)
 
 
-def list_leases() -> None:
-    result = run(["virsh", "list", "--all", "--name"])
+def list_leases() -> dict[str, str]:
+    result = run(["virsh", "--connect", LIBVIRT_URI, "list", "--all", "--name"])
     leases = {}
     for domain in sorted(line for line in result.stdout.splitlines() if line.startswith(PREFIX)):
-        state = run(["virsh", "domstate", domain]).stdout.strip().lower()
+        state = run(["virsh", "--connect", LIBVIRT_URI, "domstate", domain]).stdout.strip().lower()
         leases[domain[len(PREFIX):]] = state
-    print(json.dumps(leases, sort_keys=True))
+    return leases
+
+
+def parse_request(packet: bytes) -> dict[str, Any]:
+    if not packet or len(packet) > MAX_REQUEST_BYTES:
+        raise ProtocolError("invalid request size")
+    try:
+        request = json.loads(packet, object_pairs_hook=strict_json_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError("invalid request JSON") from exc
+    if not isinstance(request, dict):
+        raise ProtocolError("request must be an object")
+    if request.get("v") != PROTOCOL_VERSION or isinstance(request.get("v"), bool):
+        raise ProtocolError("invalid protocol version")
+    request_id = request.get("id")
+    if not isinstance(request_id, str) or not REQUEST_ID_RE.fullmatch(request_id):
+        raise ProtocolError("invalid request id")
+    operation = request.get("op")
+    if operation == "list":
+        if set(request) != {"v", "id", "op"}:
+            raise ProtocolError("invalid list request schema")
+    elif operation in {"launch", "destroy"}:
+        if set(request) != {"v", "id", "op", "lease"}:
+            raise ProtocolError("invalid mutation request schema")
+        lease = request.get("lease")
+        if not isinstance(lease, str):
+            raise ProtocolError("invalid lease type")
+        try:
+            validate_lease(lease)
+        except ValueError as exc:
+            raise ProtocolError("invalid lease") from exc
+    else:
+        raise ProtocolError("invalid operation")
+    return request
+
+
+def request_id_from_packet(packet: bytes) -> str:
+    try:
+        request = json.loads(packet)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return UNKNOWN_REQUEST_ID
+    if isinstance(request, dict) and isinstance(request.get("id"), str) \
+            and REQUEST_ID_RE.fullmatch(request["id"]):
+        return request["id"]
+    return UNKNOWN_REQUEST_ID
+
+
+def peer_credentials(connection: socket.socket) -> tuple[int, int, int]:
+    raw = connection.getsockopt(socket.SOL_SOCKET, SO_PEERCRED, struct.calcsize("3i"))
+    return struct.unpack("3i", raw)
+
+
+def recv_packet(connection: socket.socket, maximum: int) -> bytes:
+    packet = connection.recv(maximum + 1)
+    if not packet or len(packet) > maximum:
+        raise ProtocolError("invalid packet size")
+    return packet
+
+
+def encode_response(request_id: str, *, result: Any | None = None,
+                    error: str | None = None) -> bytes:
+    if not REQUEST_ID_RE.fullmatch(request_id):
+        request_id = UNKNOWN_REQUEST_ID
+    if error is None:
+        response = {"v": PROTOCOL_VERSION, "id": request_id, "ok": True, "result": result}
+    else:
+        if error not in ERROR_CODES:
+            error = "operation_failed"
+        response = {"v": PROTOCOL_VERSION, "id": request_id, "ok": False, "error": error}
+    encoded = json.dumps(response, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    if len(encoded) > MAX_RESPONSE_BYTES:
+        encoded = json.dumps({
+            "v": PROTOCOL_VERSION,
+            "id": request_id,
+            "ok": False,
+            "error": "operation_failed",
+        }, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return encoded
+
+
+def serve_connection(connection: socket.socket, *, expected_uid: int | None = None) -> None:
+    request_id = UNKNOWN_REQUEST_ID
+    try:
+        if expected_uid is None:
+            import pwd
+            expected_uid = pwd.getpwnam(MANAGER_USER).pw_uid
+        _pid, uid, _gid = peer_credentials(connection)
+        if uid != expected_uid:
+            raise PermissionError("rejected peer uid")
+        connection.settimeout(5.0)
+        request_packet = recv_packet(connection, MAX_REQUEST_BYTES)
+        request_id = request_id_from_packet(request_packet)
+        request = parse_request(request_packet)
+        jit_payload = None
+        if request["op"] == "launch":
+            jit_payload = validate_jit_payload(recv_packet(connection, MAX_JIT_BYTES))
+        connection.settimeout(None)
+
+        with HELPER_LOCK.open("a+", encoding="utf-8") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            if request["op"] == "list":
+                result: Any = list_leases()
+            elif request["op"] == "launch":
+                launch(request["lease"], jit_payload)
+                result = None
+            else:
+                destroy(request["lease"])
+                result = None
+        response = encode_response(request_id, result=result)
+    except PermissionError as exc:
+        print(f"ci-runner-host-helper: {exc}", file=sys.stderr)
+        response = encode_response(request_id, error="unauthorized")
+    except ProtocolError as exc:
+        print(f"ci-runner-host-helper: {exc}", file=sys.stderr)
+        response = encode_response(request_id, error="invalid_request")
+    except Exception as exc:
+        print(f"ci-runner-host-helper: operation failed: {type(exc).__name__}", file=sys.stderr)
+        response = encode_response(request_id, error="operation_failed")
+    connection.sendall(response)
+
+
+def serve() -> None:
+    connection = socket.fromfd(sys.stdin.fileno(), socket.AF_UNIX, socket.SOCK_SEQPACKET)
+    try:
+        serve_connection(connection)
+    finally:
+        connection.close()
 
 
 def main() -> int:
@@ -137,8 +305,12 @@ def main() -> int:
         child = sub.add_parser(command)
         child.add_argument("lease")
     sub.add_parser("list")
+    sub.add_parser("serve")
     args = parser.parse_args()
     try:
+        if args.command == "serve":
+            serve()
+            return 0
         with HELPER_LOCK.open("a+", encoding="utf-8") as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
             if args.command == "launch":
@@ -146,10 +318,10 @@ def main() -> int:
             elif args.command == "destroy":
                 destroy(args.lease)
             else:
-                list_leases()
+                print(json.dumps(list_leases(), sort_keys=True))
         return 0
     except Exception as exc:
-        print(f"ci-runner-host-helper: {exc}", file=sys.stderr)
+        print(f"ci-runner-host-helper: operation failed: {type(exc).__name__}", file=sys.stderr)
         return 1
 
 

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -12,7 +12,9 @@ import logging
 import os
 from pathlib import Path
 import re
+import secrets
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -25,6 +27,12 @@ import urllib.request
 LEASE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 LOG = logging.getLogger("ci-runner-manager")
 REGISTRATION_GRACE_SECONDS = 300
+HELPER_HEADER_MAX = 4096
+HELPER_RESPONSE_MAX = 65536
+HELPER_JIT_MAX = 131072
+HELPER_ERROR_CODES = {"invalid_request", "unauthorized", "operation_failed", "busy"}
+HELPER_QUERY_TIMEOUT_SECONDS = 120
+HELPER_MUTATION_TIMEOUT_SECONDS = 330
 
 
 class RunnerError(RuntimeError):
@@ -41,10 +49,19 @@ class NotFound(RunnerError):
     pass
 
 
+def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise RunnerError("host helper returned an invalid response")
+        result[key] = value
+    return result
+
+
 def load_config(path: Path) -> dict[str, Any]:
     with path.open("rb") as handle:
         cfg = tomllib.load(handle)
-    required = {"state_dir", "lock_file", "audit_log", "helper", "min_free_memory_mib", "min_free_disk_gib", "max_load_1m", "max_lease_seconds", "github_token_file", "repositories", "runner_label"}
+    required = {"state_dir", "lock_file", "audit_log", "helper_socket", "min_free_memory_mib", "min_free_disk_gib", "max_load_1m", "max_lease_seconds", "github_token_file", "repositories", "runner_label"}
     missing = required.difference(cfg)
     if missing:
         raise RunnerError(f"missing configuration keys: {', '.join(sorted(missing))}")
@@ -57,18 +74,22 @@ def validate_lease_id(value: str) -> str:
     return value
 
 
-def read_jit_config(path: Path) -> bytes:
-    stat = path.stat()
-    if stat.st_mode & 0o077:
-        raise RunnerError("JIT configuration file must not be accessible by group or others")
-    raw = path.read_bytes().strip()
-    if not raw or len(raw) > 131072:
+def validate_jit_config(raw: bytes) -> bytes:
+    raw = raw.strip()
+    if not raw or len(raw) > HELPER_JIT_MAX:
         raise RunnerError("JIT configuration is empty or exceeds 128 KiB")
     try:
         base64.b64decode(raw, validate=True)
     except ValueError as exc:
         raise RunnerError("JIT configuration is not valid base64") from exc
     return raw
+
+
+def read_jit_config(path: Path) -> bytes:
+    stat = path.stat()
+    if stat.st_mode & 0o077:
+        raise RunnerError("JIT configuration file must not be accessible by group or others")
+    return validate_jit_config(path.read_bytes())
 
 
 def memory_available_mib() -> int:
@@ -147,7 +168,8 @@ class StateStore:
         os.chmod(temporary, 0o600)
         os.replace(temporary, destination)
 
-    def defer_cleanup(self, lease: str, state: dict[str, Any], now: int) -> None:
+    def defer_cleanup(self, lease: str, state: dict[str, Any], now: int, *,
+                      preserve_lease: bool = False) -> None:
         attempts = int(state.get("cleanup_attempts", 0)) + 1
         pending = dict(state)
         pending.update({
@@ -160,7 +182,8 @@ class StateStore:
         temporary.write_text(json.dumps(pending, sort_keys=True) + "\n", encoding="utf-8")
         os.chmod(temporary, 0o600)
         os.replace(temporary, destination)
-        self.remove(lease)
+        if not preserve_lease:
+            self.remove(lease)
 
     def remove_cleanup(self, state: dict[str, Any]) -> None:
         self.cleanup_path(state).unlink(missing_ok=True)
@@ -276,10 +299,62 @@ def read_token(path: Path) -> str:
     return path.read_text(encoding="utf-8").strip()
 
 
-def helper(cfg: dict[str, Any], *args: str, stdin: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
-    command = ["sudo", "--non-interactive", str(cfg["helper"]), *args]
-    return subprocess.run(command, input=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                          check=check, timeout=120, text=False)
+def helper(cfg: dict[str, Any], *args: str, stdin: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    if not args or args[0] not in {"list", "launch", "destroy"} or len(args) > 2:
+        raise RunnerError("invalid host helper operation")
+    operation = args[0]
+    request_id = secrets.token_hex(16)
+    request: dict[str, Any] = {"v": 1, "id": request_id, "op": operation}
+    if operation in {"launch", "destroy"}:
+        if len(args) != 2:
+            raise RunnerError("host helper operation requires a lease")
+        request["lease"] = validate_lease_id(args[1])
+    elif len(args) != 1:
+        raise RunnerError("list operation does not accept a lease")
+    if operation == "launch":
+        if stdin is None:
+            raise RunnerError("launch requires JIT configuration")
+        stdin = validate_jit_config(stdin)
+    elif stdin is not None:
+        raise RunnerError("host helper payload is only valid for launch")
+    header = json.dumps(request, separators=(",", ":")).encode("utf-8")
+    if len(header) > HELPER_HEADER_MAX:
+        raise RunnerError("host helper request header exceeds limit")
+    command = ["host-helper", operation, *args[1:]]
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET) as connection:
+            connection.settimeout(HELPER_QUERY_TIMEOUT_SECONDS if operation == "list"
+                                  else HELPER_MUTATION_TIMEOUT_SECONDS)
+            connection.connect(str(cfg["helper_socket"]))
+            if connection.send(header) != len(header):
+                raise RunnerError("host helper request was truncated")
+            if stdin is not None and connection.send(stdin) != len(stdin):
+                raise RunnerError("host helper JIT payload was truncated")
+            payload, _ancillary, flags, _address = connection.recvmsg(HELPER_RESPONSE_MAX)
+    except (OSError, TimeoutError) as exc:
+        raise RunnerError("host helper is unavailable") from exc
+    if flags & socket.MSG_TRUNC or not payload:
+        raise RunnerError("host helper returned an invalid response")
+    try:
+        response = json.loads(payload, object_pairs_hook=strict_json_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, RunnerError) as exc:
+        raise RunnerError("host helper returned an invalid response") from exc
+    if not isinstance(response, dict) or response.get("v") != 1 or response.get("id") != request_id:
+        raise RunnerError("host helper returned an invalid response")
+    if response.get("ok") is True and set(response) == {"v", "id", "ok", "result"}:
+        result = response["result"]
+        if (operation == "list" and not isinstance(result, dict)) or \
+                (operation != "list" and result is not None):
+            raise RunnerError("host helper returned an invalid response")
+        stdout = json.dumps(result, sort_keys=True).encode("utf-8") if operation == "list" else b""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr=b"")
+    error = response.get("error")
+    if response.get("ok") is not False or set(response) != {"v", "id", "ok", "error"} or error not in HELPER_ERROR_CODES:
+        raise RunnerError("host helper returned an invalid response")
+    completed = subprocess.CompletedProcess(command, 1, stdout=b"", stderr=str(error).encode("ascii"))
+    if check:
+        raise subprocess.CalledProcessError(1, command, output=b"", stderr=completed.stderr)
+    return completed
 
 
 def with_lock(path: Path):
@@ -289,9 +364,9 @@ def with_lock(path: Path):
     return handle
 
 
-def launch(cfg: dict[str, Any], lease: str, jit_path: Path, *, metadata: dict[str, Any] | None = None) -> None:
+def launch(cfg: dict[str, Any], lease: str, jit_source: Path | bytes, *, metadata: dict[str, Any] | None = None) -> None:
     lease = validate_lease_id(lease)
-    jit = read_jit_config(jit_path)
+    jit = read_jit_config(jit_source) if isinstance(jit_source, Path) else validate_jit_config(jit_source)
     store = StateStore(Path(cfg["state_dir"]))
     with with_lock(Path(cfg["lock_file"])):
         if store.leases():
@@ -312,7 +387,11 @@ def launch(cfg: dict[str, Any], lease: str, jit_path: Path, *, metadata: dict[st
         try:
             helper(cfg, "launch", lease, stdin=jit)
         except Exception:
-            store.remove(lease)
+            # The socket may close while the root-side mutation is still being
+            # terminated. Keep the cleanup obligation durable so the next
+            # reconcile destroys both a possible domain and its lease files.
+            state["phase"] = "provisioning_failed"
+            store.write(lease, state)
             raise
         state["phase"] = "running"
         store.write(lease, state)
@@ -345,6 +424,8 @@ def destroy(cfg: dict[str, Any], lease: str, client: GitHubClient | None = None)
             raise
         else:
             store.remove(lease)
+            if isinstance(state.get("repo"), str) and isinstance(state.get("runner_id"), int):
+                store.remove_cleanup(state)
         LOG.info("destroy completed lease=%s", lease)
 
 
@@ -382,8 +463,11 @@ def reconcile(cfg: dict[str, Any], client: GitHubClient | None = None) -> None:
         states = {item["lease"]: item for item in store.leases() if "lease" in item}
         expired = {lease for lease, state in states.items()
                    if int(state.get("launched_at", 0)) + int(cfg["max_lease_seconds"]) < now}
-        running = {lease for lease, state in domains.items() if state == "running"} - expired
-        for lease in sorted(known - running):
+        healthy = {
+            lease for lease, domain_state in domains.items()
+            if domain_state == "running" and states.get(lease, {}).get("phase") == "running"
+        } - expired
+        for lease in sorted(known - healthy):
             LOG.warning("cleaning completed or missing domain lease=%s", lease)
             helper(cfg, "destroy", lease)
             try:
@@ -393,6 +477,9 @@ def reconcile(cfg: dict[str, Any], client: GitHubClient | None = None) -> None:
                 store.defer_cleanup(lease, states[lease], now)
             else:
                 store.remove(lease)
+                if isinstance(states[lease].get("repo"), str) \
+                        and isinstance(states[lease].get("runner_id"), int):
+                    store.remove_cleanup(states[lease])
         for lease in sorted(set(domains) - known):
             LOG.warning("destroying orphan domain lease=%s", lease)
             helper(cfg, "destroy", lease)
@@ -435,11 +522,8 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                     else:
                         store.remove_cleanup(registration)
                 raise RunnerError("GitHub returned an invalid JIT response")
-            jit_path = Path(cfg.get("runtime_dir", "/run/ci-runner-manager")) / f"{lease}.jit"
             try:
-                jit_path.write_text(encoded, encoding="utf-8")
-                os.chmod(jit_path, 0o600)
-                launch(cfg, lease, jit_path, metadata={
+                launch(cfg, lease, encoded.encode("ascii"), metadata={
                     "repo": repo,
                     "runner_id": runner_id,
                     "run_id": job["run_id"],
@@ -461,12 +545,10 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                         "runner_id": runner_id,
                         "run_id": job["run_id"],
                         "job_id": job["job_id"],
-                    }, int(time.time()))
+                    }, int(time.time()), preserve_lease=True)
                 else:
                     store.remove_cleanup(registration)
                 raise
-            finally:
-                jit_path.unlink(missing_ok=True)
     return False
 
 

--- a/runner/sudoers/ci-runner-manager
+++ b/runner/sudoers/ci-runner-manager
@@ -1,2 +1,0 @@
-Defaults:ci-runner-manager env_reset,secure_path=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/libexec
-ci-runner-manager ALL=(root) NOPASSWD: /usr/local/libexec/ci-runner-host-helper *

--- a/runner/systemd/ci-runner-host-helper.socket
+++ b/runner/systemd/ci-runner-host-helper.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=Sanctuary CI root helper socket
+
+[Socket]
+ListenSequentialPacket=/run/ci-runner-host-helper.sock
+Accept=yes
+MaxConnections=4
+SocketUser=ci-runner-manager
+SocketMode=0600
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target

--- a/runner/systemd/ci-runner-host-helper@.service
+++ b/runner/systemd/ci-runner-host-helper@.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Sanctuary CI root helper connection
+Requires=ci-runner-host-helper.socket
+After=libvirtd.service
+
+[Service]
+Type=exec
+User=root
+Group=root
+ExecStart=/usr/local/libexec/ci-runner-host-helper serve
+StandardInput=socket
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+RuntimeMaxSec=300s
+UMask=0077
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+ReadWritePaths=/mnt/ssd1000-01/ci-runner /run/lock
+RestrictAddressFamilies=AF_UNIX

--- a/runner/systemd/ci-runner-manager.service
+++ b/runner/systemd/ci-runner-manager.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Sanctuary CI runner reconciler
-After=network-online.target libvirtd.service sanctuary-ci-firewall.service
+After=network-online.target libvirtd.service sanctuary-ci-firewall.service ci-runner-host-helper.socket
 Wants=network-online.target
-Requires=libvirtd.service sanctuary-ci-firewall.service
+Requires=libvirtd.service sanctuary-ci-firewall.service ci-runner-host-helper.socket
 ConditionPathExists=/etc/ci-runner/github.token
 
 [Service]
@@ -17,7 +17,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/ci-runner-manager /run/lock /mnt/hdd1000-01/ci-audit
+ReadWritePaths=/var/lib/ci-runner-manager /run/ci-runner-manager /mnt/hdd1000-01/ci-audit
 RuntimeDirectory=ci-runner-manager
 RuntimeDirectoryMode=0700
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -1,4 +1,9 @@
+import base64
+import contextlib
+import io
+import json
 from pathlib import Path
+import struct
 import tempfile
 import unittest
 from unittest import mock
@@ -7,6 +12,18 @@ import ci_runner_host_helper as helper
 
 
 class HostHelperTests(unittest.TestCase):
+    request_id = "a" * 32
+
+    @staticmethod
+    def decoded_response(connection):
+        return json.loads(connection.sendall.call_args.args[0])
+
+    @staticmethod
+    def connection_for_uid(uid):
+        connection = mock.Mock()
+        connection.getsockopt.return_value = struct.pack("3i", 123, uid, 456)
+        return connection
+
     def test_domain_name_is_namespaced(self):
         self.assertEqual(helper.name("job-9"), "sanctuary-ci-job-9")
 
@@ -18,11 +35,11 @@ class HostHelperTests(unittest.TestCase):
     @mock.patch.object(helper, "run")
     @mock.patch.object(helper, "resolved_base_image")
     @mock.patch.object(helper.os, "geteuid", return_value=0)
-    def test_launch_rejects_existing_domain_before_reading_secret(self, _euid, image, run):
+    def test_launch_rejects_existing_domain_before_mutation(self, _euid, image, run):
         image.return_value = mock.Mock()
         run.return_value = mock.Mock(stdout="sanctuary-ci-existing\n")
         with self.assertRaisesRegex(RuntimeError, "domain already exists"):
-            helper.launch("new")
+            helper.launch("new", b"aml0")
 
     @mock.patch.object(helper.Path, "is_file", return_value=True)
     @mock.patch.object(helper.Path, "resolve")
@@ -50,8 +67,115 @@ class HostHelperTests(unittest.TestCase):
         self.assertIn(mock.call([
             "systemd-run", "--unit", "sanctuary-ci-expire-lease",
             "--on-active", "7200s", "--timer-property", "AccuracySec=30s",
+            "--property=NoNewPrivileges=yes", "--property=ProtectSystem=strict",
+            "--property=ProtectHome=yes", "--property=PrivateTmp=yes",
+            "--property=ReadWritePaths=/mnt/ssd1000-01/ci-runner /run/lock",
+            "--property=RestrictAddressFamilies=AF_UNIX",
             "/usr/local/libexec/ci-runner-host-helper", "destroy", "lease",
         ]), run.call_args_list)
+
+    def test_serve_rejects_untrusted_peer_before_reading_request(self):
+        connection = self.connection_for_uid(1001)
+
+        helper.serve_connection(connection, expected_uid=1002)
+
+        connection.recv.assert_not_called()
+        self.assertEqual(self.decoded_response(connection)["error"], "unauthorized")
+
+    def test_parse_request_enforces_exact_operation_schemas(self):
+        valid = [
+            {"v": 1, "id": self.request_id, "op": "list"},
+            {"v": 1, "id": self.request_id, "op": "launch", "lease": "job-1"},
+            {"v": 1, "id": self.request_id, "op": "destroy", "lease": "job-1"},
+        ]
+        for request in valid:
+            with self.subTest(request=request):
+                self.assertEqual(helper.parse_request(json.dumps(request).encode()), request)
+
+        invalid = [
+            {"v": True, "id": self.request_id, "op": "list"},
+            {"v": 1, "id": self.request_id.upper(), "op": "list"},
+            {"v": 1, "id": self.request_id, "op": "unknown"},
+            {"v": 1, "id": self.request_id, "op": "list", "lease": "extra"},
+            {"v": 1, "id": self.request_id, "op": "destroy"},
+            {"v": 1, "id": self.request_id, "op": "launch", "lease": "../escape"},
+            {"v": 1, "id": self.request_id, "op": "list", "extra": False},
+        ]
+        for request in invalid:
+            with self.subTest(request=request), self.assertRaises(helper.ProtocolError):
+                helper.parse_request(json.dumps(request).encode())
+        duplicate = ('{"v":1,"id":"' + self.request_id +
+                     '","op":"list","op":"list"}').encode()
+        with self.assertRaises(helper.ProtocolError):
+            helper.parse_request(duplicate)
+
+    def test_request_and_jit_packets_are_size_limited(self):
+        with self.assertRaises(helper.ProtocolError):
+            helper.parse_request(b"x" * (helper.MAX_REQUEST_BYTES + 1))
+        with self.assertRaises(helper.ProtocolError):
+            helper.validate_jit_payload(b"Y" * (helper.MAX_JIT_BYTES + 1))
+
+    @mock.patch.object(helper, "launch")
+    def test_serve_passes_validated_raw_jit_packet_to_launch(self, launch):
+        connection = self.connection_for_uid(1002)
+        request = {"v": 1, "id": self.request_id, "op": "launch", "lease": "job-1"}
+        jit = base64.b64encode(b"ephemeral registration material")
+        connection.recv.side_effect = [json.dumps(request).encode(), jit]
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(helper, "HELPER_LOCK", Path(directory) / "helper.lock"):
+            helper.serve_connection(connection, expected_uid=1002)
+
+        launch.assert_called_once_with("job-1", jit)
+        self.assertEqual(connection.settimeout.call_args_list, [mock.call(5.0), mock.call(None)])
+        self.assertEqual(self.decoded_response(connection), {
+            "v": 1, "id": self.request_id, "ok": True, "result": None,
+        })
+
+    @mock.patch.object(helper, "launch")
+    def test_serve_validates_jit_before_launch_mutation(self, launch):
+        connection = self.connection_for_uid(1002)
+        request = {"v": 1, "id": self.request_id, "op": "launch", "lease": "job-1"}
+        connection.recv.side_effect = [json.dumps(request).encode(), b"not base64!!"]
+
+        helper.serve_connection(connection, expected_uid=1002)
+
+        launch.assert_not_called()
+        self.assertEqual(self.decoded_response(connection)["error"], "invalid_request")
+        self.assertEqual(self.decoded_response(connection)["id"], self.request_id)
+
+    @mock.patch.object(helper, "launch")
+    def test_operation_errors_are_sanitized_in_response(self, launch):
+        connection = self.connection_for_uid(1002)
+        request = {"v": 1, "id": self.request_id, "op": "launch", "lease": "job-1"}
+        secret = "sensitive-jit-material"
+        connection.recv.side_effect = [json.dumps(request).encode(), base64.b64encode(b"jit")]
+        launch.side_effect = RuntimeError(secret)
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(helper, "HELPER_LOCK", Path(directory) / "helper.lock"), \
+                contextlib.redirect_stderr(io.StringIO()) as stderr:
+            helper.serve_connection(connection, expected_uid=1002)
+
+        encoded = connection.sendall.call_args.args[0]
+        self.assertNotIn(secret.encode(), encoded)
+        self.assertNotIn(secret, stderr.getvalue())
+        self.assertIn("RuntimeError", stderr.getvalue())
+        self.assertEqual(json.loads(encoded)["error"], "operation_failed")
+
+    @mock.patch.object(helper, "run")
+    def test_libvirt_commands_use_explicit_system_uri(self, run):
+        run.return_value = mock.Mock(stdout="")
+        helper.list_leases()
+        helper.destroy("lease")
+
+        for call in run.call_args_list:
+            command = call.args[0]
+            if command[0] == "virsh":
+                self.assertEqual(command[1:3], ["--connect", "qemu:///system"])
+
+    def test_response_falls_back_when_result_exceeds_packet_limit(self):
+        encoded = helper.encode_response(self.request_id, result="x" * helper.MAX_RESPONSE_BYTES)
+        self.assertLessEqual(len(encoded), helper.MAX_RESPONSE_BYTES)
+        self.assertEqual(json.loads(encoded)["error"], "operation_failed")
 
 
 if __name__ == "__main__":

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -6,12 +6,81 @@ import unittest
 from unittest import mock
 import json
 import io
+import subprocess
 import urllib.error
 
 import ci_runner_manager as manager
 
 
 class ManagerTests(unittest.TestCase):
+    def helper_connection(self, response):
+        connection = mock.MagicMock()
+        connection.__enter__.return_value = connection
+        packets = []
+        connection.send.side_effect = lambda packet: packets.append(packet) or len(packet)
+        connection.recvmsg.return_value = (
+            json.dumps(response, separators=(",", ":")).encode("utf-8"), [], 0, None
+        )
+        return connection, packets
+
+    @mock.patch.object(manager.secrets, "token_hex", return_value="a" * 32)
+    @mock.patch.object(manager.socket, "socket")
+    def test_helper_list_uses_bounded_seqpacket_protocol(self, socket_factory, _token):
+        connection, packets = self.helper_connection(
+            {"v": 1, "id": "a" * 32, "ok": True, "result": {"lease": "running"}}
+        )
+        socket_factory.return_value = connection
+        result = manager.helper({"helper_socket": "/run/helper.sock"}, "list")
+        self.assertEqual(json.loads(result.stdout), {"lease": "running"})
+        request = json.loads(packets[0])
+        self.assertEqual(set(request), {"v", "id", "op"})
+        self.assertEqual(request["op"], "list")
+
+    @mock.patch.object(manager.secrets, "token_hex", return_value="b" * 32)
+    @mock.patch.object(manager.socket, "socket")
+    def test_helper_launch_sends_jit_as_separate_packet(self, socket_factory, _token):
+        connection, packets = self.helper_connection(
+            {"v": 1, "id": "b" * 32, "ok": True, "result": None}
+        )
+        socket_factory.return_value = connection
+        jit = base64.b64encode(b"opaque-jit")
+        manager.helper({"helper_socket": "/run/helper.sock"}, "launch", "lease-1", stdin=jit)
+        self.assertEqual(packets[1], jit)
+        self.assertNotIn(jit, packets[0])
+
+    @mock.patch.object(manager.secrets, "token_hex", return_value="c" * 32)
+    @mock.patch.object(manager.socket, "socket")
+    def test_helper_failure_exposes_only_allowlisted_code(self, socket_factory, _token):
+        connection, _packets = self.helper_connection(
+            {"v": 1, "id": "c" * 32, "ok": False, "error": "operation_failed"}
+        )
+        socket_factory.return_value = connection
+        with self.assertRaises(subprocess.CalledProcessError) as raised:
+            manager.helper({"helper_socket": "/run/helper.sock"}, "list")
+        self.assertEqual(raised.exception.stderr, b"operation_failed")
+
+    @mock.patch.object(manager.secrets, "token_hex", return_value="d" * 32)
+    @mock.patch.object(manager.socket, "socket")
+    def test_helper_rejects_mismatched_response_id(self, socket_factory, _token):
+        connection, _packets = self.helper_connection(
+            {"v": 1, "id": "e" * 32, "ok": True, "result": {}}
+        )
+        socket_factory.return_value = connection
+        with self.assertRaisesRegex(manager.RunnerError, "invalid response"):
+            manager.helper({"helper_socket": "/run/helper.sock"}, "list")
+
+    @mock.patch.object(manager.secrets, "token_hex", return_value="f" * 32)
+    @mock.patch.object(manager.socket, "socket")
+    def test_helper_rejects_duplicate_response_members(self, socket_factory, _token):
+        connection, _packets = self.helper_connection({})
+        connection.recvmsg.return_value = (
+            ('{"v":1,"id":"' + "f" * 32 +
+             '","ok":true,"ok":true,"result":{}}').encode("utf-8"), [], 0, None
+        )
+        socket_factory.return_value = connection
+        with self.assertRaisesRegex(manager.RunnerError, "invalid response"):
+            manager.helper({"helper_socket": "/run/helper.sock"}, "list")
+
     def test_token_file_requires_private_permissions_outside_systemd_credentials(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "github.token"
@@ -104,6 +173,31 @@ class ManagerTests(unittest.TestCase):
             with self.assertRaisesRegex(manager.RunnerError, "domain already exists"):
                 manager.launch(cfg, "new-job", jit)
 
+    @mock.patch.object(manager, "capacity_errors", return_value=[])
+    @mock.patch.object(manager, "helper")
+    def test_failed_launch_keeps_durable_cleanup_state(self, helper, _capacity):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            helper.side_effect = [
+                mock.Mock(stdout=b"{}"),
+                manager.RunnerError("ambiguous launch completion"),
+            ]
+
+            with self.assertRaisesRegex(manager.RunnerError, "ambiguous"):
+                manager.launch(cfg, "new-job", base64.b64encode(b"opaque"))
+
+            states = manager.StateStore(cfg["state_dir"]).leases()
+            self.assertEqual(states[0]["lease"], "new-job")
+            self.assertEqual(states[0]["phase"], "provisioning_failed")
+
+            helper.side_effect = [mock.Mock(stdout=b'{"new-job":"running"}'), mock.Mock()]
+            manager.reconcile(cfg)
+            self.assertEqual(manager.StateStore(cfg["state_dir"]).leases(), [])
+            self.assertIn(("destroy", "new-job"),
+                          [call.args[1:] for call in helper.call_args_list])
+
     def test_candidate_jobs_filter_status_and_label(self):
         client = manager.GitHubClient("secret")
         client.request = mock.Mock(side_effect=[
@@ -183,9 +277,10 @@ class ManagerTests(unittest.TestCase):
                 mock.ANY,
                 metadata={"repo": "Tuinstra-DEV/gate", "runner_id": 30, "run_id": 10, "job_id": 20},
             )
+            self.assertEqual(launch.call_args.args[2], base64.b64encode(b"jit"))
+            self.assertEqual(list((root / "run").iterdir()), [])
 
-    @mock.patch.object(manager, "launch", side_effect=manager.RunnerError("launch failed"))
-    def test_dispatch_defers_runner_cleanup_when_launch_and_delete_fail(self, _launch):
+    def test_dispatch_preserves_host_cleanup_when_launch_and_delete_fail(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             client = mock.Mock()
@@ -199,12 +294,21 @@ class ManagerTests(unittest.TestCase):
                    "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
             (root / "run").mkdir()
 
-            with self.assertRaisesRegex(manager.RunnerError, "launch failed"):
+            def ambiguous_launch(launch_cfg, lease, _jit, *, metadata=None):
+                state = {"lease": lease, "phase": "provisioning_failed", "launched_at": 1}
+                state.update(metadata or {})
+                manager.StateStore(Path(launch_cfg["state_dir"])).write(lease, state)
+                raise manager.RunnerError("launch failed")
+
+            with mock.patch.object(manager, "launch", side_effect=ambiguous_launch), \
+                    self.assertRaisesRegex(manager.RunnerError, "launch failed"):
                 manager.dispatch_once(cfg, client)
 
-            cleanup = manager.StateStore(root / "state").cleanup_items()
+            store = manager.StateStore(root / "state")
+            cleanup = store.cleanup_items()
             self.assertEqual(cleanup[0]["repo"], "Tuinstra-DEV/gate")
             self.assertEqual(cleanup[0]["runner_id"], 30)
+            self.assertEqual(store.leases()[0]["phase"], "provisioning_failed")
 
     @mock.patch.object(manager, "launch", side_effect=manager.RunnerError("launch failed"))
     def test_repeated_failed_job_registrations_keep_distinct_cleanup_obligations(self, _launch):

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+assert_absent() {
+  local pattern="$1"
+  local file="$2"
+  if grep -q -- "$pattern" "$file"; then
+    echo "unexpected pattern in $file: $pattern" >&2
+    return 1
+  fi
+}
+
 python3 -c 'import ast,pathlib; [ast.parse(p.read_text()) for root in ("runner/manager", "runner/host-helper", "runner/tests") for p in pathlib.Path(root).glob("*.py")]'
 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="runner/manager:runner/host-helper" python3 -B -m unittest discover -s runner/tests -v
 bash -n infra/packer/scripts/install-runner.sh infra/packer/scripts/seal-image.sh \
@@ -25,6 +34,9 @@ grep -q 'DISK_GIB = "120G"' runner/host-helper/ci_runner_host_helper.py
 grep -q 'concurrency is 1' runner/manager/ci_runner_manager.py
 grep -q 'max_lease_seconds = 7200' runner/config/manager.toml
 grep -q '^RuntimeMaxSec=7200$' runner/systemd/ci-runner-job.service
+grep -q '^RuntimeMaxSec=300s$' runner/systemd/ci-runner-host-helper@.service
+grep -q '^MaxConnections=4$' runner/systemd/ci-runner-host-helper.socket
+grep -q '^HELPER_MUTATION_TIMEOUT_SECONDS = 330$' runner/manager/ci_runner_manager.py
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml
@@ -37,21 +49,21 @@ grep -q 'net-list --all --persistent --name' infra/ansible/roles/runner_host/tas
 grep -q 'net-list --all --autostart --name' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'readlink.*runner_network_autostart_link' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'refusing unexpected runner autostart entry' infra/ansible/roles/runner_host/tasks/main.yml
-! grep -q 'when: runner_network_definition.changed' infra/ansible/roles/runner_host/tasks/main.yml
+assert_absent 'when: runner_network_definition.changed' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q '<uuid>.*runner_network_uuid.*</uuid>' infra/ansible/roles/runner_host/tasks/main.yml
-! grep -q 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
-! grep -q 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
+assert_absent 'virsh net-undefine sanctuary-ci' infra/ansible/roles/runner_host/tasks/main.yml
+assert_absent 'dest: /etc/libvirt/qemu/networks/sanctuary-ci.xml' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'required_version = "= 1.15.4"' infra/packer/sanctuary-runner.pkr.hcl
 grep -q 'version = "= 1.1.6"' infra/packer/sanctuary-runner.pkr.hcl
 test "$(grep -c "execute_command.*sudo -S env" infra/packer/sanctuary-runner.pkr.hcl)" -eq 3
 grep -q "shutdown_command.*passwd --lock packer.*systemctl poweroff" infra/packer/sanctuary-runner.pkr.hcl
-! grep -q 'passwd --lock packer' infra/packer/scripts/seal-image.sh
+assert_absent 'passwd --lock packer' infra/packer/scripts/seal-image.sh
 grep -q 'packer_linux_amd64_sha256=15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1' infra/packer/toolchain.lock
 grep -q 'qemu_plugin_linux_amd64_sha256=3f735539fbdd0368785babda272b85738866f736415dce59d04b4cb550c4db87' infra/packer/toolchain.lock
 grep -q 'Tuinstra-DEV/tuinstra-site' runner/config/manager.toml
-! grep -q 'Tuinstra-DEV/devops' runner/config/manager.toml
+assert_absent 'Tuinstra-DEV/devops' runner/config/manager.toml
 grep -q '88.159.77.149/32' infra/ansible/inventory/hosts.example.yml
-! grep -q 'nftables.service' infra/ansible/roles/runner_host/tasks/main.yml
+assert_absent 'nftables.service' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'docker buildx version' infra/packer/scripts/verify-image-contract.sh
 grep -q "node --version.*v24" infra/packer/scripts/verify-image-contract.sh
 grep -q 'php8.3' infra/packer/scripts/verify-image-contract.sh
@@ -59,12 +71,26 @@ grep -q 'php8.4' infra/packer/scripts/verify-image-contract.sh
 grep -q 'B8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' infra/packer/scripts/install-runner.sh
 grep -q 'keys/ondrej-php.asc' infra/packer/sanctuary-runner.pkr.hcl
 test "$(shasum -a 256 infra/packer/keys/ondrej-php.asc | awk '{print $1}')" = '7258b1cb18300b87cd5668a6d64ce78184d9c0e129382879a0d79291c4ef463d'
-! grep -q 'keyserver.ubuntu.com' infra/packer/scripts/install-runner.sh
+assert_absent 'keyserver.ubuntu.com' infra/packer/scripts/install-runner.sh
 grep -q 'playwright install --with-deps chromium' infra/packer/scripts/install-runner.sh
 grep -q 'exec ./run.sh --jitconfig' runner/guest/run-jit-runner.sh
 grep -q 'ExecStopPost=+/usr/bin/systemctl poweroff' runner/systemd/ci-runner-job.service
 grep -q '^Restart=no$' runner/systemd/ci-runner-job.service
-! grep -q 'run.sh --jitconfig' runner/systemd/ci-runner-job.service
+grep -q '^NoNewPrivileges=yes$' runner/systemd/ci-runner-job.service
+grep -q '^NoNewPrivileges=yes$' runner/systemd/ci-runner-manager.service
+grep -q '^NoNewPrivileges=yes$' runner/systemd/ci-runner-host-helper@.service
+grep -q '^ListenSequentialPacket=/run/ci-runner-host-helper.sock$' runner/systemd/ci-runner-host-helper.socket
+grep -q '^SocketUser=ci-runner-manager$' runner/systemd/ci-runner-host-helper.socket
+grep -q '^SocketMode=0600$' runner/systemd/ci-runner-host-helper.socket
+grep -q 'SO_PEERCRED' runner/host-helper/ci_runner_host_helper.py
+grep -q 'helper_socket = "/run/ci-runner-host-helper.sock"' runner/config/manager.toml
+assert_absent 'sudo' runner/manager/ci_runner_manager.py
+if [ -e infra/ansible/roles/runner_host/templates/ci-runner-manager.sudoers.j2 ] ||
+   [ -e runner/sudoers/ci-runner-manager ]; then
+  echo "obsolete runner sudoers policy remains" >&2
+  exit 1
+fi
+assert_absent 'run.sh --jitconfig' runner/systemd/ci-runner-job.service
 if grep -Eq 'curl[^|]*\|[[:space:]]*(ba)?sh' infra/packer/scripts/install-runner.sh; then
   echo "image install must not pipe downloads to a shell" >&2
   exit 1


### PR DESCRIPTION
## Summary

- replace the manager's wildcard sudo boundary with a root-owned, socket-activated host helper
- authenticate the manager UID with `SO_PEERCRED` and use a strict bounded `SOCK_SEQPACKET` protocol
- keep launch and GitHub cleanup obligations durable across ambiguous timeouts
- remove obsolete sudoers policy and deploy/enable the socket through Ansible
- document and test the hardened lifecycle boundary

## Security controls

- manager retains `NoNewPrivileges=yes`
- socket is owned by `ci-runner-manager` with mode `0600`
- JIT data is sent in-memory in a separate bounded packet and never included in errors or logs
- helper errors expose only allowlisted codes
- helper lifetime is bounded to 300 seconds; manager mutation timeout is 330 seconds
- interrupted provisioning is reconciled even if a domain became active

## Verification

- `make lint`
- `make test` (46 tests)
- runner platform contract checks
- workflow contract checks
- `git diff --check`

Tracker: DEV-1
