### PR TITLE
fix(DEV-1): expose pinned Chromium to CI jobs

### DIFF
--- a/infra/packer/scripts/install-runner.sh
+++ b/infra/packer/scripts/install-runner.sh
@@ -105,6 +105,15 @@ sudo npm install --global --ignore-scripts "playwright@${PLAYWRIGHT_VERSION}"
 sudo /usr/bin/env PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright playwright install --with-deps chromium
 sudo chmod -R a+rX /opt/ms-playwright
 
+playwright_chromium="$(find /opt/ms-playwright -type f \
+  \( -path '*/chrome-linux/chrome' -o -path '*/chrome-linux64/chrome' \) \
+  -perm -0111 -print -quit)"
+if [[ -z "$playwright_chromium" ]]; then
+  echo "Playwright Chromium executable was not installed" >&2
+  exit 1
+fi
+sudo ln --symbolic --force "$playwright_chromium" /usr/local/bin/chromium
+
 composer_installer=/tmp/composer-setup.php
 curl --fail --silent --show-error --location https://getcomposer.org/installer --output "$composer_installer"
 printf '%s  %s\n' "$COMPOSER_SHA384" "$composer_installer" | sha384sum --check --strict

--- a/infra/packer/scripts/verify-image-contract.sh
+++ b/infra/packer/scripts/verify-image-contract.sh
@@ -30,6 +30,7 @@ php8.3 --version | grep -Eq '^PHP 8\.3\.'
 php8.4 --version | grep -Eq '^PHP 8\.4\.'
 composer --version
 playwright --version
+chromium --version
 trivy --version
 test -x /opt/actions-runner/run.sh
 test -x /usr/local/bin/run-jit-runner
@@ -50,6 +51,8 @@ test -z "$unsafe_runner_entry" || {
   exit 1
 }
 test -d /opt/ms-playwright
+test -x /usr/local/bin/chromium
+readlink -f /usr/local/bin/chromium | grep -q '^/opt/ms-playwright/'
 test -s /etc/ci-runner-image-manifest
 
 echo "immutable runner image contract passed"

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -76,6 +76,9 @@ grep -q 'keys/ondrej-php.asc' infra/packer/sanctuary-runner.pkr.hcl
 test "$(shasum -a 256 infra/packer/keys/ondrej-php.asc | awk '{print $1}')" = '7258b1cb18300b87cd5668a6d64ce78184d9c0e129382879a0d79291c4ef463d'
 assert_absent 'keyserver.ubuntu.com' infra/packer/scripts/install-runner.sh
 grep -q 'playwright install --with-deps chromium' infra/packer/scripts/install-runner.sh
+grep -q 'ln --symbolic.*playwright_chromium.*usr/local/bin/chromium' infra/packer/scripts/install-runner.sh
+grep -q 'chromium --version' infra/packer/scripts/verify-image-contract.sh
+grep -q "readlink -f /usr/local/bin/chromium.*opt/ms-playwright" infra/packer/scripts/verify-image-contract.sh
 grep -q 'exec ./run.sh --jitconfig' runner/guest/run-jit-runner.sh
 grep -q 'ExecStopPost=+/usr/bin/systemctl poweroff' runner/systemd/ci-runner-job.service
 grep -q '^Restart=no$' runner/systemd/ci-runner-job.service


### PR DESCRIPTION
## Summary
- expose the already pinned Playwright Chromium executable as `chromium`
- fail the image build if that executable is absent
- validate that the command resolves inside `/opt/ms-playwright`

## Evidence
- Gate canary 29829390317 completed audit, lint, typecheck, tests and production build on the ephemeral runner
- the only failure was `No Chrome/Chromium binary found`
- `make lint`
- `make test` (50 runner platform tests)
- `git diff --check`
- independent security review: no blockers or trust-input changes

## Scope
One image-contract fix only. No runner credentials, network policy, or repository rollout changes.