### PR TITLE
fix(runner): permit exact JIT runtime files

### DIFF
--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -136,13 +136,24 @@ def cloud_init_user_data(encoded_jit: bytes) -> str:
     return """#cloud-config
 bootcmd:
   - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
+  - [install, -d, -o, root, -g, root, -m, '0755', /etc/systemd/system/ci-runner-job.service.d]
+  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.runner]
+  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials]
+  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials_rsaparams]
 write_files:
   - path: /run/ci-runner/jit.config
     owner: ci-runner:ci-runner
     permissions: '0600'
     encoding: b64
     content: %s
+  - path: /etc/systemd/system/ci-runner-job.service.d/10-jit-files.conf
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Service]
+      ReadWritePaths=/opt/actions-runner/.runner /opt/actions-runner/.credentials /opt/actions-runner/.credentials_rsaparams
 runcmd:
+  - [systemctl, daemon-reload]
   - [systemctl, start, --no-block, ci-runner-job.service]
 """ % base64.b64encode(encoded_jit).decode("ascii")
 

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -29,6 +29,10 @@ class HostHelperTests(unittest.TestCase):
 
     def test_cloud_init_queues_runner_after_cloud_final_without_deadlock(self):
         user_data = helper.cloud_init_user_data(base64.b64encode(b"opaque-jit"))
+        for filename in (".runner", ".credentials", ".credentials_rsaparams"):
+            self.assertIn(f"/opt/actions-runner/{filename}", user_data)
+        self.assertIn("ReadWritePaths=/opt/actions-runner/.runner /opt/actions-runner/.credentials /opt/actions-runner/.credentials_rsaparams", user_data)
+        self.assertIn("- [systemctl, daemon-reload]", user_data)
         self.assertIn("- [systemctl, start, --no-block, ci-runner-job.service]", user_data)
         self.assertNotIn("- [systemctl, start, ci-runner-job.service]", user_data)
 


### PR DESCRIPTION
## Summary

- precreate the three GitHub JIT runtime files as `ci-runner:ci-runner` mode `0600`
- add a root-owned systemd drop-in granting file-level writes to exactly those paths
- reload systemd before queueing the one-shot runner service

## Root cause

The official `actions/runner` implementation expands JIT configuration into `.runner`, `.credentials`, and `.credentials_rsaparams` in the runner root. The guest correctly kept that root immutable, but had not whitelisted these three runtime files, so the runner exited before accepting its job.

## Security

- runner binaries and the runner root remain read-only
- only three exact files are writable and each is mode `0600`
- credentials exist only in the one-job guest overlay
- poweroff plus host reconciliation destroys the overlay and seed

## Verification

- failing canary reproduced the write boundary
- official `actions/runner` source inspected for JIT behavior
- `make lint`
- `make test` (50 tests)
- platform/workflow contract checks
- security review: no blockers
- `git diff --check`

Tracker: DEV-1
