### PR TITLE
fix(DEV-1): distinguish trigger and assigned runner jobs

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -24,6 +24,8 @@ are label-scoped, so GitHub may assign a different queued heavy job than the one
 used to name the runner. The manager records that candidate as `trigger_job_id`
 and records `actual_job_id` only after GitHub reports a job assigned to the
 registration's runner ID, corroborated by its runner name when available.
+Runner names are reused across retries and are never sufficient for attribution
+without the numeric runner ID.
 After runner cleanup, the manager keeps a durable handoff tombstone, waits for
 API consistency, and retries a still-queued trigger with exponential cooldown
 capped at one hour. Pending handoffs block

--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -21,13 +21,16 @@ its own changes.
 
 The adapter deduplicates completed job IDs for 24 hours. Repository JIT runners
 are label-scoped, so GitHub may assign a different queued heavy job than the one
-used to name the runner. After runner cleanup, the manager keeps a durable
-handoff tombstone, waits for API consistency, and retries a still-queued target
-with exponential cooldown capped at one hour. Pending handoffs block duplicate
-dispatch even if history is absent. It launches at most one VM and removes the
-offline GitHub runner record if VM launch fails. Any malformed API response,
-permission error, transport failure, or rate limit fails closed; rate-limit
-responses honor a bounded retry interval.
+used to name the runner. The manager records that candidate as `trigger_job_id`
+and records `actual_job_id` only after GitHub reports a job assigned to the
+registration's runner ID, corroborated by its runner name when available.
+After runner cleanup, the manager keeps a durable handoff tombstone, waits for
+API consistency, and retries a still-queued trigger with exponential cooldown
+capped at one hour. Pending handoffs block
+duplicate dispatch even if history is absent. It launches at most one VM and
+removes the offline GitHub runner record if VM launch fails. Any malformed API
+response, permission error, transport failure, or rate limit fails closed;
+rate-limit responses honor a bounded retry interval.
 
 For manual break-glass operation, a single-use JIT value can still be supplied
 to the manager using a mode `0600` file. Delete that host-side file immediately

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -31,6 +31,7 @@ HANDOFF_GRACE_SECONDS = 30
 HANDOFF_RETRY_MAX_SECONDS = 600
 DISPATCH_RETRY_BASE_SECONDS = 60
 DISPATCH_RETRY_MAX_SECONDS = 3600
+ASSIGNMENT_RUNS_PER_STATUS = 10
 HELPER_HEADER_MAX = 4096
 HELPER_RESPONSE_MAX = 65536
 HELPER_JIT_MAX = 131072
@@ -51,6 +52,12 @@ class RateLimited(RunnerError):
 
 class NotFound(RunnerError):
     pass
+
+
+def trigger_job_id(state: dict[str, Any]) -> int | None:
+    """Return the admission trigger, including leases written before the rename."""
+    value = state.get("trigger_job_id", state.get("job_id"))
+    return value if isinstance(value, int) else None
 
 
 def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -142,9 +149,10 @@ class StateStore:
 
     def pending_dispatch_keys(self) -> set[str]:
         return {
-            f"{state['repo']}:{state['job_id']}"
+            f"{state['repo']}:{job_id}"
             for state in self.cleanup_items()
-            if isinstance(state.get("repo"), str) and isinstance(state.get("job_id"), int)
+            if isinstance(state.get("repo"), str)
+            and (job_id := trigger_job_id(state)) is not None
         }
 
     def write(self, lease: str, state: dict[str, Any]) -> None:
@@ -345,6 +353,46 @@ class GitHubClient:
             "labels": ["self-hosted", "linux", "x64", label], "work_folder": "_work",
         })
 
+    def find_assigned_job(self, repo: str, runner_id: int,
+                          runner_name: str, *,
+                          include_completed: bool = True) -> dict[str, Any] | None:
+        if not runner_name or runner_id < 1:
+            return None
+        id_matches: dict[tuple[int, int], dict[str, Any]] = {}
+        name_matches: dict[tuple[int, int], dict[str, Any]] = {}
+        statuses = ("in_progress", "completed") if include_completed else ("in_progress",)
+        for status in statuses:
+            runs = self.request(
+                "GET", f"{self.repo_path(repo)}/actions/runs?status={status}"
+                f"&per_page={ASSIGNMENT_RUNS_PER_STATUS}&page=1"
+            )
+            for run in runs.get("workflow_runs", []):
+                run_id = int(run["id"])
+                jobs = self.request(
+                    "GET", f"{self.repo_path(repo)}/actions/runs/{run_id}"
+                    "/jobs?filter=latest&per_page=100&page=1"
+                )
+                for job in jobs.get("jobs", []):
+                    job_id = job.get("id")
+                    if not isinstance(job_id, int):
+                        continue
+                    reported_runner_id = job.get("runner_id")
+                    reported_runner_name = job.get("runner_name")
+                    assignment = {"repo": repo, "run_id": run_id, "job_id": job_id}
+                    key = (run_id, job_id)
+                    if isinstance(reported_runner_id, int):
+                        if reported_runner_id != runner_id:
+                            continue
+                        if reported_runner_name not in (None, "", runner_name):
+                            raise RunnerError("GitHub returned a conflicting runner assignment")
+                        id_matches[key] = assignment
+                    elif reported_runner_name == runner_name:
+                        name_matches[key] = assignment
+        matches = id_matches or name_matches
+        if len(matches) > 1:
+            raise RunnerError("GitHub returned an ambiguous runner assignment")
+        return next(iter(matches.values())) if matches else None
+
     def delete_runner(self, repo: str, runner_id: int) -> None:
         try:
             self.request("DELETE", f"{self.repo_path(repo)}/actions/runners/{runner_id}")
@@ -513,13 +561,55 @@ def cleanup_github_runner(client: GitHubClient | None, state: dict[str, Any]) ->
 
 
 def has_dispatch_target(state: dict[str, Any]) -> bool:
-    return isinstance(state.get("repo"), str) and isinstance(state.get("job_id"), int)
+    return isinstance(state.get("repo"), str) and trigger_job_id(state) is not None
+
+
+def record_verified_assignment(store: StateStore, client: GitHubClient | None,
+                               state: dict[str, Any], *,
+                               include_completed: bool) -> dict[str, Any]:
+    if client is None or isinstance(state.get("actual_job_id"), int):
+        return state
+    repo = state.get("repo")
+    runner_name = state.get("runner_name")
+    lease = state.get("lease")
+    runner_id = state.get("runner_id")
+    trigger_id = trigger_job_id(state)
+    if not isinstance(repo, str) or not isinstance(runner_name, str) \
+            or not isinstance(lease, str) or not isinstance(runner_id, int) \
+            or trigger_id is None:
+        return state
+    try:
+        assignment = client.find_assigned_job(
+            repo, runner_id, runner_name, include_completed=include_completed
+        )
+    except RunnerError as exc:
+        LOG.warning(
+            "runner assignment could not be verified lease=%s repo=%s runner_id=%s "
+            "trigger_job_id=%s error=%s",
+            lease, repo, runner_id, trigger_id, exc,
+        )
+        return state
+    if assignment is None:
+        return state
+    actual_job_id = assignment.get("job_id")
+    actual_run_id = assignment.get("run_id")
+    if not isinstance(actual_job_id, int) or not isinstance(actual_run_id, int):
+        return state
+    updated = dict(state)
+    updated.update({"actual_job_id": actual_job_id, "actual_run_id": actual_run_id})
+    store.write(lease, updated)
+    LOG.info(
+        "runner assignment verified lease=%s repo=%s runner_id=%s runner_name=%s "
+        "trigger_job_id=%s actual_job_id=%s",
+        lease, repo, runner_id, runner_name, trigger_id, actual_job_id,
+    )
+    return updated
 
 
 def retry_dispatch_handoff(store: StateStore, client: GitHubClient | None,
                            state: dict[str, Any], now: int) -> None:
     repo = state.get("repo")
-    job_id = state.get("job_id")
+    job_id = trigger_job_id(state)
     if client is None or not isinstance(repo, str) or not isinstance(job_id, int):
         store.defer_handoff_check(state, now)
         return
@@ -527,17 +617,22 @@ def retry_dispatch_handoff(store: StateStore, client: GitHubClient | None,
         job = client.get_job(repo, job_id)
     except NotFound:
         store.remove_cleanup(state)
-        LOG.info("dispatch handoff target no longer exists repo=%s job_id=%s", repo, job_id)
+        LOG.info(
+            "dispatch handoff trigger no longer exists repo=%s trigger_job_id=%s",
+            repo, job_id,
+        )
         return
     except RunnerError as exc:
-        LOG.warning("dispatch handoff could not be verified repo=%s job_id=%s error=%s",
-                    repo, job_id, exc)
+        LOG.warning(
+            "dispatch handoff trigger could not be verified repo=%s trigger_job_id=%s error=%s",
+            repo, job_id, exc,
+        )
         store.defer_handoff_check(state, now)
         return
     status = job.get("status")
     if status == "completed":
         store.remove_cleanup(state)
-        LOG.info("dispatch handoff completed repo=%s job_id=%s", repo, job_id)
+        LOG.info("dispatch handoff trigger completed repo=%s trigger_job_id=%s", repo, job_id)
         return
     if status == "queued":
         key = f"{repo}:{job_id}"
@@ -545,12 +640,16 @@ def retry_dispatch_handoff(store: StateStore, client: GitHubClient | None,
             key, now, int(state.get("dispatch_attempts", 1))
         )
         store.remove_cleanup(state)
-        LOG.info("dispatch handoff queued for retry repo=%s job_id=%s retry_after=%s",
-                 repo, job_id, delay)
+        LOG.info(
+            "dispatch handoff trigger queued for retry repo=%s trigger_job_id=%s retry_after=%s",
+            repo, job_id, delay,
+        )
         return
     store.defer_handoff_check(state, now)
-    LOG.info("dispatch handoff remains pending repo=%s job_id=%s status=%s",
-             repo, job_id, status if isinstance(status, str) else "invalid")
+    LOG.info(
+        "dispatch handoff trigger remains pending repo=%s trigger_job_id=%s status=%s",
+        repo, job_id, status if isinstance(status, str) else "invalid",
+    )
 
 
 def destroy(cfg: dict[str, Any], lease: str, client: GitHubClient | None = None) -> None:
@@ -622,6 +721,10 @@ def reconcile(cfg: dict[str, Any], client: GitHubClient | None = None) -> None:
             lease for lease, domain_state in domains.items()
             if domain_state == "running" and states.get(lease, {}).get("phase") == "running"
         } - expired
+        for lease, state in list(states.items()):
+            states[lease] = record_verified_assignment(
+                store, client, state, include_completed=lease not in healthy
+            )
         for lease in sorted(known - healthy):
             LOG.warning("cleaning completed or missing domain lease=%s", lease)
             helper(cfg, "destroy", lease)
@@ -660,14 +763,17 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
             response = client.generate_jit(repo, job["job_id"], int(cfg.get("runner_group_id", 1)), label)
             encoded = response.get("encoded_jit_config")
             runner_id = response.get("runner", {}).get("id")
+            runner_name = response.get("runner", {}).get("name")
             lease = f"gh-{job['job_id']}"
             registration = {
                 "lease": lease,
                 "repo": repo,
                 "runner_id": runner_id,
-                "run_id": job["run_id"],
-                "job_id": job["job_id"],
+                "trigger_run_id": job["run_id"],
+                "trigger_job_id": job["job_id"],
             }
+            if isinstance(runner_name, str) and runner_name:
+                registration["runner_name"] = runner_name
             if not isinstance(encoded, str) or not isinstance(runner_id, int):
                 if isinstance(runner_id, int):
                     store.write_cleanup_obligation(lease, registration, int(time.time()))
@@ -684,10 +790,16 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                 launch(cfg, lease, encoded.encode("ascii"), metadata={
                     "repo": repo,
                     "runner_id": runner_id,
-                    "run_id": job["run_id"],
-                    "job_id": job["job_id"],
+                    **({"runner_name": runner_name}
+                       if isinstance(runner_name, str) and runner_name else {}),
+                    "trigger_run_id": job["run_id"],
+                    "trigger_job_id": job["job_id"],
                 }, dispatch_history_key=key)
-                LOG.info("dispatched repo=%s run_id=%s job_id=%s", repo, job["run_id"], job["job_id"])
+                LOG.info(
+                    "runner registered lease=%s repo=%s runner_id=%s trigger_run_id=%s "
+                    "trigger_job_id=%s assignment=unverified",
+                    lease, repo, runner_id, job["run_id"], job["job_id"],
+                )
                 return True
             except Exception:
                 try:
@@ -699,8 +811,10 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                         "lease": lease,
                         "repo": repo,
                         "runner_id": runner_id,
-                        "run_id": job["run_id"],
-                        "job_id": job["job_id"],
+                        **({"runner_name": runner_name}
+                           if isinstance(runner_name, str) and runner_name else {}),
+                        "trigger_run_id": job["run_id"],
+                        "trigger_job_id": job["job_id"],
                     }, int(time.time()), preserve_lease=True)
                 else:
                     store.remove_cleanup(registration)

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -359,7 +359,6 @@ class GitHubClient:
         if not runner_name or runner_id < 1:
             return None
         id_matches: dict[tuple[int, int], dict[str, Any]] = {}
-        name_matches: dict[tuple[int, int], dict[str, Any]] = {}
         statuses = ("in_progress", "completed") if include_completed else ("in_progress",)
         for status in statuses:
             runs = self.request(
@@ -380,18 +379,15 @@ class GitHubClient:
                     reported_runner_name = job.get("runner_name")
                     assignment = {"repo": repo, "run_id": run_id, "job_id": job_id}
                     key = (run_id, job_id)
-                    if isinstance(reported_runner_id, int):
-                        if reported_runner_id != runner_id:
-                            continue
-                        if reported_runner_name not in (None, "", runner_name):
-                            raise RunnerError("GitHub returned a conflicting runner assignment")
-                        id_matches[key] = assignment
-                    elif reported_runner_name == runner_name:
-                        name_matches[key] = assignment
-        matches = id_matches or name_matches
-        if len(matches) > 1:
+                    if not isinstance(reported_runner_id, int) \
+                            or reported_runner_id != runner_id:
+                        continue
+                    if reported_runner_name not in (None, "", runner_name):
+                        raise RunnerError("GitHub returned a conflicting runner assignment")
+                    id_matches[key] = assignment
+        if len(id_matches) > 1:
             raise RunnerError("GitHub returned an ambiguous runner assignment")
-        return next(iter(matches.values())) if matches else None
+        return next(iter(id_matches.values())) if id_matches else None
 
     def delete_runner(self, repo: str, runner_id: int) -> None:
         try:

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -272,7 +272,7 @@ class ManagerTests(unittest.TestCase):
         client.request = mock.Mock(side_effect=[
             {"workflow_runs": [{"id": 10}, {"id": 11}]},
             {"jobs": [{"id": 20, "status": "queued", "runner_name": ""}]},
-            {"jobs": [{"id": 83, "status": "in_progress",
+            {"jobs": [{"id": 83, "status": "in_progress", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
             {"workflow_runs": []},
         ])
@@ -312,14 +312,27 @@ class ManagerTests(unittest.TestCase):
             {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
         )
 
-    def test_find_assigned_job_fails_closed_for_ambiguous_name_fallback(self):
+    def test_find_assigned_job_ignores_single_stale_name_without_runner_id(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": []},
+            {"workflow_runs": [{"id": 10}]},
+            {"jobs": [{"id": 21, "status": "completed",
+                       "runner_name": "sanctuary-20"}]},
+        ])
+
+        self.assertIsNone(
+            client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20")
+        )
+
+    def test_find_assigned_job_fails_closed_for_ambiguous_runner_id(self):
         client = manager.GitHubClient("secret")
         client.request = mock.Mock(side_effect=[
             {"workflow_runs": []},
             {"workflow_runs": [{"id": 10}, {"id": 11}]},
-            {"jobs": [{"id": 21, "status": "completed",
+            {"jobs": [{"id": 21, "status": "completed", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
-            {"jobs": [{"id": 83, "status": "completed",
+            {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
         ])
 

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -267,6 +267,65 @@ class ManagerTests(unittest.TestCase):
         self.assertEqual(client.candidate_jobs("Tuinstra-DEV/gate", "trusted-heavy"),
                          [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 1}])
 
+    def test_find_assigned_job_matches_github_reported_runner_name(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": [{"id": 10}, {"id": 11}]},
+            {"jobs": [{"id": 20, "status": "queued", "runner_name": ""}]},
+            {"jobs": [{"id": 83, "status": "in_progress",
+                       "runner_name": "sanctuary-20"}]},
+            {"workflow_runs": []},
+        ])
+
+        self.assertEqual(
+            client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20"),
+            {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
+        )
+
+    def test_find_assigned_job_captures_fast_completed_job_by_runner_id(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": []},
+            {"workflow_runs": [{"id": 11}]},
+            {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
+                       "runner_name": "sanctuary-20"}]},
+        ])
+
+        self.assertEqual(
+            client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20"),
+            {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
+        )
+
+    def test_find_assigned_job_ignores_reused_name_with_different_runner_id(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": []},
+            {"workflow_runs": [{"id": 10}, {"id": 11}]},
+            {"jobs": [{"id": 21, "status": "completed", "runner_id": 29,
+                       "runner_name": "sanctuary-20"}]},
+            {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
+                       "runner_name": "sanctuary-20"}]},
+        ])
+
+        self.assertEqual(
+            client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20"),
+            {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
+        )
+
+    def test_find_assigned_job_fails_closed_for_ambiguous_name_fallback(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": []},
+            {"workflow_runs": [{"id": 10}, {"id": 11}]},
+            {"jobs": [{"id": 21, "status": "completed",
+                       "runner_name": "sanctuary-20"}]},
+            {"jobs": [{"id": 83, "status": "completed",
+                       "runner_name": "sanctuary-20"}]},
+        ])
+
+        with self.assertRaisesRegex(manager.RunnerError, "ambiguous"):
+            client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20")
+
     @mock.patch.object(manager.urllib.request, "urlopen")
     def test_rate_limit_is_fail_closed_and_does_not_expose_token(self, urlopen):
         headers = {"Retry-After": "60"}
@@ -354,21 +413,30 @@ class ManagerTests(unittest.TestCase):
             client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
             client.generate_jit.return_value = {
                 "encoded_jit_config": base64.b64encode(b"jit").decode(),
-                "runner": {"id": 30},
+                "runner": {"id": 30, "name": "sanctuary-20"},
             }
             cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
                    "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
             (root / "run").mkdir()
 
-            self.assertTrue(manager.dispatch_once(cfg, client))
+            with self.assertLogs("ci-runner-manager", level="INFO") as logs:
+                self.assertTrue(manager.dispatch_once(cfg, client))
 
             launch.assert_called_once_with(
                 cfg,
                 "gh-20",
                 mock.ANY,
-                metadata={"repo": "Tuinstra-DEV/gate", "runner_id": 30, "run_id": 10, "job_id": 20},
+                metadata={
+                    "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                    "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                    "trigger_job_id": 20,
+                },
                 dispatch_history_key="Tuinstra-DEV/gate:20",
             )
+            self.assertNotIn("actual_job_id", launch.call_args.kwargs["metadata"])
+            audit = "\n".join(logs.output)
+            self.assertIn("trigger_job_id=20 assignment=unverified", audit)
+            self.assertNotIn("actual_job_id=20", audit)
             self.assertEqual(launch.call_args.args[2], base64.b64encode(b"jit"))
             self.assertEqual(list((root / "run").iterdir()), [])
 
@@ -506,6 +574,83 @@ class ManagerTests(unittest.TestCase):
 
             client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
             self.assertEqual(store.leases(), [])
+
+    @mock.patch.object(manager.time, "time", return_value=1001)
+    @mock.patch.object(manager, "helper")
+    def test_reconcile_records_verified_actual_job_without_relabeling_trigger(
+            self, helper, _time):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.return_value = mock.Mock(stdout=b'{"gh-20":"running"}')
+            client = mock.Mock()
+            client.find_assigned_job.return_value = {
+                "repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83,
+            }
+
+            with self.assertLogs("ci-runner-manager", level="INFO") as logs:
+                manager.reconcile(cfg, client)
+
+            state = store.leases()[0]
+            self.assertEqual(state["trigger_job_id"], 20)
+            self.assertEqual(state["actual_job_id"], 83)
+            self.assertEqual(state["actual_run_id"], 11)
+            self.assertEqual(state["runner_id"], 30)
+            self.assertEqual(state["lease"], "gh-20")
+            self.assertIn("trigger_job_id=20 actual_job_id=83", "\n".join(logs.output))
+            client.find_assigned_job.assert_called_once_with(
+                "Tuinstra-DEV/gate", 30, "sanctuary-20", include_completed=False
+            )
+
+    @mock.patch.object(manager.time, "time", return_value=1001)
+    @mock.patch.object(manager, "helper")
+    def test_label_steal_cleanup_retries_trigger_and_retains_actual_audit(self, helper, _time):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            history = manager.DispatchHistory(cfg["state_dir"])
+            state = {
+                "lease": "gh-20", "phase": "running", "launched_at": 1,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20, "dispatch_attempts": 1,
+            }
+            store.write("gh-20", state)
+            history.add("Tuinstra-DEV/gate:20", 1000)
+            helper.side_effect = [mock.Mock(stdout=b'{"gh-20":"shut off"}'), mock.Mock()]
+            client = mock.Mock()
+            client.find_assigned_job.return_value = {
+                "repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83,
+            }
+            client.get_job.return_value = {
+                "id": 20, "status": "queued", "runner_name": "",
+            }
+
+            manager.reconcile(cfg, client)
+
+            pending = store.cleanup_items()[0]
+            self.assertEqual(pending["trigger_job_id"], 20)
+            self.assertEqual(pending["actual_job_id"], 83)
+            self.assertEqual(pending["runner_id"], 30)
+            self.assertEqual(pending["lease"], "gh-20")
+            client.find_assigned_job.assert_called_once_with(
+                "Tuinstra-DEV/gate", 30, "sanctuary-20", include_completed=True
+            )
+            manager.retry_pending_cleanup(store, client, 1031)
+
+            client.get_job.assert_called_once_with("Tuinstra-DEV/gate", 20)
+            self.assertEqual(store.cleanup_items(), [])
+            self.assertFalse(history.contains("Tuinstra-DEV/gate:20", 1091))
 
     @mock.patch.object(manager.time, "time", return_value=1001)
     @mock.patch.object(manager, "helper")


### PR DESCRIPTION
## Summary
- persist the admission trigger separately from the GitHub-verified assigned job
- require exact runner ID for assignment attribution; runner name only corroborates
- retain backward-compatible cleanup and handoff for existing leases
- document label-scoped repository JIT behavior

## Verification
- 73 runner tests passed
- runner platform contracts passed
- lint passed
- diff check passed
- independent security review approved

## Rollback
Revert the merge commit and redeploy the Ansible role. Repository execution variables remain hosted until the deployed audit path is verified.

Tracker: DEV-1