### PR TITLE
bug[DEV-1] preserve cross-assigned runner jobs

### DIFF
--- a/runner/manager/ci_runner_manager.py
+++ b/runner/manager/ci_runner_manager.py
@@ -418,10 +418,39 @@ class GitHubClient:
 
     def find_assigned_job(self, repo: str, runner_id: int,
                           runner_name: str, *,
+                          preferred_run_id: int | None = None,
                           include_completed: bool = True) -> dict[str, Any] | None:
         if not runner_name or runner_id < 1:
             return None
         id_matches: dict[tuple[int, int], dict[str, Any]] = {}
+
+        def inspect_run(run_id: int) -> None:
+            jobs = self.request(
+                "GET", f"{self.repo_path(repo)}/actions/runs/{run_id}"
+                "/jobs?filter=latest&per_page=100&page=1"
+            )
+            for job in jobs.get("jobs", []):
+                job_id = job.get("id")
+                if not isinstance(job_id, int):
+                    continue
+                reported_runner_id = job.get("runner_id")
+                reported_runner_name = job.get("runner_name")
+                assignment = {"repo": repo, "run_id": run_id, "job_id": job_id}
+                key = (run_id, job_id)
+                if not isinstance(reported_runner_id, int) \
+                        or reported_runner_id != runner_id:
+                    continue
+                if reported_runner_name not in (None, "", runner_name):
+                    raise RunnerError("GitHub returned a conflicting runner assignment")
+                id_matches[key] = assignment
+
+        if isinstance(preferred_run_id, int) and preferred_run_id > 0:
+            inspect_run(preferred_run_id)
+            if len(id_matches) > 1:
+                raise RunnerError("GitHub returned an ambiguous runner assignment")
+            if id_matches:
+                return next(iter(id_matches.values()))
+
         statuses = ("in_progress", "completed", "queued") \
             if include_completed else ("in_progress",)
         for status in statuses:
@@ -431,24 +460,8 @@ class GitHubClient:
             )
             for run in runs.get("workflow_runs", []):
                 run_id = int(run["id"])
-                jobs = self.request(
-                    "GET", f"{self.repo_path(repo)}/actions/runs/{run_id}"
-                    "/jobs?filter=latest&per_page=100&page=1"
-                )
-                for job in jobs.get("jobs", []):
-                    job_id = job.get("id")
-                    if not isinstance(job_id, int):
-                        continue
-                    reported_runner_id = job.get("runner_id")
-                    reported_runner_name = job.get("runner_name")
-                    assignment = {"repo": repo, "run_id": run_id, "job_id": job_id}
-                    key = (run_id, job_id)
-                    if not isinstance(reported_runner_id, int) \
-                            or reported_runner_id != runner_id:
-                        continue
-                    if reported_runner_name not in (None, "", runner_name):
-                        raise RunnerError("GitHub returned a conflicting runner assignment")
-                    id_matches[key] = assignment
+                if run_id != preferred_run_id:
+                    inspect_run(run_id)
         if len(id_matches) > 1:
             raise RunnerError("GitHub returned an ambiguous runner assignment")
         return next(iter(id_matches.values())) if id_matches else None
@@ -661,13 +674,18 @@ def record_verified_assignment(store: StateStore, client: GitHubClient | None,
     lease = state.get("lease")
     runner_id = state.get("runner_id")
     trigger_id = trigger_job_id(state)
+    trigger_run_id = state.get("trigger_run_id", state.get("run_id"))
     if not isinstance(repo, str) or not isinstance(runner_name, str) \
             or not isinstance(lease, str) or not isinstance(runner_id, int) \
             or trigger_id is None:
         return state
     try:
         assignment = client.find_assigned_job(
-            repo, runner_id, runner_name, include_completed=include_completed
+            repo,
+            runner_id,
+            runner_name,
+            preferred_run_id=trigger_run_id if isinstance(trigger_run_id, int) else None,
+            include_completed=include_completed,
         )
     except RunnerError as exc:
         LOG.warning(
@@ -695,10 +713,13 @@ def record_verified_assignment(store: StateStore, client: GitHubClient | None,
 
 def unassigned_lease_is_stale(client: GitHubClient | None,
                               state: dict[str, Any], now: int) -> bool:
-    """Identify a terminal trigger or a runner that never registered.
+    """Identify an unassigned runner with positive offline evidence.
 
-    API failures preserve the lease. A completed trigger is terminal immediately;
-    an offline runner gets a bounded boot/registration grace period first.
+    Trigger identity is only an admission hint: a JIT runner can accept another
+    same-label job. API failures and missing ephemeral registrations therefore
+    preserve the lease. After the boot grace period, only a present, offline,
+    non-busy registration is safe to reap before the local domain stops or its
+    hard TTL expires.
     """
     if client is None or isinstance(state.get("actual_job_id"), int):
         return False
@@ -726,18 +747,6 @@ def unassigned_lease_is_stale(client: GitHubClient | None,
             lease, repo, runner_id, trigger_id,
         )
         return False
-    if job_status == "completed":
-        LOG.info(
-            "unassigned runner trigger completed lease=%s repo=%s runner_id=%s "
-            "trigger_job_id=%s",
-            lease, repo, runner_id, trigger_id,
-        )
-        return True
-    if job_status == "in_progress":
-        # GitHub may remove an ephemeral runner registration from the runner
-        # endpoint as soon as it accepts work. The active trigger is the
-        # authoritative liveness signal until assignment audit catches up.
-        return False
     launched_at = state.get("launched_at")
     if not isinstance(launched_at, int) \
             or launched_at + REGISTRATION_GRACE_SECONDS >= now:
@@ -746,11 +755,11 @@ def unassigned_lease_is_stale(client: GitHubClient | None,
         runner = client.get_runner(repo, runner_id)
     except NotFound:
         LOG.info(
-            "unassigned runner registration disappeared lease=%s repo=%s "
-            "runner_id=%s trigger_job_id=%s",
+            "preserving unassigned lease with missing ephemeral registration "
+            "lease=%s repo=%s runner_id=%s trigger_job_id=%s",
             lease, repo, runner_id, trigger_id,
         )
-        return True
+        return False
     except RunnerError as exc:
         LOG.warning(
             "runner registration status could not be verified lease=%s repo=%s "

--- a/runner/tests/test_manager.py
+++ b/runner/tests/test_manager.py
@@ -372,6 +372,31 @@ class ManagerTests(unittest.TestCase):
             {"repo": "Tuinstra-DEV/gate", "run_id": 11, "job_id": 83},
         )
 
+    def test_find_assigned_job_checks_trigger_run_before_bounded_status_scan(self):
+        client = manager.GitHubClient("secret")
+        client.request = mock.Mock(return_value={
+            "jobs": [
+                {"id": 83, "status": "in_progress", "runner_id": 30,
+                 "runner_name": "sanctuary-20"},
+            ],
+        })
+
+        self.assertEqual(
+            client.find_assigned_job(
+                "Tuinstra-DEV/gate",
+                30,
+                "sanctuary-20",
+                preferred_run_id=10,
+                include_completed=False,
+            ),
+            {"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 83},
+        )
+        client.request.assert_called_once_with(
+            "GET",
+            "/repos/Tuinstra-DEV/gate/actions/runs/10/jobs"
+            "?filter=latest&per_page=100&page=1",
+        )
+
     def test_find_assigned_job_captures_fast_completed_job_by_runner_id(self):
         client = manager.GitHubClient("secret")
         client.request = mock.Mock(side_effect=[
@@ -919,8 +944,8 @@ class ManagerTests(unittest.TestCase):
             client.delete_runner.assert_not_called()
 
     @mock.patch.object(manager, "helper")
-    @mock.patch.object(manager.time, "time", return_value=1100)
-    def test_reconcile_destroys_unassigned_runner_when_trigger_is_completed(
+    @mock.patch.object(manager.time, "time", return_value=2000)
+    def test_reconcile_preserves_unassigned_runner_when_completed_trigger_is_ambiguous(
             self, _time, helper):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -942,12 +967,68 @@ class ManagerTests(unittest.TestCase):
             client.get_job.return_value = {
                 "id": 20, "status": "completed", "conclusion": "cancelled",
             }
+            client.get_runner.side_effect = manager.NotFound(
+                "ephemeral registration may already be assigned"
+            )
 
             manager.reconcile(cfg, client)
 
-            self.assertEqual(store.leases(), [])
-            client.get_runner.assert_not_called()
-            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            self.assertEqual([state["lease"] for state in store.leases()], ["gh-20"])
+            self.assertNotIn(("destroy", "gh-20"), [
+                call.args[1:] for call in helper.call_args_list
+            ])
+            client.get_runner.assert_called_once_with("Tuinstra-DEV/gate", 30)
+            client.delete_runner.assert_not_called()
+
+    @mock.patch.object(manager, "helper")
+    @mock.patch.object(manager.time, "time", return_value=2000)
+    def test_reconcile_cross_assignment_never_reaps_ambiguous_running_lease(
+            self, _time, helper):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cfg = {"state_dir": root / "state", "lock_file": root / "lock",
+                   "max_lease_seconds": 7200}
+            store = manager.StateStore(cfg["state_dir"])
+            store.write("gh-20", {
+                "lease": "gh-20", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 30,
+                "runner_name": "sanctuary-20", "trigger_run_id": 10,
+                "trigger_job_id": 20,
+            })
+            store.write("gh-21", {
+                "lease": "gh-21", "phase": "running", "launched_at": 1000,
+                "repo": "Tuinstra-DEV/gate", "runner_id": 31,
+                "runner_name": "sanctuary-21", "trigger_run_id": 10,
+                "trigger_job_id": 21,
+            })
+            helper.side_effect = [
+                mock.Mock(stdout=b'{"gh-20":"running","gh-21":"shut off"}'),
+                mock.Mock(),
+            ]
+            client = mock.Mock()
+            client.find_assigned_job.side_effect = [
+                None,
+                {"repo": "Tuinstra-DEV/gate", "run_id": 10, "job_id": 20},
+            ]
+            client.get_job.return_value = {
+                "id": 20, "status": "completed", "conclusion": "success",
+            }
+            client.get_runner.side_effect = manager.NotFound(
+                "ephemeral registration may already be assigned"
+            )
+
+            manager.reconcile(cfg, client)
+
+            leases = {state["lease"]: state for state in store.leases()}
+            self.assertEqual(set(leases), {"gh-20"})
+            self.assertNotIn("actual_job_id", leases["gh-20"])
+            self.assertNotIn(("destroy", "gh-20"), [
+                call.args[1:] for call in helper.call_args_list
+            ])
+            self.assertIn(("destroy", "gh-21"), [
+                call.args[1:] for call in helper.call_args_list
+            ])
+            client.delete_runner.assert_called_once_with("Tuinstra-DEV/gate", 31)
 
     @mock.patch.object(manager, "helper")
     @mock.patch.object(manager.time, "time", return_value=2000)
@@ -1025,7 +1106,11 @@ class ManagerTests(unittest.TestCase):
             self.assertEqual(state["lease"], "gh-20")
             self.assertIn("trigger_job_id=20 actual_job_id=83", "\n".join(logs.output))
             client.find_assigned_job.assert_called_once_with(
-                "Tuinstra-DEV/gate", 30, "sanctuary-20", include_completed=False
+                "Tuinstra-DEV/gate",
+                30,
+                "sanctuary-20",
+                preferred_run_id=10,
+                include_completed=False,
             )
 
     @mock.patch.object(manager.time, "time", return_value=1001)
@@ -1062,7 +1147,11 @@ class ManagerTests(unittest.TestCase):
             self.assertEqual(pending["runner_id"], 30)
             self.assertEqual(pending["lease"], "gh-20")
             client.find_assigned_job.assert_called_once_with(
-                "Tuinstra-DEV/gate", 30, "sanctuary-20", include_completed=True
+                "Tuinstra-DEV/gate",
+                30,
+                "sanctuary-20",
+                preferred_run_id=10,
+                include_completed=True,
             )
             manager.retry_pending_cleanup(store, client, 1031)
 


### PR DESCRIPTION
## Summary
- inspect the known workflow run before the bounded status scan so cross-assigned JIT runners are correlated by numeric runner ID
- stop treating an admission trigger completing or an ephemeral runner registration disappearing as proof that a running VM is idle
- reap unassigned running guests only with positive offline/non-busy evidence, local shutdown, or the existing hard TTL

## Live reproduction
Tracker release canary run `30008167431` cross-assigned frontend job `89209199487` to runner 103 and backend job `89209199573` to runner 102. The manager missed runner 102 in its bounded scan and destroyed the backend VM when runner 102's unrelated trigger completed.

## Verification
- regression test failed on `main` before implementation
- exact two-lease cross-assignment regression is covered
- `make lint`
- `make test` (93 tests)

## Safety
Ambiguous GitHub state now fails safe. Local domain shutdown and the 7,200-second hard TTL remain authoritative cleanup boundaries; a present `offline && !busy` registration is still reaped after the five-minute registration grace.