### PR TITLE
fix(runner): avoid cloud-final start deadlock

### DIFF
--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -131,6 +131,22 @@ def validate_jit_payload(encoded_jit: bytes) -> bytes:
     return encoded_jit
 
 
+def cloud_init_user_data(encoded_jit: bytes) -> str:
+    encoded_jit = validate_jit_payload(encoded_jit)
+    return """#cloud-config
+bootcmd:
+  - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
+write_files:
+  - path: /run/ci-runner/jit.config
+    owner: ci-runner:ci-runner
+    permissions: '0600'
+    encoding: b64
+    content: %s
+runcmd:
+  - [systemctl, start, --no-block, ci-runner-job.service]
+""" % base64.b64encode(encoded_jit).decode("ascii")
+
+
 def launch(lease: str, encoded_jit: bytes | None = None) -> None:
     if os.geteuid() != 0:
         raise PermissionError("helper must run as root")
@@ -153,18 +169,7 @@ def launch(lease: str, encoded_jit: bytes | None = None) -> None:
     try:
         run(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", str(base_image), str(overlay), DISK_GIB])
         set_qemu_access(overlay, qemu_uid, qemu_gid, 0o600)
-        user_data = """#cloud-config
-bootcmd:
-  - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
-write_files:
-  - path: /run/ci-runner/jit.config
-    owner: ci-runner:ci-runner
-    permissions: '0600'
-    encoding: b64
-    content: %s
-runcmd:
-  - [systemctl, start, ci-runner-job.service]
-""" % base64.b64encode(encoded_jit).decode("ascii")
+        user_data = cloud_init_user_data(encoded_jit)
         meta_data = f"instance-id: {name(lease)}\nlocal-hostname: ci-worker\n"
         with tempfile.TemporaryDirectory(dir=directory) as temporary:
             temp = Path(temporary)

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -27,6 +27,11 @@ class HostHelperTests(unittest.TestCase):
     def test_domain_name_is_namespaced(self):
         self.assertEqual(helper.name("job-9"), "sanctuary-ci-job-9")
 
+    def test_cloud_init_queues_runner_after_cloud_final_without_deadlock(self):
+        user_data = helper.cloud_init_user_data(base64.b64encode(b"opaque-jit"))
+        self.assertIn("- [systemctl, start, --no-block, ci-runner-job.service]", user_data)
+        self.assertNotIn("- [systemctl, start, ci-runner-job.service]", user_data)
+
     def test_lease_directory_cannot_escape_overlay_root(self):
         for value in ("../etc", "a/b", "white space", ""):
             with self.subTest(value=value), self.assertRaises(ValueError):

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -38,6 +38,7 @@ grep -q '^RuntimeMaxSec=300s$' runner/systemd/ci-runner-host-helper@.service
 grep -q '^MaxConnections=4$' runner/systemd/ci-runner-host-helper.socket
 grep -q '^HELPER_MUTATION_TIMEOUT_SECONDS = 330$' runner/manager/ci_runner_manager.py
 grep -q 'QEMU_USER = "libvirt-qemu"' runner/host-helper/ci_runner_host_helper.py
+grep -q '\[systemctl, start, --no-block, ci-runner-job.service\]' runner/host-helper/ci_runner_host_helper.py
 grep -q "path: /mnt/ssd1000-01/ci-runner, owner: root, group: kvm, mode: '0710'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml


### PR DESCRIPTION
## Summary

- generate the guest cloud-init payload through a tested helper
- enqueue `ci-runner-job.service` with `systemctl start --no-block`
- retain the unit's `After=cloud-final.service` ordering and all JIT protections

## Root cause

Cloud-init `runcmd` synchronously started a unit ordered after `cloud-final.service`. Cloud-final therefore waited for the runner unit while the runner unit waited for cloud-final, leaving the JIT runner offline in an otherwise healthy VM.

## Verification

- failing regression test reproduced before the fix
- `make lint`
- `make test` (50 tests)
- runner platform and workflow contract checks
- security review: no blockers
- `git diff --check`

Tracker: DEV-1
