### PR TITLE
fix(runner): add safe host command diagnostics

### DIFF
--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -40,12 +40,25 @@ MAX_JIT_BYTES = 131072
 MAX_RESPONSE_BYTES = 65536
 REQUEST_ID_RE = re.compile(r"^[a-f0-9]{32}$")
 ERROR_CODES = frozenset({"invalid_request", "unauthorized", "operation_failed", "busy"})
+DIAGNOSTIC_COMMANDS = frozenset({
+    "cloud-localds", "qemu-img", "systemctl", "systemd-run", "virsh", "virt-install",
+})
 UNKNOWN_REQUEST_ID = "0" * 32
 SO_PEERCRED = getattr(socket, "SO_PEERCRED", 17)
 
 
 class ProtocolError(ValueError):
     """A request error that is safe to represent with a generic code."""
+
+
+class HostCommandError(RuntimeError):
+    """A host command failure containing only allowlisted diagnostic metadata."""
+
+    def __init__(self, command_name: str, returncode: int | str) -> None:
+        safe_name = Path(command_name).name
+        self.command_name = safe_name if safe_name in DIAGNOSTIC_COMMANDS else "unknown"
+        self.returncode = returncode if isinstance(returncode, int) else "timeout"
+        super().__init__(f"{self.command_name} rc={self.returncode}")
 
 
 def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -58,8 +71,13 @@ def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 
 
 def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, check=check, text=True, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE, timeout=90)
+    try:
+        return subprocess.run(command, check=check, text=True, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, timeout=90)
+    except subprocess.CalledProcessError as exc:
+        raise HostCommandError(command[0], exc.returncode) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HostCommandError(command[0], "timeout") from exc
 
 
 def validate_lease(value: str) -> str:
@@ -284,6 +302,9 @@ def serve_connection(connection: socket.socket, *, expected_uid: int | None = No
     except ProtocolError as exc:
         print(f"ci-runner-host-helper: {exc}", file=sys.stderr)
         response = encode_response(request_id, error="invalid_request")
+    except HostCommandError as exc:
+        print(f"ci-runner-host-helper: command failed: {exc}", file=sys.stderr)
+        response = encode_response(request_id, error="operation_failed")
     except Exception as exc:
         print(f"ci-runner-host-helper: operation failed: {type(exc).__name__}", file=sys.stderr)
         response = encode_response(request_id, error="operation_failed")
@@ -320,6 +341,9 @@ def main() -> int:
             else:
                 print(json.dumps(list_leases(), sort_keys=True))
         return 0
+    except HostCommandError as exc:
+        print(f"ci-runner-host-helper: command failed: {exc}", file=sys.stderr)
+        return 1
     except Exception as exc:
         print(f"ci-runner-host-helper: operation failed: {type(exc).__name__}", file=sys.stderr)
         return 1

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -161,6 +161,26 @@ class HostHelperTests(unittest.TestCase):
         self.assertIn("RuntimeError", stderr.getvalue())
         self.assertEqual(json.loads(encoded)["error"], "operation_failed")
 
+    @mock.patch.object(helper.subprocess, "run")
+    def test_command_failure_keeps_output_secret_and_exposes_safe_stage(self, run):
+        secret = "sensitive-command-output"
+        run.side_effect = helper.subprocess.CalledProcessError(
+            7, ["virt-install"], output="ignored", stderr=secret
+        )
+
+        with self.assertRaises(helper.HostCommandError) as raised:
+            helper.run(["virt-install", "--connect", "qemu:///system"])
+
+        self.assertEqual(raised.exception.command_name, "virt-install")
+        self.assertEqual(raised.exception.returncode, 7)
+        self.assertNotIn(secret, str(raised.exception))
+
+    def test_command_diagnostic_rejects_unknown_name_and_normalizes_timeout(self):
+        error = helper.HostCommandError("untrusted-command-name", "anything")
+        self.assertEqual(error.command_name, "unknown")
+        self.assertEqual(error.returncode, "timeout")
+        self.assertEqual(str(error), "unknown rc=timeout")
+
     @mock.patch.object(helper, "run")
     def test_libvirt_commands_use_explicit_system_uri(self, run):
         run.return_value = mock.Mock(stdout="")


### PR DESCRIPTION
## Summary

- report only an allowlisted host command basename and return code when a runner launch fails
- keep subprocess arguments, stdout, stderr and JIT material out of journald and manager responses
- normalize timeouts and unknown command names to bounded diagnostic values

## Context

The first `notify` trusted-heavy canary failed closed and cleaned up correctly, but the deliberately generic helper error did not identify which host command failed. This change provides the minimum safe diagnostic needed to fix the host incompatibility.

## Verification

- `make lint`
- `make test` (48 tests)
- runner platform and workflow contract checks
- security review: no blockers
- `git diff --check`

Tracker: DEV-1
