### PR TITLE
fix(DEV-1): audit queued run assignments

### DIFF
--- a/docs/runner/sanctuary-kvm-runner.md
+++ b/docs/runner/sanctuary-kvm-runner.md
@@ -24,8 +24,13 @@ are label-scoped, so GitHub may assign a different queued heavy job than the one
 used to name the runner. The manager records that candidate as `trigger_job_id`
 and records `actual_job_id` only after GitHub reports a job assigned to the
 registration's runner ID, corroborated by its runner name when available.
+The locally requested runner name is persisted when the JIT response omits it;
+a conflicting non-empty reported name rejects the registration.
 Runner names are reused across retries and are never sufficient for attribution
 without the numeric runner ID.
+During teardown the bounded assignment search also inspects recent queued
+workflow runs because GitHub can return an overall run to `queued` between its
+serial ephemeral jobs while retaining completed-job runner metadata.
 After runner cleanup, the manager keeps a durable handoff tombstone, waits for
 API consistency, and retries a still-queued trigger with exponential cooldown
 capped at one hour. Pending handoffs block

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -60,6 +60,10 @@ def trigger_job_id(state: dict[str, Any]) -> int | None:
     return value if isinstance(value, int) else None
 
 
+def runner_name_for_trigger(job_id: int) -> str:
+    return f"sanctuary-{job_id}"
+
+
 def strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
@@ -349,7 +353,7 @@ class GitHubClient:
 
     def generate_jit(self, repo: str, job_id: int, group_id: int, label: str) -> dict[str, Any]:
         return self.request("POST", f"{self.repo_path(repo)}/actions/runners/generate-jitconfig", {
-            "name": f"sanctuary-{job_id}", "runner_group_id": group_id,
+            "name": runner_name_for_trigger(job_id), "runner_group_id": group_id,
             "labels": ["self-hosted", "linux", "x64", label], "work_folder": "_work",
         })
 
@@ -359,7 +363,8 @@ class GitHubClient:
         if not runner_name or runner_id < 1:
             return None
         id_matches: dict[tuple[int, int], dict[str, Any]] = {}
-        statuses = ("in_progress", "completed") if include_completed else ("in_progress",)
+        statuses = ("in_progress", "completed", "queued") \
+            if include_completed else ("in_progress",)
         for status in statuses:
             runs = self.request(
                 "GET", f"{self.repo_path(repo)}/actions/runs?status={status}"
@@ -758,8 +763,11 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                 continue
             response = client.generate_jit(repo, job["job_id"], int(cfg.get("runner_group_id", 1)), label)
             encoded = response.get("encoded_jit_config")
-            runner_id = response.get("runner", {}).get("id")
-            runner_name = response.get("runner", {}).get("name")
+            runner = response.get("runner", {})
+            runner_id = runner.get("id") if isinstance(runner, dict) else None
+            reported_runner_name = runner.get("name") if isinstance(runner, dict) else None
+            runner_name = runner_name_for_trigger(job["job_id"])
+            runner_name_conflicts = reported_runner_name not in (None, "", runner_name)
             lease = f"gh-{job['job_id']}"
             registration = {
                 "lease": lease,
@@ -768,9 +776,9 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                 "trigger_run_id": job["run_id"],
                 "trigger_job_id": job["job_id"],
             }
-            if isinstance(runner_name, str) and runner_name:
-                registration["runner_name"] = runner_name
-            if not isinstance(encoded, str) or not isinstance(runner_id, int):
+            registration["runner_name"] = runner_name
+            if not isinstance(encoded, str) or not isinstance(runner_id, int) \
+                    or runner_name_conflicts:
                 if isinstance(runner_id, int):
                     store.write_cleanup_obligation(lease, registration, int(time.time()))
                     try:
@@ -786,8 +794,7 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                 launch(cfg, lease, encoded.encode("ascii"), metadata={
                     "repo": repo,
                     "runner_id": runner_id,
-                    **({"runner_name": runner_name}
-                       if isinstance(runner_name, str) and runner_name else {}),
+                    "runner_name": runner_name,
                     "trigger_run_id": job["run_id"],
                     "trigger_job_id": job["job_id"],
                 }, dispatch_history_key=key)
@@ -807,8 +814,7 @@ def dispatch_once(cfg: dict[str, Any], client: GitHubClient) -> bool:
                         "lease": lease,
                         "repo": repo,
                         "runner_id": runner_id,
-                        **({"runner_name": runner_name}
-                           if isinstance(runner_name, str) and runner_name else {}),
+                        "runner_name": runner_name,
                         "trigger_run_id": job["run_id"],
                         "trigger_job_id": job["job_id"],
                     }, int(time.time()), preserve_lease=True)

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -275,6 +275,7 @@ class ManagerTests(unittest.TestCase):
             {"jobs": [{"id": 83, "status": "in_progress", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
             {"workflow_runs": []},
+            {"workflow_runs": []},
         ])
 
         self.assertEqual(
@@ -289,11 +290,40 @@ class ManagerTests(unittest.TestCase):
             {"workflow_runs": [{"id": 11}]},
             {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
+            {"workflow_runs": []},
         ])
 
         self.assertEqual(
             client.find_assigned_job("Tuinstra-DEV/gate", 30, "sanctuary-20"),
             {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
+        )
+
+    def test_teardown_finds_completed_job_inside_queued_workflow_run(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(side_effect=[
+            {"workflow_runs": []},
+            {"workflow_runs": []},
+            {"workflow_runs": [{"id": 11}]},
+            {"jobs": [{"id": 77, "status": "completed", "runner_id": 36,
+                       "runner_name": "sanctuary-20"}]},
+        ])
+
+        self.assertEqual(
+            client.find_assigned_job("Tuinstra-DEV/gate", 36, "sanctuary-20"),
+            {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 77},
+        )
+
+    def test_healthy_assignment_search_does_not_scan_queued_workflow_runs(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(return_value={"workflow_runs": []})
+
+        self.assertIsNone(client.find_assigned_job(
+            "Tuinstra-DEV/gate", 36, "sanctuary-20", include_completed=False
+        ))
+
+        client.request.assert_called_once_with(
+            "GET", "/repos/Tuinstra-DEV/gate/actions/runs?status=in_progress"
+            f"&per_page={manager.ASSIGNMENT_RUNS_PER_STATUS}&page=1"
         )
 
     def test_find_assigned_job_ignores_reused_name_with_different_runner_id(self):
@@ -305,6 +335,7 @@ class ManagerTests(unittest.TestCase):
                        "runner_name": "sanctuary-20"}]},
             {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
+            {"workflow_runs": []},
         ])
 
         self.assertEqual(
@@ -319,6 +350,7 @@ class ManagerTests(unittest.TestCase):
             {"workflow_runs": [{"id": 10}]},
             {"jobs": [{"id": 21, "status": "completed",
                        "runner_name": "sanctuary-20"}]},
+            {"workflow_runs": []},
         ])
 
         self.assertIsNone(
@@ -334,6 +366,7 @@ class ManagerTests(unittest.TestCase):
                        "runner_name": "sanctuary-20"}]},
             {"jobs": [{"id": 83, "status": "completed", "runner_id": 30,
                        "runner_name": "sanctuary-20"}]},
+            {"workflow_runs": []},
         ])
 
         with self.assertRaisesRegex(manager.RunnerError, "ambiguous"):
@@ -426,7 +459,7 @@ class ManagerTests(unittest.TestCase):
             client.candidate_jobs.return_value = [{"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}]
             client.generate_jit.return_value = {
                 "encoded_jit_config": base64.b64encode(b"jit").decode(),
-                "runner": {"id": 30, "name": "sanctuary-20"},
+                "runner": {"id": 30},
             }
             cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
                    "repositories": ["Tuinstra-DEV/gate"], "runner_label": "trusted-heavy"}
@@ -452,6 +485,29 @@ class ManagerTests(unittest.TestCase):
             self.assertNotIn("actual_job_id=20", audit)
             self.assertEqual(launch.call_args.args[2], base64.b64encode(b"jit"))
             self.assertEqual(list((root / "run").iterdir()), [])
+
+    @mock.patch.object(manager, "launch")
+    def test_dispatch_rejects_conflicting_reported_runner_name(self, launch):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            client = mock.Mock()
+            client.candidate_jobs.return_value = [
+                {"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20}
+            ]
+            client.generate_jit.return_value = {
+                "encoded_jit_config": base64.b64encode(b"jit").decode(),
+                "runner": {"id": 30, "name": "unexpected-runner"},
+            }
+            cfg = {"state_dir": root / "state", "runtime_dir": root / "run",
+                   "repositories": ["Tuinstra-DEV/gate"],
+                   "runner_label": "trusted-heavy"}
+            (root / "run").mkdir()
+
+            with self.assertRaisesRegex(manager.RunnerError, "invalid JIT"):
+                manager.dispatch_once(cfg, client)
+
+            launch.assert_not_called()
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
 
     def test_dispatch_preserves_host_cleanup_when_launch_and_delete_fail(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- persist the locally requested runner name when GitHub omits it from the JIT response
- reject conflicting reported runner names and clean the registration
- discover completed assignments inside temporarily queued serial workflow runs
- keep actual attribution strictly bound to numeric runner ID

## Live evidence
Gate canary 29866948196 showed a 34-second completed job retained under a queued workflow run and a JIT response without a usable runner name. Runtime and cleanup stayed healthy; Gate remained hosted.

## Verification
- 76 runner tests passed
- platform contracts and lint passed
- diff check passed
- independent security review approved

## Rollback
Revert the merge commit and redeploy. Gate remains hosted until the live audit canary passes.

Tracker: DEV-1