### PR TITLE
bug[DEV-4] reap offline unassigned runners

### DIFF
--- a/runner/host-helper/ci_runner_host_helper.py
+++ b/runner/host-helper/ci_runner_host_helper.py
@@ -188,6 +188,18 @@ runcmd:
 """ % base64.b64encode(encoded_jit).decode("ascii")
 
 
+def cloud_init_network_config() -> str:
+    """Enable DHCP without depending on a hypervisor-specific interface name."""
+    return """version: 2
+ethernets:
+  runner:
+    match:
+      name: "en*"
+    dhcp4: true
+    dhcp6: false
+"""
+
+
 def launch(lease: str, encoded_jit: bytes | None = None, *,
            vcpus: int = VCPUS, memory_mib: int = MEMORY_MIB) -> None:
     if os.geteuid() != 0:
@@ -223,8 +235,16 @@ def launch(lease: str, encoded_jit: bytes | None = None, *,
             temp = Path(temporary)
             (temp / "user-data").write_text(user_data, encoding="utf-8")
             (temp / "meta-data").write_text(meta_data, encoding="utf-8")
+            (temp / "network-config").write_text(
+                cloud_init_network_config(), encoding="utf-8"
+            )
             os.chmod(temp / "user-data", 0o600)
-            run(["cloud-localds", str(seed), str(temp / "user-data"), str(temp / "meta-data")])
+            os.chmod(temp / "network-config", 0o600)
+            run([
+                "cloud-localds",
+                f"--network-config={temp / 'network-config'}",
+                str(seed), str(temp / "user-data"), str(temp / "meta-data"),
+            ])
         set_qemu_access(seed, qemu_uid, qemu_gid, 0o600)
         run(["virt-install", "--connect", LIBVIRT_URI,
              "--name", name(lease), "--memory", str(memory_mib), "--vcpus", str(vcpus),

--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -459,6 +459,16 @@ class GitHubClient:
         except NotFound:
             return
 
+    def get_runner(self, repo: str, runner_id: int) -> dict[str, Any]:
+        runner = self.request(
+            "GET", f"{self.repo_path(repo)}/actions/runners/{runner_id}"
+        )
+        if not isinstance(runner, dict) or runner.get("id") != runner_id \
+                or runner.get("status") not in {"online", "offline"} \
+                or not isinstance(runner.get("busy"), bool):
+            raise RunnerError("GitHub returned an invalid runner response")
+        return runner
+
     def get_job(self, repo: str, job_id: int) -> dict[str, Any]:
         job = self.request("GET", f"{self.repo_path(repo)}/actions/jobs/{job_id}")
         if not isinstance(job, dict) or job.get("id") != job_id:
@@ -683,6 +693,76 @@ def record_verified_assignment(store: StateStore, client: GitHubClient | None,
     return updated
 
 
+def unassigned_lease_is_stale(client: GitHubClient | None,
+                              state: dict[str, Any], now: int) -> bool:
+    """Identify a terminal trigger or a runner that never registered.
+
+    API failures preserve the lease. A completed trigger is terminal immediately;
+    an offline runner gets a bounded boot/registration grace period first.
+    """
+    if client is None or isinstance(state.get("actual_job_id"), int):
+        return False
+    repo = state.get("repo")
+    runner_id = state.get("runner_id")
+    lease = state.get("lease")
+    trigger_id = trigger_job_id(state)
+    if not isinstance(repo, str) or not isinstance(runner_id, int) \
+            or not isinstance(lease, str) or trigger_id is None:
+        return False
+    try:
+        job = client.get_job(repo, trigger_id)
+    except (NotFound, RunnerError) as exc:
+        LOG.warning(
+            "runner trigger status could not be verified lease=%s repo=%s "
+            "runner_id=%s trigger_job_id=%s error=%s",
+            lease, repo, runner_id, trigger_id, exc,
+        )
+        return False
+    job_status = job.get("status")
+    if job_status not in {"queued", "in_progress", "completed"}:
+        LOG.warning(
+            "runner trigger returned invalid status lease=%s repo=%s "
+            "runner_id=%s trigger_job_id=%s",
+            lease, repo, runner_id, trigger_id,
+        )
+        return False
+    if job_status == "completed":
+        LOG.info(
+            "unassigned runner trigger completed lease=%s repo=%s runner_id=%s "
+            "trigger_job_id=%s",
+            lease, repo, runner_id, trigger_id,
+        )
+        return True
+    launched_at = state.get("launched_at")
+    if not isinstance(launched_at, int) \
+            or launched_at + REGISTRATION_GRACE_SECONDS >= now:
+        return False
+    try:
+        runner = client.get_runner(repo, runner_id)
+    except NotFound:
+        LOG.info(
+            "unassigned runner registration disappeared lease=%s repo=%s "
+            "runner_id=%s trigger_job_id=%s",
+            lease, repo, runner_id, trigger_id,
+        )
+        return True
+    except RunnerError as exc:
+        LOG.warning(
+            "runner registration status could not be verified lease=%s repo=%s "
+            "runner_id=%s trigger_job_id=%s error=%s",
+            lease, repo, runner_id, trigger_id, exc,
+        )
+        return False
+    if runner["status"] == "offline" and runner["busy"] is False:
+        LOG.warning(
+            "unassigned runner stayed offline beyond registration grace "
+            "lease=%s repo=%s runner_id=%s trigger_job_id=%s",
+            lease, repo, runner_id, trigger_id,
+        )
+        return True
+    return False
+
+
 def retry_dispatch_handoff(store: StateStore, client: GitHubClient | None,
                            state: dict[str, Any], now: int) -> None:
     repo = state.get("repo")
@@ -800,6 +880,11 @@ def reconcile(cfg: dict[str, Any], client: GitHubClient | None = None) -> None:
             states[lease] = record_verified_assignment(
                 store, client, state, include_completed=lease not in healthy
             )
+        stale_unassigned = {
+            lease for lease in healthy
+            if unassigned_lease_is_stale(client, states[lease], now)
+        }
+        healthy -= stale_unassigned
         for lease in sorted(known - healthy):
             LOG.warning("cleaning completed or missing domain lease=%s", lease)
             helper(cfg, "destroy", lease)

--- a/runner/tests/test_host_helper.py
+++ b/runner/tests/test_host_helper.py
@@ -56,6 +56,14 @@ class HostHelperTests(unittest.TestCase):
         runcmd = user_data.split("runcmd:\n", 1)[1]
         self.assertEqual(runcmd, "  - [/usr/local/sbin/ci-runner-prepare-docker]\n")
 
+    def test_cloud_init_network_uses_name_independent_dhcp(self):
+        network_config = helper.cloud_init_network_config()
+
+        self.assertIn('name: "en*"', network_config)
+        self.assertIn("dhcp4: true", network_config)
+        self.assertIn("dhcp6: false", network_config)
+        self.assertNotIn("ens3", network_config)
+
     def test_lease_directory_cannot_escape_overlay_root(self):
         for value in ("../etc", "a/b", "white space", ""):
             with self.subTest(value=value), self.assertRaises(ValueError):
@@ -113,6 +121,13 @@ class HostHelperTests(unittest.TestCase):
         )
         self.assertEqual(
             virt_install[virt_install.index("--memory") + 1], str(helper.MEMORY_MIB)
+        )
+        cloud_localds = next(
+            call.args[0] for call in run.call_args_list
+            if call.args[0][0] == "cloud-localds"
+        )
+        self.assertTrue(
+            any(argument.startswith("--network-config=") for argument in cloud_localds)
         )
 
         self.assertIn(mock.call([

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -494,6 +494,20 @@ class ManagerTests(unittest.TestCase):
         )
         client.request.assert_called_once_with("GET", "/repos/Tuinstra-DEV/gate/actions/jobs/20")
 
+    def test_get_runner_validates_repository_runner_status(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(
+            return_value={"id": 30, "status": "offline", "busy": False}
+        )
+
+        self.assertEqual(
+            client.get_runner("Tuinstra-DEV/gate", 30),
+            {"id": 30, "status": "offline", "busy": False},
+        )
+        client.request.assert_called_once_with(
+            "GET", "/repos/Tuinstra-DEV/gate/actions/runners/30"
+        )
+
     def test_dispatch_history_deduplicates_job(self):
         with tempfile.TemporaryDirectory() as directory:
             history = manager.DispatchHistory(Path(directory))
@@ -790,6 +804,147 @@ class ManagerTests(unittest.TestCase):
             self.assertNotIn(("destroy", "healthy"), [
                 call.args[1:] for call in helper.call_args_list
             ])
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=2000)
+    def test_reconcile_destroys_unassigned_offline_runner_after_registration_grace(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.side_effect = [
+                mock.Mock(stdout=b'{"gh-20":"running"}'),
+                mock.Mock(),
+            ]
+            client = mock.Mock()
+            client.find_assigned_job.return_value = None
+            client.get_job.return_value = {"id": 20, "status": "queued"}
+            client.get_runner.return_value = {"id": 30, "status": "offline", "busy": False}
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual(store.leases(), [])
+            self.assertIn(("destroy", "gh-20"), [
+                call.args[1:] for call in helper.call_args_list
+            ])
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=1100)
+    def test_reconcile_preserves_offline_runner_during_registration_grace(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.return_value = mock.Mock(stdout=b'{"gh-20":"running"}')
+            client = mock.Mock()
+            client.find_assigned_job.return_value = None
+            client.get_job.return_value = {"id": 20, "status": "queued"}
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual([state["lease"] for state in store.leases()], ["gh-20"])
+            client.get_runner.assert_not_called()
+            client.delete_runner.assert_not_called()
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=2000)
+    def test_reconcile_preserves_unassigned_online_runner_after_registration_grace(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.return_value = mock.Mock(stdout=b'{"gh-20":"running"}')
+            client = mock.Mock()
+            client.find_assigned_job.return_value = None
+            client.get_job.return_value = {"id": 20, "status": "queued"}
+            client.get_runner.return_value = {"id": 30, "status": "online", "busy": False}
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual([state["lease"] for state in store.leases()], ["gh-20"])
+            client.delete_runner.assert_not_called()
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=1100)
+    def test_reconcile_destroys_unassigned_runner_when_trigger_is_completed(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.side_effect = [
+                mock.Mock(stdout=b'{"gh-20":"running"}'),
+                mock.Mock(),
+            ]
+            client = mock.Mock()
+            client.find_assigned_job.return_value = None
+            client.get_job.return_value = {
+                "id": 20, "status": "completed", "conclusion": "cancelled",
+            }
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual(store.leases(), [])
+            client.get_runner.assert_not_called()
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=2000)
+    def test_reconcile_preserves_unassigned_runner_when_github_status_is_unavailable(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            helper.return_value = mock.Mock(stdout=b'{"gh-20":"running"}')
+            client = mock.Mock()
+            client.find_assigned_job.return_value = None
+            client.get_job.side_effect = manager.RunnerError("GitHub API unavailable")
+
+            manager.reconcile(cfg, client)
+
+            self.assertEqual([state["lease"] for state in store.leases()], ["gh-20"])
+            client.get_runner.assert_not_called()
+            client.delete_runner.assert_not_called()
 
     @mock.patch.object(manager, "helper")
     def test_reconcile_deletes_persisted_github_runner_before_state(self, helper):


### PR DESCRIPTION
## Summary
- detect terminal dispatch triggers immediately
- reap unassigned runners that remain offline beyond the 5-minute registration grace
- seed explicit name-independent DHCP configuration into every NoCloud guest
- preserve leases when GitHub status cannot be verified

## Root cause
The immutable image retained installer networking for `ens3`, while Q35 runtime guests do not have a stable interface name. A failed guest could therefore remain offline while still occupying a healthy-looking running lease.

## Verification
- `make lint`
- `make test` (90 tests)
- targeted cleanup left zero runner domains on Sanctuary

## Security / availability
Lifecycle checks fail closed on GitHub API errors and keep online or assigned workers. Only terminal triggers and verified offline, idle registrations are reclaimed. DHCP matches Ethernet interfaces only and disables DHCPv6.