### PR TITLE
feat[DEV-6] Implement shared heavy-CI orchestration contract v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,6 @@ docs/workflows/release-procedure.md @marcel-tuinstra
 # Security policy and executable workflow contract checks
 docs/security/pipeline-security-policy.md @marcel-tuinstra
 scripts/workflow-contract-test.sh @marcel-tuinstra
+scripts/heavy-ci-v2-contract-test.rb @marcel-tuinstra
+tests/fixtures/heavy-ci-v2/ @marcel-tuinstra
+templates/workflows/caller-heavy-ci-v2-canary.yml @marcel-tuinstra

--- a/.github/workflows/heavy-ci-v2-integration.yml
+++ b/.github/workflows/heavy-ci-v2-integration.yml
@@ -1,0 +1,39 @@
+name: Heavy CI v2 integration
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-heavy-ci-v2.yml
+      - .github/workflows/heavy-ci-v2-integration.yml
+      - tests/fixtures/heavy-ci-v2/**
+      - scripts/heavy-ci-v2-contract-test.rb
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wodiq-shape:
+    uses: ./.github/workflows/reusable-heavy-ci-v2.yml
+    with:
+      contract-id: wodiq-shape
+      execution-class: hosted
+      cache-policy: off
+      toolchain: node24-npm11
+      lockfile: tests/fixtures/heavy-ci-v2/wodiq/package-lock.json
+      entrypoint: tests/fixtures/heavy-ci-v2/wodiq/entrypoint.sh
+      run-unit: true
+      run-browser: true
+
+  tracker-shape:
+    uses: ./.github/workflows/reusable-heavy-ci-v2.yml
+    with:
+      contract-id: tracker-shape
+      execution-class: hosted
+      cache-policy: off
+      toolchain: node24-pnpm10-php83
+      lockfile: tests/fixtures/heavy-ci-v2/tracker/pnpm-lock.yaml
+      entrypoint: tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
+      run-unit: true
+      run-integration: true
+      run-browser: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Run lint
         run: make lint
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Run test
         run: make test

--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -1,0 +1,448 @@
+name: Reusable Heavy CI v2
+
+on:
+  workflow_call:
+    inputs:
+      contract-id:
+        description: Unique identifier when a caller invokes the contract more than once
+        required: false
+        default: default
+        type: string
+      execution-class:
+        description: "Execution class: hosted or trusted-heavy"
+        required: false
+        default: hosted
+        type: string
+      cache-policy:
+        description: "Dependency cache policy: off, restore-only, or trusted-write"
+        required: false
+        default: restore-only
+        type: string
+      cache-path:
+        description: Repository-relative tool download cache; installed dependencies and build output are forbidden
+        required: false
+        default: .cache/heavy-ci
+        type: string
+      cache-schema:
+        description: Caller-controlled cache schema version
+        required: false
+        default: v1
+        type: string
+      toolchain:
+        description: Stable toolchain identifier included in the cache key
+        required: true
+        type: string
+      lockfile:
+        description: Repository-relative lockfile used in the cache key
+        required: true
+        type: string
+      entrypoint:
+        description: Repository-relative Bash adapter accepting a fixed stage name
+        required: false
+        default: .github/ci/heavy-ci
+        type: string
+      artifact-path:
+        description: Repository-relative build payload produced by the build stage
+        required: false
+        default: .heavy-ci/payload
+        type: string
+      run-unit:
+        required: false
+        default: true
+        type: boolean
+      run-integration:
+        required: false
+        default: false
+        type: boolean
+      run-browser:
+        required: false
+        default: false
+        type: boolean
+      run-live-smoke:
+        required: false
+        default: false
+        type: boolean
+      artifact-retention-days:
+        required: false
+        default: 14
+        type: number
+    outputs:
+      contract-version:
+        value: ${{ jobs.preflight.outputs.contract-version }}
+      artifact-name:
+        value: ${{ jobs.preflight.outputs.artifact-name }}
+      artifact-id:
+        value: ${{ jobs.build.outputs.artifact-id }}
+      artifact-digest:
+        value: ${{ jobs.build.outputs.artifact-digest }}
+      payload-sha256:
+        value: ${{ jobs.build.outputs.payload-sha256 }}
+      effective-execution-class:
+        value: ${{ jobs.preflight.outputs.effective-execution-class }}
+      cache-key:
+        value: ${{ jobs.build.outputs.cache-key }}
+      cache-hit:
+        value: ${{ jobs.build.outputs.cache-hit }}
+      metrics-artifact:
+        value: ${{ jobs.summary.outputs.metrics-artifact }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      contract-version: ${{ steps.contract.outputs.contract-version }}
+      artifact-name: ${{ steps.contract.outputs.artifact-name }}
+      metrics-artifact: ${{ steps.contract.outputs.metrics-artifact }}
+      runner: ${{ steps.contract.outputs.runner }}
+      trust-tier: ${{ steps.contract.outputs.trust-tier }}
+      can-write-cache: ${{ steps.contract.outputs.can-write-cache }}
+      effective-execution-class: ${{ steps.contract.outputs.effective-execution-class }}
+      matrix: ${{ steps.contract.outputs.matrix }}
+      has-fanout: ${{ steps.contract.outputs.has-fanout }}
+    steps:
+      - name: Validate contract and route trust
+        id: contract
+        shell: bash
+        env:
+          CONTRACT_ID: ${{ inputs.contract-id }}
+          EXECUTION_CLASS: ${{ inputs.execution-class }}
+          CACHE_POLICY: ${{ inputs.cache-policy }}
+          CACHE_PATH: ${{ inputs.cache-path }}
+          CACHE_SCHEMA: ${{ inputs.cache-schema }}
+          TOOLCHAIN: ${{ inputs.toolchain }}
+          LOCKFILE: ${{ inputs.lockfile }}
+          ENTRYPOINT: ${{ inputs.entrypoint }}
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+          RETENTION_DAYS: ${{ inputs.artifact-retention-days }}
+          EVENT_NAME: ${{ github.event_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          ACTOR: ${{ github.actor }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_UNIT: ${{ inputs.run-unit }}
+          RUN_INTEGRATION: ${{ inputs.run-integration }}
+          RUN_BROWSER: ${{ inputs.run-browser }}
+          RUN_LIVE_SMOKE: ${{ inputs.run-live-smoke }}
+        run: |
+          set -euo pipefail
+          case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
+          case "$CACHE_POLICY" in off|restore-only|trusted-write) ;; *) echo "cache-policy must be off, restore-only, or trusted-write" >&2; exit 2 ;; esac
+          for token in "$CONTRACT_ID" "$CACHE_SCHEMA" "$TOOLCHAIN"; do
+            [[ "$token" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "contract-id, cache-schema, and toolchain accept only safe identifier characters" >&2; exit 2; }
+          done
+          for path in "$CACHE_PATH" "$LOCKFILE" "$ENTRYPOINT" "$ARTIFACT_PATH"; do
+            [[ -n "$path" && "$path" != /* && ! "$path" =~ (^|/)\.\.(/|$) ]] || { echo "paths must be non-empty, repository-relative, and may not contain '..'" >&2; exit 2; }
+          done
+          [[ "$CACHE_PATH" != *$'\n'* ]] || { echo "cache-path accepts one repository-relative path" >&2; exit 2; }
+          while IFS= read -r cache_entry; do
+            [[ -z "$cache_entry" ]] && continue
+            [[ "$cache_entry" != /* && ! "$cache_entry" =~ (^|/)\.\.(/|$) ]] || { echo "cache paths must be repository-relative" >&2; exit 2; }
+            [[ ! "$cache_entry" =~ (^|/)(node_modules|vendor|dist|build|\.output)(/|$) ]] || { echo "installed dependencies and build outputs may not be shared as dependency caches" >&2; exit 2; }
+          done <<< "$CACHE_PATH"
+          (( RETENTION_DAYS >= 1 && RETENTION_DAYS <= 30 )) || { echo "artifact-retention-days must be between 1 and 30" >&2; exit 2; }
+
+          untrusted=false
+          if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = 'dependabot[bot]' ]]; then
+            untrusted=true
+          fi
+          if [[ "$EXECUTION_CLASS" = trusted-heavy && "$untrusted" = true ]]; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+            exit 2
+          fi
+
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]]; then
+            runner='["self-hosted","trusted-heavy"]'
+          else
+            runner='"ubuntu-24.04"'
+          fi
+          trust_tier=trusted
+          [[ "$untrusted" = true ]] && trust_tier=untrusted
+          can_write_cache=false
+          if [[ "$CACHE_POLICY" = trusted-write && "$trust_tier" = trusted && "$EVENT_NAME" = push && "$REF_NAME" = "$DEFAULT_BRANCH" ]]; then
+            can_write_cache=true
+          fi
+
+          stages=()
+          [[ "$RUN_UNIT" = true ]] && stages+=(unit)
+          [[ "$RUN_INTEGRATION" = true ]] && stages+=(integration)
+          [[ "$RUN_BROWSER" = true ]] && stages+=(browser)
+          [[ "$RUN_LIVE_SMOKE" = true ]] && stages+=(live-smoke)
+          matrix='{"include":['
+          separator=''
+          for stage in "${stages[@]}"; do
+            matrix+="${separator}{\"stage\":\"${stage}\"}"
+            separator=,
+          done
+          matrix+=']}'
+          [[ ${#stages[@]} -gt 0 ]] && has_fanout=true || has_fanout=false
+
+          artifact_name="heavy-ci-v2-${CONTRACT_ID}-${GITHUB_REPOSITORY_ID}-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "contract-version=heavy-ci/v2"
+            echo "artifact-name=$artifact_name"
+            echo "metrics-artifact=${artifact_name}-metrics"
+            echo "runner=$runner"
+            echo "trust-tier=$trust_tier"
+            echo "can-write-cache=$can_write_cache"
+            echo "effective-execution-class=$EXECUTION_CLASS"
+            echo "matrix=$matrix"
+            echo "has-fanout=$has_fanout"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: preflight
+    runs-on: ${{ fromJSON(needs.preflight.outputs.runner) }}
+    permissions:
+      contents: read
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
+      payload-sha256: ${{ steps.bundle.outputs.payload-sha256 }}
+      cache-key: ${{ steps.cache-key.outputs.key }}
+      cache-hit: ${{ steps.cache-restore.outputs.cache-hit || 'false' }}
+    steps:
+      - name: Checkout exact source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+
+      - name: Validate repository adapter and lockfile
+        shell: bash
+        env:
+          ENTRYPOINT: ${{ inputs.entrypoint }}
+          LOCKFILE: ${{ inputs.lockfile }}
+        run: |
+          set -euo pipefail
+          [[ -f "$ENTRYPOINT" ]] || { echo "missing entrypoint: $ENTRYPOINT" >&2; exit 2; }
+          [[ -f "$LOCKFILE" ]] || { echo "missing lockfile: $LOCKFILE" >&2; exit 2; }
+
+      - name: Derive isolated dependency cache key
+        id: cache-key
+        shell: bash
+        env:
+          TRUST_TIER: ${{ needs.preflight.outputs.trust-tier }}
+          CONTRACT_ID: ${{ inputs.contract-id }}
+          TOOLCHAIN: ${{ inputs.toolchain }}
+          CACHE_SCHEMA: ${{ inputs.cache-schema }}
+          LOCKFILE_HASH: ${{ hashFiles(inputs.lockfile) }}
+          CONTENT_HASH: ${{ hashFiles(inputs.lockfile, inputs.entrypoint) }}
+        run: |
+          set -euo pipefail
+          runner_image="${ImageOS:-self-hosted}"
+          key="${GITHUB_REPOSITORY_ID}-heavy-ci-v2-${CONTRACT_ID}-${TRUST_TIER}-${RUNNER_OS}-${RUNNER_ARCH}-${runner_image}-${TOOLCHAIN}-${CACHE_SCHEMA}-${LOCKFILE_HASH}-${CONTENT_HASH}"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore isolated dependency cache
+        id: cache-restore
+        if: ${{ inputs.cache-policy != 'off' }}
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ inputs.cache-path }}
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Bootstrap once and build once
+        id: build-stage
+        shell: bash
+        env:
+          ENTRYPOINT: ${{ inputs.entrypoint }}
+          CACHE_PATH: ${{ inputs.cache-path }}
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        run: |
+          set -uo pipefail
+          mkdir -p .heavy-ci/evidence "$CACHE_PATH"
+          bootstrap_started=$(date +%s)
+          bash "$ENTRYPOINT" bootstrap
+          bootstrap_status=$?
+          bootstrap_finished=$(date +%s)
+          printf '{"stage":"bootstrap","started":%s,"finished":%s,"duration_seconds":%s,"status":%s}\n' \
+            "$bootstrap_started" "$bootstrap_finished" "$((bootstrap_finished-bootstrap_started))" "$bootstrap_status" > .heavy-ci/evidence/bootstrap.json
+          if (( bootstrap_status == 0 )); then
+            build_started=$(date +%s)
+            bash "$ENTRYPOINT" build
+            stage_status=$?
+            build_finished=$(date +%s)
+            printf '{"stage":"build","started":%s,"finished":%s,"duration_seconds":%s,"status":%s}\n' \
+              "$build_started" "$build_finished" "$((build_finished-build_started))" "$stage_status" > .heavy-ci/evidence/build.json
+          else
+            stage_status=$bootstrap_status
+          fi
+          (( stage_status == 0 )) || exit "$stage_status"
+          [[ -e "$ARTIFACT_PATH" ]] || { echo "build did not produce artifact-path: $ARTIFACT_PATH" >&2; exit 2; }
+
+      - name: Save canonical dependency cache
+        if: ${{ needs.preflight.outputs.can-write-cache == 'true' && steps.cache-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ inputs.cache-path }}
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Create immutable build bundle
+        id: bundle
+        shell: bash
+        env:
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+          ARTIFACT_NAME: ${{ needs.preflight.outputs.artifact-name }}
+          CONTRACT_VERSION: ${{ needs.preflight.outputs.contract-version }}
+        run: |
+          set -euo pipefail
+          started=$(date +%s)
+          bundle_dir="$RUNNER_TEMP/heavy-ci-bundle"
+          mkdir -p "$bundle_dir"
+          if find "$ARTIFACT_PATH" -type l -print -quit | grep -q .; then
+            echo "artifact-path may not contain symbolic links" >&2
+            exit 2
+          fi
+          tar -czf "$bundle_dir/payload.tar.gz" "$ARTIFACT_PATH"
+          payload_sha=$(sha256sum "$bundle_dir/payload.tar.gz" | awk '{print $1}')
+          printf '{"contract_version":"%s","source_sha":"%s","repository_id":"%s","run_id":"%s","run_attempt":"%s","artifact_name":"%s","payload_sha256":"%s","runner_os":"%s","runner_arch":"%s"}\n' \
+            "$CONTRACT_VERSION" "$GITHUB_SHA" "$GITHUB_REPOSITORY_ID" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$ARTIFACT_NAME" "$payload_sha" "$RUNNER_OS" "$RUNNER_ARCH" > "$bundle_dir/manifest.json"
+          finished=$(date +%s)
+          printf '{"stage":"artifact-capture","started":%s,"finished":%s,"duration_seconds":%s,"status":0}\n' \
+            "$started" "$finished" "$((finished-started))" > .heavy-ci/evidence/artifact-capture.json
+          echo "payload-sha256=$payload_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable build bundle
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ needs.preflight.outputs.artifact-name }}
+          path: ${{ runner.temp }}/heavy-ci-bundle
+          if-no-files-found: error
+          retention-days: ${{ inputs.artifact-retention-days }}
+          compression-level: 0
+
+      - name: Upload build timing and failure evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ needs.preflight.outputs.artifact-name }}-evidence-build
+          path: .heavy-ci/evidence
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
+
+  fanout:
+    if: ${{ needs.preflight.outputs.has-fanout == 'true' }}
+    needs: [preflight, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.preflight.outputs.matrix) }}
+    runs-on: ${{ fromJSON(needs.preflight.outputs.runner) }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+
+      - name: Download build bundle by immutable artifact ID
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact-id }}
+          path: ${{ runner.temp }}/heavy-ci-bundle
+
+      - name: Verify and restore exact build bundle
+        shell: bash
+        env:
+          CONTRACT_VERSION: ${{ needs.preflight.outputs.contract-version }}
+          ARTIFACT_NAME: ${{ needs.preflight.outputs.artifact-name }}
+          PAYLOAD_SHA256: ${{ needs.build.outputs.payload-sha256 }}
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        run: |
+          set -euo pipefail
+          bundle_dir="$RUNNER_TEMP/heavy-ci-bundle"
+          manifest="$bundle_dir/manifest.json"
+          payload="$bundle_dir/payload.tar.gz"
+          [[ -f "$manifest" && -f "$payload" ]] || { echo "artifact bundle is incomplete" >&2; exit 2; }
+          grep -Fq "\"contract_version\":\"$CONTRACT_VERSION\"" "$manifest"
+          grep -Fq "\"source_sha\":\"$GITHUB_SHA\"" "$manifest"
+          grep -Fq "\"repository_id\":\"$GITHUB_REPOSITORY_ID\"" "$manifest"
+          grep -Fq "\"run_id\":\"$GITHUB_RUN_ID\"" "$manifest"
+          grep -Fq "\"run_attempt\":\"$GITHUB_RUN_ATTEMPT\"" "$manifest"
+          grep -Fq "\"artifact_name\":\"$ARTIFACT_NAME\"" "$manifest"
+          grep -Fq "\"runner_os\":\"$RUNNER_OS\"" "$manifest"
+          grep -Fq "\"runner_arch\":\"$RUNNER_ARCH\"" "$manifest"
+          actual_sha=$(sha256sum "$payload" | awk '{print $1}')
+          [[ "$actual_sha" = "$PAYLOAD_SHA256" ]] || { echo "artifact payload checksum mismatch" >&2; exit 2; }
+          if tar -tzf "$payload" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+            echo "artifact contains an unsafe path" >&2
+            exit 2
+          fi
+          while IFS= read -r entry; do
+            [[ "$entry" = "$ARTIFACT_PATH" || "$entry" = "$ARTIFACT_PATH/"* ]] || { echo "artifact contains a path outside artifact-path" >&2; exit 2; }
+          done < <(tar -tzf "$payload")
+          tar -xzf "$payload" -C "$GITHUB_WORKSPACE"
+
+      - name: Run typed fan-out stage
+        shell: bash
+        env:
+          ENTRYPOINT: ${{ inputs.entrypoint }}
+          STAGE: ${{ matrix.stage }}
+          HEAVY_CI_ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        run: |
+          set -uo pipefail
+          mkdir -p .heavy-ci/evidence
+          if [[ "$STAGE" = browser ]]; then
+            prepare_started=$(date +%s)
+            bash "$ENTRYPOINT" e2e-prepare
+            stage_status=$?
+            prepare_finished=$(date +%s)
+            printf '{"stage":"e2e-prepare","started":%s,"finished":%s,"duration_seconds":%s,"status":%s,"artifact_id":"%s","payload_sha256":"%s"}\n' \
+              "$prepare_started" "$prepare_finished" "$((prepare_finished-prepare_started))" "$stage_status" "${{ needs.build.outputs.artifact-id }}" "${{ needs.build.outputs.payload-sha256 }}" > .heavy-ci/evidence/e2e-prepare.json
+          else
+            stage_status=0
+          fi
+          if (( stage_status == 0 )); then
+            started=$(date +%s)
+            bash "$ENTRYPOINT" "$STAGE"
+            stage_status=$?
+            finished=$(date +%s)
+            printf '{"stage":"%s","started":%s,"finished":%s,"duration_seconds":%s,"status":%s,"artifact_id":"%s","payload_sha256":"%s"}\n' \
+              "$STAGE" "$started" "$finished" "$((finished-started))" "$stage_status" "${{ needs.build.outputs.artifact-id }}" "${{ needs.build.outputs.payload-sha256 }}" > ".heavy-ci/evidence/${STAGE}.json"
+          fi
+          exit "$stage_status"
+
+      - name: Upload stage timing and failure evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ needs.preflight.outputs.artifact-name }}-evidence-${{ matrix.stage }}
+          path: .heavy-ci/evidence
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
+
+  summary:
+    if: ${{ always() && needs.preflight.result == 'success' }}
+    needs: [preflight, build, fanout]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      metrics-artifact: ${{ steps.metrics.outputs.metrics-artifact }}
+    steps:
+      - name: Download stage evidence from this run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: ${{ needs.preflight.outputs.artifact-name }}-evidence-*
+          path: evidence
+          merge-multiple: true
+
+      - name: Assemble timing summary
+        id: metrics
+        shell: bash
+        env:
+          METRICS_ARTIFACT: ${{ needs.preflight.outputs.metrics-artifact }}
+        run: |
+          set -euo pipefail
+          mkdir -p metrics
+          find evidence -type f -name '*.json' -print0 | sort -z | xargs -0 -r cat > metrics/stages.ndjson
+          echo "metrics-artifact=$METRICS_ARTIFACT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload consolidated timing evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ needs.preflight.outputs.metrics-artifact }}
+          path: metrics/stages.ndjson
+          if-no-files-found: error
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -341,6 +341,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.build.outputs.artifact-id }}
           path: ${{ runner.temp }}/heavy-ci-bundle
+          merge-multiple: true
 
       - name: Verify and restore exact build bundle
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@ This repository is maintained through story-driven branches.
 
 ## Delivery Rules
 
-- Branch naming: `feat/SC-<id>`.
+- Branch naming: `feat/<story-key>-<slug>`.
 - Every story must run `make lint` and `make test`.
-- PR titles use `<type>[SC-<id>] <title>` where `<type>` is `feat`, `chore`, or `bug`.
+- PR titles use `<type>[<story-key>] <title>` where `<type>` is `feat`, `chore`, or `bug`.
 - Do not merge story branches automatically.
 
 ## Release Tags
 
 - Reusable workflows are consumed via major version tags (`v1`, `v2`, ...).
-- After merging to `main`, update the tag: `make release-tag TAG=v1`.
-- Never force-push `main`. Only force-push tags via `make release-tag`.
+- After merging to `main`, create a new immutable semantic release tag using the documented procedure.
+- Never force-push branches or tags and never move an existing release tag.
 - See `docs/workflows/release-procedure.md` for full procedure.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test-runner release-tag
+.PHONY: lint test test-runner
 
 lint:
 	./scripts/lint.sh
@@ -8,11 +8,3 @@ test:
 
 test-runner:
 	./scripts/test-runner-platform.sh
-
-# Usage: make release-tag TAG=v1
-# Moves an existing tag to current HEAD and force-pushes it.
-release-tag:
-	@if [ -z "$(TAG)" ]; then echo "Usage: make release-tag TAG=v1"; exit 1; fi
-	git tag -f $(TAG) HEAD
-	git push origin $(TAG) --force
-	@echo "Tag $(TAG) now points to $$(git rev-parse --short HEAD)"

--- a/docs/security/pipeline-security-policy.md
+++ b/docs/security/pipeline-security-policy.md
@@ -66,6 +66,14 @@ the DevOps platform.
 - Production reusable-workflow callers pin the approved v10 release commit by full SHA. Tags remain immutable discovery and audit markers.
 - Rollback changes caller SHAs and image digests through normal reviewed commits; it never rewrites a branch or moves a tag.
 
+### 9) Heavy CI Cache and Artifact Isolation
+
+- Dependency caches contain package-manager/tool downloads only; installed dependencies, build outputs, credentials, and generated secret material are prohibited.
+- Cache keys include repository, contract major and ID, trust tier, runner OS, architecture and image, toolchain, cache schema, lockfile hash, and adapter content hash. Broad restore prefixes are prohibited.
+- Canonical cache writes are allowed only for trusted pushes to the default branch. Pull requests restore at most; forks, Dependabot, and `pull_request_target` use an isolated untrusted tier and cannot write.
+- Build artifacts are current-run handoff objects, downloaded by returned artifact ID and verified against source SHA, repository ID, run ID, run attempt, contract version, and payload SHA-256 before extraction.
+- Heavy CI jobs remain read-only and cannot publish packages, deploy, request OIDC tokens, or inherit caller secrets.
+
 ## Pilot Repository Baseline
 
 The pilot model for control validation is documented in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,3 +6,7 @@ All story branches must pass the local hard gates before commit:
 - `make test`
 
 The local test gate validates required repository structure and baseline docs.
+
+`make test` also validates the heavy CI v2 public inputs and outputs, trust/cache negative cases, immutable artifact checks, action pinning, and the WODIQ- and Tracker-shaped fixtures. `.github/workflows/heavy-ci-v2-integration.yml` exercises both shapes on hosted GitHub runners when the contract or fixtures change.
+
+The integration workflow records per-stage NDJSON evidence. Consumer speed improvements require a separate hosted A/B canary with cold and warm cache runs; the contract test proves correctness and isolation, not performance.

--- a/docs/workflows/contracts/README.md
+++ b/docs/workflows/contracts/README.md
@@ -12,6 +12,12 @@ Workflow contracts document the stable API surface of each reusable workflow:
 
 ## Available Contracts
 
+### Heavy CI orchestration
+
+| Workflow | Contract | Status |
+|----------|----------|--------|
+| [reusable-heavy-ci-v2.yml](reusable-heavy-ci-v2.md) | heavy-ci/v2 | Candidate; devops-only validation |
+
 ### v10 CI and release contracts
 
 | Workflow | Version | Status |

--- a/docs/workflows/contracts/reusable-heavy-ci-v2.md
+++ b/docs/workflows/contracts/reusable-heavy-ci-v2.md
@@ -1,0 +1,102 @@
+# Reusable Heavy CI v2 contract
+
+`reusable-heavy-ci-v2.yml` is the shared build-once/test-many orchestration contract. It centralizes runner routing, dependency-cache isolation, immutable artifact handoff, typed stages, timing, and failure evidence. Repository-specific install, build, and test semantics stay in a caller-owned Bash adapter.
+
+`heavy-ci/v2` is the schema version of this contract. It is not a mutable Git tag and does not change the platform's current v10 release channel. A later platform release must use a new immutable semantic tag and consumers must pin its resolved 40-character commit SHA.
+
+## Execution graph
+
+```text
+hosted preflight
+  -> bootstrap + build
+       -> unit
+       -> integration
+       -> e2e-prepare + browser
+       -> live-smoke
+  -> consolidated timing evidence
+```
+
+Bootstrap and build execute exactly once. Every enabled fan-out stage downloads the same artifact by the artifact ID returned by the build job. Before extraction it verifies the contract version, source SHA, repository ID, run ID, run attempt, artifact name, archive checksum, and archive paths.
+
+## Adapter interface
+
+The `entrypoint` input names a repository-relative Bash script. The workflow passes exactly one of these fixed stage names; callers cannot inject free-form shell commands:
+
+| Stage | Required behavior |
+|---|---|
+| `bootstrap` | Install locked dependencies and prepare tool downloads. |
+| `build` | Produce `artifact-path`. |
+| `unit` | Run unit/static checks against the restored build. |
+| `integration` | Run repository-specific integration checks. |
+| `e2e-prepare` | Install or prepare the pinned browser/runtime before `browser`. |
+| `browser` | Run browser/E2E checks. |
+| `live-smoke` | Run caller-owned smoke checks without receiving shared secrets. |
+
+The caller controls whether optional stages run. The shared workflow never encodes WODIQ or Tracker commands, databases, credentials, routes, or product behavior.
+
+## Inputs
+
+| Input | Type | Default | Notes |
+|---|---|---|---|
+| `contract-id` | string | `default` | Safe identifier; separates two calls in one workflow run. |
+| `execution-class` | string | `hosted` | Only `hosted` or `trusted-heavy`. |
+| `cache-policy` | string | `restore-only` | `off`, `restore-only`, or `trusted-write`. |
+| `cache-path` | string | `.cache/heavy-ci` | Tool download cache only. |
+| `cache-schema` | string | `v1` | Explicit invalidation dimension. |
+| `toolchain` | string | required | Stable runtime/package-manager identifier. |
+| `lockfile` | string | required | Repository-relative lockfile hashed into the cache key. |
+| `entrypoint` | string | `.github/ci/heavy-ci` | Repository-owned adapter. |
+| `artifact-path` | string | `.heavy-ci/payload` | Build payload packed once and restored by every stage. |
+| `run-unit` | boolean | `true` | Enables `unit`. |
+| `run-integration` | boolean | `false` | Enables `integration`. |
+| `run-browser` | boolean | `false` | Enables `e2e-prepare` and `browser`. |
+| `run-live-smoke` | boolean | `false` | Enables `live-smoke`. |
+| `artifact-retention-days` | number | `14` | Allowed range 1-30 days. |
+
+All paths must be repository-relative and cannot contain `..`. Dependency-cache paths cannot contain `node_modules`, Composer `vendor`, `dist`, `build`, or `.output`; those are installed dependencies or build products, not trusted cross-run caches.
+
+## Outputs
+
+The workflow exports `contract-version`, `artifact-name`, `artifact-id`, `artifact-digest`, `payload-sha256`, `effective-execution-class`, `cache-key`, `cache-hit`, and `metrics-artifact`.
+
+Artifact names include contract ID, repository ID, source SHA, run ID, and run attempt. They are unique within retries and cannot overwrite another run's artifact. Failure and timing evidence is uploaded per stage and consolidated as newline-delimited JSON.
+
+## Cache ownership and key dimensions
+
+The shared workflow owns restore/save mechanics and key construction. The consumer owns the contents of `cache-path`, the lockfile, `toolchain`, and `cache-schema` values.
+
+Platform-owned warm content is limited to the versioned runner image, system toolchains, and base/container layers maintained by the runner platform. It never contains repository dependencies, application build output, secrets, or consumer state. The runner image dimension and explicit `toolchain` value invalidate repository caches when that platform content changes.
+
+The exact cache key contains repository ID, contract major and ID, trust tier, runner OS, runner architecture and image, toolchain, cache schema, lockfile hash, and a content hash of the lockfile plus adapter. There are no broad restore prefixes. Cache entries therefore never cross repositories, contract calls, trust tiers, runner images, architectures, toolchains, schemas, or dependency states.
+
+- `off`: no restore and no save.
+- `restore-only`: exact-key restore only; never save.
+- `trusted-write`: save only on a trusted `push` to the repository's default branch. All other events behave as restore-only.
+
+Forks, Dependabot, and `pull_request_target` are assigned the `untrusted` cache tier and cannot save. They cannot request `trusted-heavy`. Same-repository trusted pull requests may restore the exact trusted default-branch cache but cannot write it.
+
+The contract test contains negative cases for fork pull requests, Dependabot, `pull_request_target`, ordinary pull requests, unsafe cache paths, parent traversal, broad restore prefixes, privileged permissions, secret inheritance, incomplete artifact binding, and non-SHA Action references. The hosted preflight performs the same trust decision before any self-hosted job is queued.
+
+## Security boundaries
+
+- Jobs have only `contents: read`; the workflow has no package, deployment, OIDC, attestation, or security-event write permission.
+- No secrets are declared or inherited.
+- Artifact downloads use the current run's build output ID; callers cannot provide a run ID or artifact ID.
+- Full SHA pinning is mandatory for every external Action.
+- Artifact creation rejects symbolic links. Extraction rejects absolute paths, parent traversal, and entries outside `artifact-path`.
+- Build payloads are same-run transport, not reusable dependency caches. They are portable only between compatible runner OS/architecture and toolchains.
+
+## WODIQ and Tracker compatibility
+
+The contract fixtures model both shapes without modifying either consumer:
+
+- WODIQ: Node/npm adapter with unit and browser stages.
+- Tracker: Node/pnpm-style adapter with unit, integration, and browser stages; backend/database orchestration remains caller-owned.
+
+Both use the same reusable workflow. A future consumer migration changes only its adapter and caller inputs, not the shared contract.
+
+## Rollout and rollback
+
+DEV-6 adds the contract in parallel and migrates no consumer. Validate it in this repository first, then canary a reviewed full commit SHA on hosted runners. Measure bootstrap, build, cache, artifact-transfer, and test durations before claiming an improvement or enabling `trusted-heavy`.
+
+Rollback is a normal consumer commit restoring its last known-good full workflow SHA. Keep the hosted caller path available throughout rollout. Never move a release tag or rewrite history; publish a new immutable patch or major release for a correction.

--- a/docs/workflows/versioning-policy.md
+++ b/docs/workflows/versioning-policy.md
@@ -14,6 +14,10 @@ uses: Tuinstra-DEV/devops/.github/workflows/reusable-ci-docker.yml@<full-v10-com
 
 This prevents an upstream tag movement or compromised release from silently changing consumer CI. `@main`, floating major tags, and short SHAs are prohibited in production callers. Canary validation may pin a reviewed feature commit SHA.
 
+## Heavy CI v2 candidate
+
+`heavy-ci/v2` names the orchestration schema, not a Git release tag. DEV-6 keeps it parallel to the stable v10 contracts and does not migrate consumers. After hosted canary evidence and review, release it under a new immutable platform version; do not repoint `v10` or introduce a moving `v2` tag. Consumers pin the reviewed release commit by full SHA and retain their previous hosted caller as the rollback path.
+
 ## Release semantics
 
 - Patch: implementation hardening or documentation with no public-interface or default change. Publish an immutable `v10.0.x` tag and deliberately update consumer SHAs after canary validation.
@@ -38,6 +42,8 @@ Existing required inputs are never removed within a major. New inputs must be op
 3. Resolve the release tag to a full commit SHA and validate that SHA in designated canary repositories on hosted runners.
 4. Enable `trusted-heavy` only for trusted repository events after runner controls are verified.
 5. Update production callers deliberately to the approved SHA and monitor them.
+
+For heavy CI v2, first run the WODIQ- and Tracker-shaped fixtures in the devops repository. A later consumer canary must start hosted, record cache restore, bootstrap, build, artifact transfer, and test-stage timings, and compare repeated runs before any speed claim or `trusted-heavy` rollout.
 
 Repository variables may select the execution class with a safe fallback:
 

--- a/scripts/heavy-ci-v2-contract-test.rb
+++ b/scripts/heavy-ci-v2-contract-test.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+
+WORKFLOW = ".github/workflows/reusable-heavy-ci-v2.yml"
+FIXTURES = %w[
+  tests/fixtures/heavy-ci-v2/wodiq.yml
+  tests/fixtures/heavy-ci-v2/tracker.yml
+].freeze
+
+failures = []
+check = lambda do |condition, message|
+  failures << message unless condition
+end
+
+text = File.read(WORKFLOW)
+required_inputs = %w[contract-id execution-class cache-policy cache-path cache-schema toolchain lockfile entrypoint artifact-path run-unit run-integration run-browser run-live-smoke artifact-retention-days]
+required_outputs = %w[contract-version artifact-name artifact-id artifact-digest payload-sha256 effective-execution-class cache-key cache-hit metrics-artifact]
+required_stages = %w[bootstrap build unit integration e2e-prepare browser live-smoke]
+
+required_inputs.each { |name| check.call(text.include?("      #{name}:"), "missing input #{name}") }
+required_outputs.each { |name| check.call(text.include?("      #{name}:"), "missing output #{name}") }
+required_stages.each { |name| check.call(text.include?(name), "missing typed stage #{name}") }
+
+check.call(text.include?("default: hosted"), "hosted must remain the execution default")
+check.call(text.include?("hosted|trusted-heavy"), "execution-class enum is not enforced")
+check.call(text.include?("off|restore-only|trusted-write"), "cache-policy enum is not enforced")
+check.call(text.include?("github.event.pull_request.head.repo.fork || false"), "fork boundary is missing")
+check.call(text.include?("dependabot[bot]"), "Dependabot boundary is missing")
+check.call(text.include?("pull_request_target"), "pull_request_target boundary is missing")
+check.call(text.include?("EVENT_NAME\" = push") && text.include?("REF_NAME\" = \"$DEFAULT_BRANCH"), "canonical cache write is not restricted to default-branch pushes")
+check.call(text.include?("actions/cache/restore@") && text.include?("actions/cache/save@"), "split restore/save cache actions are required")
+check.call(!text.include?("restore-keys:"), "broad cache restore prefixes are prohibited")
+check.call(text.include?("node_modules|vendor|dist|build|\\.output"), "unsafe dependency/build cache paths are not rejected")
+check.call(text.include?("GITHUB_REPOSITORY_ID") && text.include?("CONTRACT_ID") && text.include?("RUNNER_OS") && text.include?("RUNNER_ARCH") && text.include?("ImageOS") && text.include?("LOCKFILE_HASH") && text.include?("CONTENT_HASH"), "cache key dimensions are incomplete")
+
+check.call(text.include?("artifact-ids: ${{ needs.build.outputs.artifact-id }}"), "fan-out does not consume the build artifact by ID")
+check.call(text.include?("payload checksum mismatch"), "payload checksum verification is missing")
+check.call(text.include?("run_attempt") && text.include?("repository_id") && text.include?("source_sha"), "artifact manifest binding is incomplete")
+check.call(text.include?("artifact contains an unsafe path"), "archive path traversal check is missing")
+check.call(text.include?("artifact-path may not contain symbolic links"), "artifact symlinks are not rejected")
+check.call(text.include?("artifact contains a path outside artifact-path"), "artifact root confinement is missing")
+check.call(text.include?("compression-level: 0"), "already-compressed bundle should not be recompressed")
+check.call(text.include?("duration_seconds") && text.include?("status"), "stage timing/failure evidence is missing")
+%w[bootstrap build artifact-capture e2e-prepare].each { |stage| check.call(text.include?("stage\":\"#{stage}"), "timing evidence missing for #{stage}") }
+check.call(!text.match?(/^\s*(packages|deployments|id-token|attestations|security-events):\s*write\s*$/), "heavy CI grants a privileged write permission")
+check.call(!text.match?(/^\s*secrets:\s*inherit\s*$/), "secrets: inherit is prohibited")
+
+text.scan(/^\s*uses:\s*([^\s#]+)(?:\s+#.*)?$/).flatten.each do |reference|
+  next if reference.start_with?("./")
+
+  check.call(reference.match?(/@[0-9a-f]{40}$/), "external action is not pinned by full SHA: #{reference}")
+end
+
+def safe_path?(path)
+  !path.empty? && !path.start_with?("/") && path.split("/").none?("..")
+end
+
+def cache_path?(path)
+  forbidden = %w[node_modules vendor dist build .output]
+  safe_path?(path) && (path.split("/") & forbidden).empty?
+end
+
+def untrusted?(event:, fork:, actor:)
+  event == "pull_request_target" || fork || actor == "dependabot[bot]"
+end
+
+def can_write_cache?(policy:, event:, fork:, actor:, ref:, default_branch:)
+  policy == "trusted-write" && !untrusted?(event: event, fork: fork, actor: actor) && event == "push" && ref == default_branch
+end
+
+%w[.cache/heavy-ci .npm frontend/.pnpm-store].each { |path| check.call(cache_path?(path), "valid cache path rejected: #{path}") }
+%w[/tmp/cache ../cache app/../cache node_modules backend/vendor dist .output build].each { |path| check.call(!cache_path?(path), "unsafe cache path accepted: #{path}") }
+
+negative_contexts = [
+  { event: "pull_request", fork: true, actor: "contributor" },
+  { event: "pull_request", fork: false, actor: "dependabot[bot]" },
+  { event: "pull_request_target", fork: false, actor: "maintainer" },
+  { event: "pull_request", fork: false, actor: "maintainer" }
+]
+negative_contexts.each do |context|
+  check.call(!can_write_cache?(policy: "trusted-write", ref: "main", default_branch: "main", **context), "non-default-push context can write the canonical cache: #{context}")
+end
+check.call(can_write_cache?(policy: "trusted-write", event: "push", fork: false, actor: "maintainer", ref: "main", default_branch: "main"), "trusted default-branch push cannot write cache")
+
+fixture_shapes = FIXTURES.map do |path|
+  fixture = YAML.safe_load(File.read(path), aliases: false)
+  %w[contract-id toolchain lockfile entrypoint artifact-path stages].each do |key|
+    check.call(fixture.key?(key), "#{path} is missing #{key}")
+  end
+  check.call(fixture.fetch("stages").all? { |stage| required_stages.include?(stage) }, "#{path} declares an unknown stage")
+  fixture
+end
+check.call(fixture_shapes.map { |fixture| fixture.fetch("entrypoint") }.uniq.length == 2, "consumer fixtures must keep repository-specific adapters local")
+check.call(fixture_shapes.map { |fixture| fixture.fetch("contract-id") }.uniq.length == 2, "consumer fixtures need unique contract IDs")
+
+if failures.any?
+  failures.each { |failure| warn "heavy CI v2 contract test failed: #{failure}" }
+  exit 1
+end
+
+puts "heavy CI v2 contract test passed (#{required_inputs.length} inputs, #{required_outputs.length} outputs, #{required_stages.length} stages, #{FIXTURES.length} consumer shapes)"

--- a/scripts/heavy-ci-v2-contract-test.rb
+++ b/scripts/heavy-ci-v2-contract-test.rb
@@ -36,6 +36,7 @@ check.call(text.include?("node_modules|vendor|dist|build|\\.output"), "unsafe de
 check.call(text.include?("GITHUB_REPOSITORY_ID") && text.include?("CONTRACT_ID") && text.include?("RUNNER_OS") && text.include?("RUNNER_ARCH") && text.include?("ImageOS") && text.include?("LOCKFILE_HASH") && text.include?("CONTENT_HASH"), "cache key dimensions are incomplete")
 
 check.call(text.include?("artifact-ids: ${{ needs.build.outputs.artifact-id }}"), "fan-out does not consume the build artifact by ID")
+check.call(text.include?("merge-multiple: true"), "artifact ID download does not restore bundle files directly into the verified directory")
 check.call(text.include?("payload checksum mismatch"), "payload checksum verification is missing")
 check.call(text.include?("run_attempt") && text.include?("repository_id") && text.include?("source_sha"), "artifact manifest binding is incomplete")
 check.call(text.include?("artifact contains an unsafe path"), "archive path traversal check is missing")

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,12 +7,14 @@ required_paths=(
   ".github/workflows/reusable-browser-quality.yml"
   ".github/workflows/reusable-ci-docker.yml"
   ".github/workflows/reusable-release-image.yml"
+  ".github/workflows/reusable-heavy-ci-v2.yml"
   "README.md"
   "docs/testing.md"
   "docs/standards/gate-baseline.md"
   "docs/workflows/contracts/reusable-gate-baseline.md"
   "scripts/gate-baseline-scan.sh"
   "scripts/workflow-contract-test.sh"
+  "scripts/heavy-ci-v2-contract-test.rb"
   "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
@@ -28,5 +30,7 @@ ruby -e '
   require "yaml"
   Dir[".github/workflows/*.{yml,yaml}"].sort.each { |file| YAML.safe_load(File.read(file), aliases: true) }
 '
+
+ruby -c scripts/heavy-ci-v2-contract-test.rb
 
 echo "lint passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,5 +23,6 @@ if ! grep -q "Auth0" "README.md"; then
 fi
 
 ./scripts/workflow-contract-test.sh
+ruby ./scripts/heavy-ci-v2-contract-test.rb
 
 echo "test passed"

--- a/scripts/workflow-contract-test.sh
+++ b/scripts/workflow-contract-test.sh
@@ -10,9 +10,11 @@ required_paths=(
   ".github/workflows/reusable-browser-quality.yml"
   ".github/workflows/reusable-ci-docker.yml"
   ".github/workflows/reusable-release-image.yml"
+  ".github/workflows/reusable-heavy-ci-v2.yml"
   "docs/workflows/contracts/reusable-browser-quality.md"
   "docs/workflows/contracts/reusable-ci-docker.md"
   "docs/workflows/contracts/reusable-release-image.md"
+  "docs/workflows/contracts/reusable-heavy-ci-v2.md"
 )
 
 for path in "${required_paths[@]}"; do

--- a/templates/workflows/caller-heavy-ci-v2-canary.yml
+++ b/templates/workflows/caller-heavy-ci-v2-canary.yml
@@ -1,0 +1,25 @@
+name: Heavy CI v2 canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  heavy-ci:
+    uses: "Tuinstra-DEV/devops/.github/workflows/reusable-heavy-ci-v2.yml@<full-reviewed-commit-sha>"
+    with:
+      contract-id: app
+      execution-class: hosted
+      cache-policy: restore-only
+      cache-path: .npm
+      cache-schema: v1
+      toolchain: node24-npm11
+      lockfile: package-lock.json
+      entrypoint: .github/ci/heavy-ci
+      artifact-path: .heavy-ci/payload
+      run-unit: true
+      run-integration: false
+      run-browser: true
+      run-live-smoke: false

--- a/tests/fixtures/heavy-ci-v2/tracker.yml
+++ b/tests/fixtures/heavy-ci-v2/tracker.yml
@@ -1,0 +1,9 @@
+contract-id: tracker-shape
+toolchain: node24-pnpm10-php83
+lockfile: tests/fixtures/heavy-ci-v2/tracker/pnpm-lock.yaml
+entrypoint: tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
+artifact-path: .heavy-ci/payload
+stages:
+  - unit
+  - integration
+  - browser

--- a/tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
+++ b/tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  bootstrap) mkdir -p .cache/heavy-ci ;;
+  build) mkdir -p .heavy-ci/payload && printf 'tracker-fixture\n' > .heavy-ci/payload/marker ;;
+  unit|integration|e2e-prepare|browser) grep -Fqx 'tracker-fixture' .heavy-ci/payload/marker ;;
+  *) echo "unsupported Tracker fixture stage: ${1:-missing}" >&2; exit 2 ;;
+esac

--- a/tests/fixtures/heavy-ci-v2/tracker/pnpm-lock.yaml
+++ b/tests/fixtures/heavy-ci-v2/tracker/pnpm-lock.yaml
@@ -1,0 +1,2 @@
+lockfileVersion: '9.0'
+importers: {}

--- a/tests/fixtures/heavy-ci-v2/wodiq.yml
+++ b/tests/fixtures/heavy-ci-v2/wodiq.yml
@@ -1,0 +1,8 @@
+contract-id: wodiq-shape
+toolchain: node24-npm11
+lockfile: tests/fixtures/heavy-ci-v2/wodiq/package-lock.json
+entrypoint: tests/fixtures/heavy-ci-v2/wodiq/entrypoint.sh
+artifact-path: .heavy-ci/payload
+stages:
+  - unit
+  - browser

--- a/tests/fixtures/heavy-ci-v2/wodiq/entrypoint.sh
+++ b/tests/fixtures/heavy-ci-v2/wodiq/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  bootstrap) mkdir -p .cache/heavy-ci ;;
+  build) mkdir -p .heavy-ci/payload && printf 'wodiq-fixture\n' > .heavy-ci/payload/marker ;;
+  unit|e2e-prepare|browser) grep -Fqx 'wodiq-fixture' .heavy-ci/payload/marker ;;
+  *) echo "unsupported WODIQ fixture stage: ${1:-missing}" >&2; exit 2 ;;
+esac

--- a/tests/fixtures/heavy-ci-v2/wodiq/package-lock.json
+++ b/tests/fixtures/heavy-ci-v2/wodiq/package-lock.json
@@ -1,0 +1,1 @@
+{"name":"heavy-ci-wodiq-fixture","lockfileVersion":3,"packages":{}}


### PR DESCRIPTION
## What changed

- add a reusable Heavy CI v2 build-once/test-many contract
- isolate dependency caches by repository, contract, trust tier, runner image, toolchain and content hashes
- fan out immutable build artifacts with manifest, SHA-256 and path verification
- add WODIQ- and Tracker-shaped integration fixtures without modifying either consumer repository
- add timing/failure evidence, security, versioning and rollback documentation
- remove the contradictory force-moving release-tag target and pin PR checkout Actions by full SHA

## Why

Heavy CI consumers currently repeat install/build work and lack one shared, measurable orchestration contract. DEV-6 provides the secure platform contract that later consumer migrations can adopt independently.

## Validation

- `make lint`
- `make test` (93 runner-platform tests plus workflow contract tests)
- Actionlint v1.7.12
- `git diff --check`
- WODIQ- and Tracker-shaped fixture adapters executed successfully in isolated temporary workspaces

## Rollout

No consumer is migrated by this PR. Hosted execution remains the default and rollback path. Performance gains must be proven with later cold/warm canary runs before trusted-heavy rollout.
