### PR TITLE
DEV-1 Start JIT runner with absent state

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -70,8 +70,10 @@ fork pull requests select this machine.
   isolated `libvirt-qemu` account owns the mode `0600` overlay and seed images.
 - Inside each one-job guest, existing runner files remain root-owned and
   non-writable. Cloud-init makes only the top-level runner directory sticky and
-  group-writable so upstream JIT configuration can atomically replace its own
-  mode `0600` runtime files; the entire overlay is destroyed after the job.
+  group-writable so upstream JIT configuration can create and atomically replace
+  its own mode `0600` runtime files. Those files must start absent because the
+  upstream runner treats an existing `.runner` as configured state. The entire
+  overlay is destroyed after the job.
 - A running lease older than `max_lease_seconds` (default 7,200 seconds) is
   destroyed by reconciliation even if libvirt still reports it running.
 

--- a/infra/packer/scripts/verify-image-contract.sh
+++ b/infra/packer/scripts/verify-image-contract.sh
@@ -34,6 +34,13 @@ trivy --version
 test -x /opt/actions-runner/run.sh
 test -x /usr/local/bin/run-jit-runner
 test "$(stat -c '%U:%G:%a' /opt/actions-runner)" = "root:root:755"
+for runtime_file in .runner .credentials .credentials_rsaparams .runner_migrated .credentials_migrated; do
+  runtime_path="/opt/actions-runner/$runtime_file"
+  if [[ -e "$runtime_path" || -L "$runtime_path" ]]; then
+    echo "image contract found pre-existing runner state: $runtime_path" >&2
+    exit 1
+  fi
+done
 unsafe_runner_entry="$(find /opt/actions-runner -xdev \
   \( -path /opt/actions-runner/_diag -o -path /opt/actions-runner/_work \) -prune -o \
   \( \( ! -user root -o ! -group root \) -o \( \( -type f -o -type d \) -perm /022 \) \) \

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -137,11 +137,6 @@ def cloud_init_user_data(encoded_jit: bytes) -> str:
 bootcmd:
   - [install, -d, -o, ci-runner, -g, ci-runner, -m, '0700', /run/ci-runner]
   - [install, -d, -o, root, -g, root, -m, '0755', /etc/systemd/system/ci-runner-job.service.d]
-  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.runner]
-  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials]
-  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials_rsaparams]
-  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.runner_migrated]
-  - [install, -o, ci-runner, -g, ci-runner, -m, '0600', /dev/null, /opt/actions-runner/.credentials_migrated]
   - [chown, root:ci-runner, /opt/actions-runner]
   - [chmod, '1770', /opt/actions-runner]
 write_files:

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -31,7 +31,7 @@ class HostHelperTests(unittest.TestCase):
         user_data = helper.cloud_init_user_data(base64.b64encode(b"opaque-jit"))
         for filename in (".runner", ".credentials", ".credentials_rsaparams",
                          ".runner_migrated", ".credentials_migrated"):
-            self.assertIn(f"/opt/actions-runner/{filename}", user_data)
+            self.assertNotIn(f"/opt/actions-runner/{filename}", user_data)
         self.assertIn("- [chown, root:ci-runner, /opt/actions-runner]", user_data)
         self.assertIn("- [chmod, '1770', /opt/actions-runner]", user_data)
         self.assertIn("ReadWritePaths=/opt/actions-runner", user_data)


### PR DESCRIPTION
## Root cause
Actions Runner v2.332.0 treats the existence of `.runner` as configured state and immediately parses it as JSON. Cloud-init precreated that file empty, so every guest exited before becoming online.

## Fix
- stop precreating the five JIT runtime state files
- retain the sticky `root:ci-runner` directory, `ReadWritePaths`, and `UMask=0077` so upstream creates them securely
- make the base-image contract reject existing state paths, including dangling symlinks

## Evidence
- failure reproduced first with a focused test
- official pinned upstream `ConfigurationStore.IsConfigured()` and `GetSettings()` confirm the behavior
- `make lint`
- `make test` (50 tests)
- `bash -n` and `git diff --check`
- independent security review: no merge blockers

Tracker: DEV-1