### PR TITLE
fix(runner): grant QEMU minimal disk access

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -65,8 +65,9 @@ fork pull requests select this machine.
 - Admission requires at least 8 host logical CPUs, 14 GiB available memory,
   140 GiB free on `/mnt/ssd1000-01/ci-runner`, and one-minute load no higher
   than 8. Thresholds are configurable; VM dimensions are root-helper constants.
-- The base image is root-owned and mode `0444`. Per-job files live in a mode
-  `0700` lease directory.
+- The base image is root-owned and mode `0444`. The overlay root and per-job
+  lease directories are root-owned, group `kvm`, and mode `0710`. Only the
+  isolated `libvirt-qemu` account owns the mode `0600` overlay and seed images.
 - A running lease older than `max_lease_seconds` (default 7,200 seconds) is
   destroyed by reconciliation even if libvirt still reports it running.
 

--- a/infra/ansible/roles/runner_host/tasks/main.yml
+++ b/infra/ansible/roles/runner_host/tasks/main.yml
@@ -59,7 +59,7 @@
     - { path: /usr/local/libexec, owner: root, group: root, mode: '0755' }
     - { path: /var/lib/ci-runner/images, owner: root, group: root, mode: '0755' }
     - { path: /var/lib/ci-runner-manager/state, owner: ci-runner-manager, group: ci-runner-manager, mode: '0700' }
-    - { path: /mnt/ssd1000-01/ci-runner, owner: root, group: root, mode: '0700' }
+    - { path: /mnt/ssd1000-01/ci-runner, owner: root, group: kvm, mode: '0710' }
     - { path: /mnt/hdd1000-01/ci-audit, owner: ci-runner-manager, group: ci-runner-manager, mode: '0750' }
 
 - name: Inspect root-provisioned GitHub credential

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -7,9 +7,11 @@ import argparse
 import base64
 import binascii
 import fcntl
+import grp
 import json
 import os
 from pathlib import Path
+import pwd
 import re
 import shutil
 import socket
@@ -34,6 +36,8 @@ MAX_LEASE_SECONDS = "7200"
 HELPER_LOCK = Path("/run/lock/ci-runner-host-helper.lock")
 HELPER_PATH = "/usr/local/libexec/ci-runner-host-helper"
 MANAGER_USER = "ci-runner-manager"
+QEMU_USER = "libvirt-qemu"
+QEMU_GROUP = "kvm"
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 4096
 MAX_JIT_BYTES = 131072
@@ -104,6 +108,19 @@ def resolved_base_image() -> Path:
     return image
 
 
+def qemu_identity() -> tuple[int, int]:
+    user = pwd.getpwnam(QEMU_USER)
+    group = grp.getgrnam(QEMU_GROUP)
+    if user.pw_gid != group.gr_gid:
+        raise RuntimeError("libvirt QEMU primary group does not match configured group")
+    return user.pw_uid, group.gr_gid
+
+
+def set_qemu_access(path: Path, uid: int, gid: int, mode: int) -> None:
+    os.chown(path, uid, gid)
+    os.chmod(path, mode)
+
+
 def validate_jit_payload(encoded_jit: bytes) -> bytes:
     if not encoded_jit or len(encoded_jit) > MAX_JIT_BYTES:
         raise ProtocolError("invalid JIT configuration size")
@@ -131,8 +148,11 @@ def launch(lease: str, encoded_jit: bytes | None = None) -> None:
     directory.mkdir(mode=0o700)
     overlay = directory / "root.qcow2"
     seed = directory / "seed.iso"
+    qemu_uid, qemu_gid = qemu_identity()
+    set_qemu_access(directory, 0, qemu_gid, 0o710)
     try:
         run(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", str(base_image), str(overlay), DISK_GIB])
+        set_qemu_access(overlay, qemu_uid, qemu_gid, 0o600)
         user_data = """#cloud-config
 bootcmd:
   - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
@@ -152,6 +172,7 @@ runcmd:
             (temp / "meta-data").write_text(meta_data, encoding="utf-8")
             os.chmod(temp / "user-data", 0o600)
             run(["cloud-localds", str(seed), str(temp / "user-data"), str(temp / "meta-data")])
+        set_qemu_access(seed, qemu_uid, qemu_gid, 0o600)
         run(["virt-install", "--connect", LIBVIRT_URI,
              "--name", name(lease), "--memory", MEMORY_MIB, "--vcpus", VCPUS,
              "--cpu", "host-passthrough", "--import", "--noautoconsole", "--os-variant", "ubuntu24.04",
@@ -271,7 +292,6 @@ def serve_connection(connection: socket.socket, *, expected_uid: int | None = No
     request_id = UNKNOWN_REQUEST_ID
     try:
         if expected_uid is None:
-            import pwd
             expected_uid = pwd.getpwnam(MANAGER_USER).pw_uid
         _pid, uid, _gid = peer_credentials(connection)
         if uid != expected_uid:

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -61,8 +61,17 @@ class HostHelperTests(unittest.TestCase):
             image.return_value = helper.IMAGE_ROOT / ("ubuntu-24.04-runner-" + "a" * 64 + ".qcow2")
             run.return_value = mock.Mock(stdout="")
             with mock.patch.object(helper, "lease_dir", return_value=Path(directory) / "lease"), \
-                    mock.patch.object(helper.sys, "stdin", stdin):
+                    mock.patch.object(helper.sys, "stdin", stdin), \
+                    mock.patch.object(helper, "qemu_identity", return_value=(64055, 994)), \
+                    mock.patch.object(helper, "set_qemu_access") as set_access:
                 helper.launch("lease")
+
+            lease = Path(directory) / "lease"
+            self.assertEqual(set_access.call_args_list, [
+                mock.call(lease, 0, 994, 0o710),
+                mock.call(lease / "root.qcow2", 64055, 994, 0o600),
+                mock.call(lease / "seed.iso", 64055, 994, 0o600),
+            ])
 
         self.assertIn(mock.call([
             "systemd-run", "--unit", "sanctuary-ci-expire-lease",
@@ -73,6 +82,14 @@ class HostHelperTests(unittest.TestCase):
             "--property=RestrictAddressFamilies=AF_UNIX",
             "/usr/local/libexec/ci-runner-host-helper", "destroy", "lease",
         ]), run.call_args_list)
+
+    @mock.patch.object(helper.os, "chmod")
+    @mock.patch.object(helper.os, "chown")
+    def test_qemu_access_sets_exact_owner_group_and_mode(self, chown, chmod):
+        path = Path("/runner/seed.iso")
+        helper.set_qemu_access(path, 64055, 994, 0o600)
+        chown.assert_called_once_with(path, 64055, 994)
+        chmod.assert_called_once_with(path, 0o600)
 
     def test_serve_rejects_untrusted_peer_before_reading_request(self):
         connection = self.connection_for_uid(1001)

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -37,6 +37,8 @@ grep -q '^RuntimeMaxSec=7200$' runner/systemd/ci-runner-job.service
 grep -q '^RuntimeMaxSec=300s$' runner/systemd/ci-runner-host-helper@.service
 grep -q '^MaxConnections=4$' runner/systemd/ci-runner-host-helper.socket
 grep -q '^HELPER_MUTATION_TIMEOUT_SECONDS = 330$' runner/manager/ci_runner_manager.py
+grep -q 'QEMU_USER = "libvirt-qemu"' runner/host-helper/ci_runner_host_helper.py
+grep -q "path: /mnt/ssd1000-01/ci-runner, owner: root, group: kvm, mode: '0710'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml
 grep -q "path: /usr/local/libexec.*owner: root.*group: root.*mode: '0755'" infra/ansible/roles/runner_host/tasks/main.yml


### PR DESCRIPTION
## Summary

- make the runner overlay root and lease directories root-owned, group `kvm`, mode `0710`
- resolve and validate the host's `libvirt-qemu:kvm` identity at launch time
- grant only `libvirt-qemu` mode `0600` access to each overlay and JIT-containing seed image
- document and statically test the DAC boundary

## Root cause

The first canaries failed closed at `virt-install`: QEMU runs as uid `libvirt-qemu` with primary group `kvm` and could not traverse the root-only runner directory or read its disk images.

## Security

- `kvm` receives traverse only, not directory listing or write access
- overlay and seed remain unreadable to other group members
- manager remains outside the `kvm` group and keeps `NoNewPrivileges=yes`
- root helper retains deterministic cleanup ownership

## Verification

- `make lint`
- `make test` (49 tests)
- runner platform and workflow contract checks
- live Sanctuary identity check: `libvirt-qemu` uid 64055, primary `kvm` gid 994
- security review: no blockers
- `git diff --check`

Tracker: DEV-1
