### PR TITLE
DEV-1 Support atomic JIT config refresh

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -68,6 +68,10 @@ fork pull requests select this machine.
 - The base image is root-owned and mode `0444`. The overlay root and per-job
   lease directories are root-owned, group `kvm`, and mode `0710`. Only the
   isolated `libvirt-qemu` account owns the mode `0600` overlay and seed images.
+- Inside each one-job guest, existing runner files remain root-owned and
+  non-writable. Cloud-init makes only the top-level runner directory sticky and
+  group-writable so upstream JIT configuration can atomically replace its own
+  mode `0600` runtime files; the entire overlay is destroyed after the job.
 - A running lease older than `max_lease_seconds` (default 7,200 seconds) is
   destroyed by reconciliation even if libvirt still reports it running.
 

--- a/infra/packer/scripts/verify-image-contract.sh
+++ b/infra/packer/scripts/verify-image-contract.sh
@@ -33,6 +33,15 @@ playwright --version
 trivy --version
 test -x /opt/actions-runner/run.sh
 test -x /usr/local/bin/run-jit-runner
+test "$(stat -c '%U:%G:%a' /opt/actions-runner)" = "root:root:755"
+unsafe_runner_entry="$(find /opt/actions-runner -xdev \
+  \( -path /opt/actions-runner/_diag -o -path /opt/actions-runner/_work \) -prune -o \
+  \( \( ! -user root -o ! -group root \) -o \( \( -type f -o -type d \) -perm /022 \) \) \
+  -print -quit)"
+test -z "$unsafe_runner_entry" || {
+  echo "image contract found mutable non-runtime runner entry: $unsafe_runner_entry" >&2
+  exit 1
+}
 test -d /opt/ms-playwright
 test -s /etc/ci-runner-image-manifest
 

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -140,6 +140,10 @@ bootcmd:
   - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.runner]
   - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials]
   - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials_rsaparams]
+  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.runner_migrated]
+  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials_migrated]
+  - [chown, root:ci-runner, /opt/actions-runner]
+  - [chmod, '1770', /opt/actions-runner]
 write_files:
   - path: /run/ci-runner/jit.config
     owner: ci-runner:ci-runner
@@ -151,7 +155,8 @@ write_files:
     permissions: '0644'
     content: |
       [Service]
-      ReadWritePaths=/opt/actions-runner/.runner /opt/actions-runner/.credentials /opt/actions-runner/.credentials_rsaparams
+      ReadWritePaths=/opt/actions-runner
+      UMask=0077
 runcmd:
   - [systemctl, daemon-reload]
   - [systemctl, start, --no-block, ci-runner-job.service]

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -29,9 +29,13 @@ class HostHelperTests(unittest.TestCase):
 
     def test_cloud_init_queues_runner_after_cloud_final_without_deadlock(self):
         user_data = helper.cloud_init_user_data(base64.b64encode(b"opaque-jit"))
-        for filename in (".runner", ".credentials", ".credentials_rsaparams"):
+        for filename in (".runner", ".credentials", ".credentials_rsaparams",
+                         ".runner_migrated", ".credentials_migrated"):
             self.assertIn(f"/opt/actions-runner/{filename}", user_data)
-        self.assertIn("ReadWritePaths=/opt/actions-runner/.runner /opt/actions-runner/.credentials /opt/actions-runner/.credentials_rsaparams", user_data)
+        self.assertIn("- [chown, root:ci-runner, /opt/actions-runner]", user_data)
+        self.assertIn("- [chmod, '1770', /opt/actions-runner]", user_data)
+        self.assertIn("ReadWritePaths=/opt/actions-runner", user_data)
+        self.assertIn("UMask=0077", user_data)
         self.assertIn("- [systemctl, daemon-reload]", user_data)
         self.assertIn("- [systemctl, start, --no-block, ci-runner-job.service]", user_data)
         self.assertNotIn("- [systemctl, start, ci-runner-job.service]", user_data)


### PR DESCRIPTION
## Summary
- allow the upstream Actions runner to atomically replace JIT runtime configuration inside the one-job guest
- keep all existing runner payload files root-owned while restricting new runtime files with sticky-directory semantics and `UMask=0077`
- fail closed when the immutable base image contains mutable or non-root runner payload entries

## Security boundary
The writable exception exists only inside the ephemeral KVM guest. Existing root-owned runner binaries cannot be replaced or removed by `ci-runner`; the full overlay is destroyed after one job.

## Verification
- `make lint`
- `make test` (50 tests)
- `git diff --check`
- independent security re-review: no merge-blocking findings

Tracker: DEV-1