### PR TITLE
fix(DEV-1): use stable Docker image store in guests

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -79,6 +79,11 @@ fork pull requests select this machine.
   its own mode `0600` runtime files. Those files must start absent because the
   upstream runner treats an existing `.runner` as configured state. The entire
   overlay is destroyed after the job.
+- Cloud-init selects Docker's `overlay2` image store before admitting the JIT
+  runner and verifies the active driver. This avoids the observed Docker 29.6.2
+  containerd snapshotter failure where a build-time `COPY` layer was absent
+  from the runtime filesystem. Driver activation failure prevents the job from
+  starting; the guest is disposable, so no image-store migration is required.
 - A running lease older than `max_lease_seconds` (default 7,200 seconds) is
   destroyed by reconciliation even if libvirt still reports it running.
 

--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -152,9 +152,29 @@ write_files:
       [Service]
       ReadWritePaths=/opt/actions-runner
       UMask=0077
+  - path: /etc/docker/daemon.json
+    owner: root:root
+    permissions: '0644'
+    content: |
+      {
+        "features": {
+          "containerd-snapshotter": false
+        },
+        "storage-driver": "overlay2"
+      }
+  - path: /usr/local/sbin/ci-runner-prepare-docker
+    owner: root:root
+    permissions: '0755'
+    content: |
+      #!/bin/sh
+      set -eu
+      systemctl restart docker.service
+      systemctl is-active --quiet docker.service
+      test "$(docker info --format '{{.Driver}}')" = overlay2
+      systemctl daemon-reload
+      systemctl start --no-block ci-runner-job.service
 runcmd:
-  - [systemctl, daemon-reload]
-  - [systemctl, start, --no-block, ci-runner-job.service]
+  - [/usr/local/sbin/ci-runner-prepare-docker]
 """ % base64.b64encode(encoded_jit).decode("ascii")
 
 

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -36,9 +36,22 @@ class HostHelperTests(unittest.TestCase):
         self.assertIn("- [chmod, '1770', /opt/actions-runner]", user_data)
         self.assertIn("ReadWritePaths=/opt/actions-runner", user_data)
         self.assertIn("UMask=0077", user_data)
-        self.assertIn("- [systemctl, daemon-reload]", user_data)
-        self.assertIn("- [systemctl, start, --no-block, ci-runner-job.service]", user_data)
+        self.assertIn("systemctl daemon-reload", user_data)
+        self.assertIn("systemctl start --no-block ci-runner-job.service", user_data)
+        self.assertNotIn("- [systemctl, start, --no-block, ci-runner-job.service]", user_data)
         self.assertNotIn("- [systemctl, start, ci-runner-job.service]", user_data)
+
+    def test_cloud_init_selects_verified_overlay2_before_runner_start(self):
+        user_data = helper.cloud_init_user_data(base64.b64encode(b"opaque-jit"))
+
+        self.assertIn('"containerd-snapshotter": false', user_data)
+        self.assertIn('"storage-driver": "overlay2"', user_data)
+        self.assertIn("docker info --format '{{.Driver}}'", user_data)
+        verify = user_data.index("test \"$(docker info --format '{{.Driver}}')\" = overlay2")
+        runner = user_data.index("systemctl start --no-block ci-runner-job.service")
+        self.assertLess(verify, runner)
+        runcmd = user_data.split("runcmd:\n", 1)[1]
+        self.assertEqual(runcmd, "  - [/usr/local/sbin/ci-runner-prepare-docker]\n")
 
     def test_lease_directory_cannot_escape_overlay_root(self):
         for value in ("../etc", "a/b", "white space", ""):

--- a/scripts/test-runner-platform.sh
+++ b/scripts/test-runner-platform.sh
@@ -38,7 +38,9 @@ grep -q '^RuntimeMaxSec=300s$' runner/systemd/ci-runner-host-helper@.service
 grep -q '^MaxConnections=4$' runner/systemd/ci-runner-host-helper.socket
 grep -q '^HELPER_MUTATION_TIMEOUT_SECONDS = 330$' runner/manager/ci_runner_manager.py
 grep -q 'QEMU_USER = "libvirt-qemu"' runner/host-helper/ci_runner_host_helper.py
-grep -q '\[systemctl, start, --no-block, ci-runner-job.service\]' runner/host-helper/ci_runner_host_helper.py
+grep -q 'systemctl start --no-block ci-runner-job.service' runner/host-helper/ci_runner_host_helper.py
+grep -q -- '- \[/usr/local/sbin/ci-runner-prepare-docker\]' runner/host-helper/ci_runner_host_helper.py
+assert_absent '\[systemctl, start, --no-block, ci-runner-job.service\]' runner/host-helper/ci_runner_host_helper.py
 grep -q "path: /mnt/ssd1000-01/ci-runner, owner: root, group: kvm, mode: '0710'" infra/ansible/roles/runner_host/tasks/main.yml
 grep -q 'systemd-run' runner/host-helper/ci_runner_host_helper.py
 grep -q 'ubuntu-24.04-runner-{{ runner_base_image_sha256 }}.qcow2' infra/ansible/roles/runner_host/tasks/main.yml


### PR DESCRIPTION
## Summary
- select Docker overlay2 inside each disposable runner guest before JIT admission
- verify Docker is active and the expected storage driver is in use before starting the runner
- keep the whole preparation path fail-closed in one root-owned cloud-init boundary
- document the Docker 29 containerd snapshotter runtime failure observed by the Notify canary

## Verification
- 66 runner unit tests
- runner platform contract test
- workflow contract test
- make lint
- make test
- git diff --check
- cloud-init schema validation on Sanctuary
- Docker daemon configuration validation on Sanctuary
- platform and security review approved

## Rollback
Revert this commit and redeploy the Ansible role. Existing base images are unchanged; the setting only affects new disposable guest overlays.