### PR TITLE
chore[DEV-8] Create heavy-CI evidence gate and rollout matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Auth0 is the accepted central identity provider for the DevOps platform and down
 See `docs/onboarding/consumer-migration-checklist.md` for a step-by-step guide to integrating your project with these reusable workflows.
 Gate rollout readiness is documented in `docs/standards/gate-baseline.md`.
 
+Heavy CI adoption is governed by the
+[`rollout matrix`](docs/workflows/heavy-ci-rollout-matrix.md), its reusable
+[`evidence template`](docs/workflows/heavy-ci-evidence-template.md), and the
+[`consumer cutover and rollback runbook`](docs/playbooks/heavy-ci-consumer-cutover.md).
+
 ## Reusable Workflow Example
 
 An example caller exists at `.github/workflows/example-caller.yml`.

--- a/docs/playbooks/heavy-ci-consumer-cutover.md
+++ b/docs/playbooks/heavy-ci-consumer-cutover.md
@@ -1,0 +1,97 @@
+# Heavy CI consumer cutover and rollback
+
+Use this runbook with the
+[rollout matrix](../workflows/heavy-ci-rollout-matrix.md) and
+[evidence template](../workflows/heavy-ci-evidence-template.md). It covers CI
+routing and workflow rollback; application deploy rollback remains in the
+[deployment rollback playbook](rollback.md).
+
+## Owner checklist
+
+Before opening a consumer change:
+
+- [ ] Confirm the repository classification, decision state, owner, fallback
+      approver, DEV story, dependencies, and blockers in the rollout matrix.
+- [ ] Record the incumbent caller, last known-good full workflow SHA, exact
+      required-check contexts, and current default branch.
+- [ ] Pin the candidate reusable workflow by reviewed 40-character commit SHA.
+- [ ] Keep the incumbent hosted caller or an explicit `hosted` execution-class
+      fallback available.
+- [ ] Keep caller-owned aggregate job names stable; do not make reusable
+      fan-out job names part of branch protection.
+- [ ] Confirm third-party Actions remain full-SHA pinned, permissions are least
+      privilege, `secrets: inherit` is absent, and no deploy/OIDC/package-write
+      scope enters heavy jobs.
+- [ ] Confirm dependency caches contain downloads only and use the full trust,
+      platform, toolchain, lockfile, and adapter identity.
+- [ ] Prepare the evidence template and predeclare benefit, capacity, flake,
+      required-check, trust, and rollback thresholds.
+
+Before enabling `trusted-heavy`:
+
+- [ ] Hosted canary evidence passes first.
+- [ ] The repository is in the Sanctuary allowlist; `devops` is never eligible.
+- [ ] Fork, Dependabot, and `pull_request_target` tests fail closed to hosted and
+      cannot write canonical caches.
+- [ ] Runner acceptance, two-slot admission, production-network denial, audit
+      attribution, one-job teardown, and reconciliation checks are current.
+- [ ] The fallback approver can disable repository runner-group access.
+
+## Staged cutover
+
+1. Add the candidate in report-only/canary mode on GitHub-hosted runners. Do not
+   alter required checks.
+2. Collect the minimum incumbent and candidate samples. Keep failed, cancelled,
+   and rerun attempts in the reliability evidence.
+3. Review timing, queue, cache, compute/cost, failure/flake, trust, artifact, and
+   rollback evidence. A cache hit alone is not a pass.
+4. Verify classic branch protection and all applicable rulesets through the
+   GitHub API or settings UI. Record exact contexts and screenshots/API output.
+5. If every gate passes, switch the caller deliberately in a normal reviewed
+   commit. Preserve the stable aggregate check name.
+6. Enable a new required check only after a green report-only period and after
+   proving that rollback will not wait forever on that check.
+7. Enable `trusted-heavy`, when justified, as a separate change after hosted
+   evidence and runner-control approval. Never combine trust expansion with a
+   contract-version or required-check change.
+8. Monitor the first five merged/default-branch runs and retain artifacts and
+   audit evidence for at least 30 days.
+
+## Rollback triggers
+
+Rollback on any stop condition in the rollout matrix, including check-name
+drift, unexplained performance or flake regression, queue/capacity breach,
+artifact verification failure, missing evidence, or any trust/cache isolation
+failure.
+
+## Hosted rollback procedure
+
+1. If containment is required, disable the consumer's access to the
+   `trusted-heavy` runner group. Let safe in-flight work finish or cancel it.
+2. Prevent a new required check from blocking recovery: temporarily remove only
+   the newly introduced context through the reviewed ruleset process. Preserve
+   all incumbent security, release, and test checks.
+3. Route the caller to `hosted` and restore the last known-good full workflow
+   SHA in a normal reviewed commit. Never force-push, move a tag, or rewrite
+   history.
+4. Run the incumbent required checks and confirm their original context names
+   complete successfully.
+5. For a trusted-runner incident, stop new admission, reconcile the manager,
+   and verify no orphan runner record, lease, domain, seed, or overlay remains.
+6. Record trigger, run/job IDs, actual runner attribution, workflow SHAs,
+   required-check change, UTC timeline, and outcome. Do not copy JIT material,
+   credentials, seed images, or unnecessary logs.
+7. Retain evidence for at least 30 days. Open a separate fix/follow-up story and
+   require a fresh hosted canary before retrying.
+
+## Completion record
+
+- Repository / story:
+- Cutover or rollback commit:
+- Incumbent and candidate workflow SHAs:
+- Required contexts before / after:
+- Evidence record:
+- Runner-group action, if any:
+- Verification runs:
+- Owner / fallback approver / UTC timestamp:
+- Follow-up risks:

--- a/docs/workflows/heavy-ci-evidence-template.md
+++ b/docs/workflows/heavy-ci-evidence-template.md
@@ -1,0 +1,160 @@
+# Heavy CI rollout evidence template
+
+Copy this template into the consumer repository or its delivery record for each
+candidate rollout. One record covers one repository, one incumbent/candidate
+pair, and one decision. Link raw GitHub run and artifact evidence; do not paste
+secrets, credentials, full logs, or untrusted job payloads.
+
+Treat the incumbent as the **before** path and the candidate as the **after**
+path. The heavy-CI workflow emits stage status/timing and artifact integrity data.
+Queue time, cost, retries, required-check settings, trust review, and rollback
+evidence must be added at the rollout layer.
+
+## 1. Identity and ownership
+
+| Field | Value |
+|---|---|
+| Repository and default branch | |
+| Classification (`heavy`, `medium`, `light`) | |
+| Decision (`evidence-only`, `deferred`, `hosted-canary`, `ready`) | |
+| Repository owner | |
+| Fallback approver | |
+| DEV story / migration scope | |
+| Incumbent workflow file and full SHA | |
+| Candidate workflow file and full SHA | |
+| Adapter content SHA | |
+| Toolchain and runner image | |
+| Lockfile SHA | |
+| Event and trust class | |
+| Evidence window (UTC) | |
+| Evidence retention expiry (minimum 30 days) | |
+
+## 2. Predeclared hypothesis
+
+Record before running the canary:
+
+- affected stage(s):
+- expected benefit and target percentage:
+- critical-path ceiling:
+- queue/capacity ceiling:
+- compute or Actions-minute ceiling:
+- allowed failure/flake delta:
+- required-check contexts that must remain stable:
+- security/isolation assertions:
+- stop condition and last known-good fallback SHA:
+
+## 3. Comparable run data
+
+Use one row per workflow attempt. Keep reruns as separate rows. `eligible_at` is
+the later of workflow creation and completion of all `needs` dependencies;
+`queue_seconds = job_started_at - eligible_at`. Do not mistake concurrency or
+dependency wait for runner queue.
+
+| Path | Run / attempt | Source SHA | Trigger | Trust class | Runner class/image | Cache state/key | Eligible / started / completed UTC | Queue s | Bootstrap s | Build s | Artifact transfer s | Unit s | Integration s | E2E prepare s | Browser s | Live smoke s | Wall s | Compute s | Result | Failure/flake cause | Rerun? |
+|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|
+| incumbent | | | | | | hit/miss/off/unknown | | | | | | | | | | | | | | | no |
+| candidate | | | | | | hit/miss/off/unknown | | | | | | | | | | | | | | | no |
+
+Attach the heavy-CI `metrics/stages.ndjson` artifact when applicable. A cache
+hit without a lower comparable stage time is not proof of acceleration.
+
+## 4. Derived metrics
+
+Calculate over successful first attempts only; count every attempt in failure
+and flake rates.
+
+```text
+critical_path_seconds = bootstrap + build +
+  max(unit, integration, live-smoke, e2e-prepare + browser)
+
+compute_seconds = bootstrap + build + unit + integration +
+  e2e-prepare + browser + live-smoke
+
+improvement_pct =
+  1 - median(candidate_critical_path) / median(incumbent_critical_path)
+
+cache_hit_rate = cache_hits / cache_restore_eligible_runs
+failure_rate = failed_attempts / all_attempts
+flake_rate = nondeterministic_or_infrastructure_failures / all_attempts
+
+estimated_cost_delta =
+  candidate_compute_minutes * candidate_runner_rate -
+  incumbent_compute_minutes * incumbent_runner_rate
+```
+
+If runner rates are unavailable, report hosted job-minutes and trusted-runner
+occupation separately; do not invent a currency value.
+
+| Summary | Incumbent | Candidate | Delta |
+|---|---:|---:|---:|
+| Valid successful first attempts | | | |
+| Median critical path | | | |
+| Median compute time | | | |
+| Median queue time | | | |
+| Cache hit rate | | | |
+| Failures / all attempts | | | |
+| Flakes / all attempts | | | |
+| Hosted job-minutes | | | |
+| Trusted-runner occupation | | | |
+
+## 5. Sample and performance gate
+
+- [ ] At least 5 comparable successful first attempts exist for the incumbent.
+- [ ] At least 5 comparable successful first attempts exist for the candidate.
+- [ ] Workflow/adapter version, trigger, stage set, lockfile, toolchain, and
+      runner class are controlled or every difference is explained.
+- [ ] Any cache claim has at least 3 comparable misses and 3 comparable hits.
+- [ ] A p95 claim uses at least 20 valid samples; otherwise only median/range
+      are reported.
+- [ ] The candidate meets the predeclared target; a cache-speed claim shows at
+      least 20% median improvement in the affected stage.
+- [ ] Median critical path does not regress more than 10%.
+- [ ] Queue time does not erase the execution gain or exceed the two-runner
+      capacity envelope.
+- [ ] Compute/cost and failure/flake deltas are acceptable and explained.
+
+If a required field is unknown or too few valid samples remain, mark the result
+`insufficient evidence`. Do not convert unknown values to zero or silently drop
+cancelled, failed, or rerun attempts.
+
+## 6. Required-check compatibility
+
+- [ ] Classic branch protection and repository/organization rulesets were both
+      read on the decision date.
+- [ ] Current required contexts are recorded exactly, including workflow and
+      caller-owned aggregate job names.
+- [ ] The candidate preserves those names on every trigger and path.
+- [ ] Internal matrix/fan-out jobs are not individually required.
+- [ ] Report-only canary evidence is green before a new context is enforced.
+- [ ] The rollback can complete without being blocked by the new context.
+- [ ] Release, deploy, vulnerability, and artifact evidence remain equivalent
+      or stronger.
+
+## 7. Trust and isolation
+
+- [ ] Fork, Dependabot, and `pull_request_target` runs resolve to hosted.
+- [ ] Untrusted events cannot write canonical caches.
+- [ ] Cache keys include repository, contract, trust, OS/architecture, image,
+      toolchain, schema, lockfile, and adapter/content identity.
+- [ ] No broad restore prefix, installed dependency tree, build output, secret,
+      or generated credential is cached.
+- [ ] Artifacts are same-run, immutable, identity-checked, and path-checked.
+- [ ] Heavy jobs use `contents: read`, receive no inherited secrets, and have
+      no package, deployment, OIDC, attestation, or security-event write scope.
+- [ ] `trusted-heavy` eligibility, runner allowlist, audit attribution, and
+      runner acceptance checks are recorded where applicable.
+
+## 8. Rollback readiness and decision
+
+- [ ] Last known-good hosted workflow and full SHA are recorded.
+- [ ] The owner completed the dry-run in
+      [the consumer cutover runbook](../playbooks/heavy-ci-consumer-cutover.md).
+- [ ] Required-check rollback order is recorded.
+- [ ] Runner-group disablement and reconciliation are understood where used.
+- [ ] Evidence will be retained for at least 30 days.
+
+Decision: `GO` / `NO-GO` / `INSUFFICIENT EVIDENCE`
+
+Decision owner and UTC timestamp:
+
+Rationale, residual risks, and follow-up story:

--- a/docs/workflows/heavy-ci-rollout-matrix.md
+++ b/docs/workflows/heavy-ci-rollout-matrix.md
@@ -1,0 +1,126 @@
+# Heavy CI evidence gate and rollout matrix
+
+This document turns the DEV-6 contract, DEV-7 pilot, and DEV-9 baseline into a
+controlled adoption path. It is a decision record for repository owners; it
+does not migrate a consumer or change product test semantics.
+
+Evidence in this document was reviewed on 2026-08-12. Revalidate repository
+workflows, rulesets, and default branches before each cutover because those are
+live GitHub settings.
+
+## Classification and decision states
+
+Classification describes the workflow shape, not the runner that must execute
+it:
+
+- **Heavy**: two or more expensive container, browser, integration, or live
+  stages can reuse one build, or the workflow already has a `trusted-heavy`
+  candidate path. Heavy consumers still start with a hosted canary.
+- **Medium**: browser, integration, container, or release work is material, but
+  build-once fan-out is not yet proven to beat the current hosted workflow.
+  Consume telemetry or selected reusable contracts first.
+- **Light**: a short single-path workflow with no meaningful fan-out. Keep it
+  hosted and adopt only safe contract, pin, or telemetry updates.
+
+Every matrix row also has a decision state:
+
+- `evidence-only`: collect or validate evidence; do not change routing.
+- `deferred`: a named blocker must be resolved before a canary.
+- `hosted-canary`: eligible for an A/B canary on GitHub-hosted runners.
+- `ready`: all gates in [the evidence template](heavy-ci-evidence-template.md)
+  pass and the owner has approved cutover.
+
+`trusted-heavy` is never implied by classification. It requires a separate
+hosted canary, trust review, allowlist check, and rollback approval.
+
+## Repository rollout matrix
+
+The owner is the repository maintainer responsible for the rollout evidence.
+For the current repositories that DRI is Marcel; a replacement must be recorded
+before ownership changes.
+
+| Repository | Class | Decision | Expected benefit and evidence basis | Owner | Dependencies | Blockers | Required-check review | Fallback path |
+|---|---|---|---|---|---|---|---|---|
+| `console` | Medium | Deferred | DEV-9 measured CI p50 2:21; browser quality at 1:09 is the largest current stage. A contract-pin refresh and hosted browser telemetry are more likely to help than full heavy fan-out. | Marcel / Console maintainer | DEV-3 consumer migration scope; reviewed immutable DevOps workflow SHA; hosted evidence set | Browser setup requires privileged hosted package changes; no 5+5 comparable A/B set; build-once reuse is unproven | Default `develop`; active organization ruleset has no required status check. Preserve the caller-owned job names (`Lint & Static Analysis`, `Tests`, `Browser Quality Gate`, `Security Check`) during any canary. | Restore the current hosted `ci.yml` and its last known-good full DevOps SHA in a normal reviewed commit. |
+| `notify` | Heavy | Deferred | DEV-9 measured CI p50 4:06; production targets, local stack, and isolated browser runtime each cost about 2:46-2:54. Shared container/build reuse could be material. | Marcel / Notify maintainer | DEV-3 consumer migration scope; Notify reliability work; hosted heavy-ci adapter and exact BuildKit/cache telemetry | 8 of 18 sampled runs were cancelled; benefit and image equivalence are unproven. Reliability is a gate, not noise to discard. | Default `main`; active organization ruleset has no required status check. Keep existing `quality`, `production-images`, and `browser-smoke` result semantics stable. | Set `execution-class`/`CI_HEAVY_EXECUTION_CLASS` to `hosted`, then restore the prior hosted caller SHA if needed. |
+| `tuinstra-site` | Light | Evidence-only | DEV-9 measured a roughly 27-43 second site class; dependency install was 8 seconds. Heavy orchestration overhead would dominate. Benefit is governance: current contract pin, telemetry, and predictable rollback. | Marcel / tuinstra-site maintainer | DEV-3 contract-refresh scope; reviewed immutable reusable-ci SHA | No performance case for heavy CI | Default `develop`; repository ruleset requires exactly `ci / ci`. A pin refresh must preserve that context. | Revert the caller SHA to the previously passing full SHA; remain on hosted `reusable-ci`. |
+| `marcel-site` | Light | Evidence-only | DEV-9 measured a roughly 27-43 second site class; dependency install was 8 seconds. Use only contract refresh and evidence hygiene. | Marcel / marcel-site maintainer | DEV-3 contract-refresh scope; reviewed immutable reusable-ci SHA | No performance case for heavy CI | Default `develop`; repository ruleset requires exactly `ci / ci`. A pin refresh must preserve that context. | Revert the caller SHA to the previously passing full SHA; remain on hosted `reusable-ci`. |
+| `wodiq-site` | Light | Evidence-only | DEV-9 found build 12 seconds, tests 9 seconds, and install 7 seconds. Heavy fan-out has no credible payoff. | Marcel / wodiq-site maintainer | DEV-3 contract-refresh scope; reviewed immutable reusable-ci SHA | No performance case for heavy CI | Default `develop`; active organization ruleset has no required status check. Preserve the current `ci / ci` check name for future compatibility. | Revert the caller SHA to the previously passing full SHA; remain on hosted `reusable-ci`. |
+| `devops` | Light (control plane) | Evidence-only | DEV-9 measured PR test p50 10 seconds. Its role is contract fixtures, policy tests, and evidence-template validation, not consumer acceleration. | Marcel / DevOps platform maintainer | DEV-6 contract and DEV-8 evidence tests | Explicitly excluded from the Sanctuary allowlist so the runner control plane cannot execute its own changes | Default `main`; active organization ruleset has no required status check. Keep `PR Checks / lint` and `PR Checks / test` stable if they become required. | Keep all PR checks hosted; revert documentation or contract changes through a normal commit. Never add devops to `trusted-heavy`. |
+
+The workflow review also found that the five consumer callers still pin the
+older full DevOps SHA `a8815205609fdc709a521914bd927ba72d8d7ad5`. A pin refresh
+is a reviewed DEV-3 migration activity; it is not evidence that heavy CI is
+faster.
+
+## Evidence and readiness gate
+
+A repository is `ready` only when all of these are true:
+
+1. The owner completed [the standard evidence template](heavy-ci-evidence-template.md).
+2. The incumbent and candidate use comparable workflow/adapter versions,
+   triggers, attempts, stage sets, toolchains, lockfiles, and runner classes.
+3. There are at least five comparable successful first attempts per path.
+   Cache claims additionally have at least three cold misses and three warm
+   hits. Twenty samples are required before publishing p95 claims.
+4. The candidate meets its predeclared target. A cache-speed claim requires at
+   least 20% median improvement in the affected stage. Queue time must not erase
+   the critical-path gain, and compute/cost may not materially regress without
+   an explicit owner decision.
+5. Required checks are reviewed against both classic branch protection and
+   repository/organization rulesets. Existing external check names remain
+   stable through a caller-owned aggregate job; internal fan-out jobs are not
+   added individually.
+6. Required stages and evidence are present in every counted run. Reruns are
+   excluded from timing medians and included in failure/flake evidence.
+7. Fork, Dependabot, and `pull_request_target` traffic is proven hosted-only;
+   only trusted default-branch pushes can write canonical caches.
+8. The owner and fallback approver have executed or dry-run the linked
+   [cutover and rollback runbook](../playbooks/heavy-ci-consumer-cutover.md).
+
+Missing queue, cache, trust, required-check, or rollback evidence means
+`insufficient evidence`, never an assumed pass.
+
+## Rollout order
+
+1. **DevOps evidence-only:** validate this policy and its tests on hosted PR
+   checks. DevOps never moves to Sanctuary.
+2. **Light sites:** refresh immutable reusable-workflow pins under DEV-3 only
+   when normal repository work allows it. Preserve `ci / ci` where required.
+   Do not add heavy orchestration.
+3. **Console hosted telemetry:** keep the privileged browser path hosted and
+   test selected contract/pin improvements under DEV-3. Promote only if the
+   evidence gate proves a benefit.
+4. **Notify reliability, then hosted A/B:** first separate cancellations,
+   failures, and concurrency waits. Only then test build-once/container reuse
+   on hosted runners. `trusted-heavy` is a later decision.
+5. **Cross-pilot review:** use the completed DEV-6 through DEV-9 review to
+   decide whether any additional consumer implementation story is justified.
+
+DEV-8 owns the matrix, evidence rules, and operator runbook only. Consumer
+caller or adapter changes for Console, Notify, and the sites belong to DEV-3 or
+a follow-up linked to it. WODIQ, Tracker, or Gate migration corrections belong
+to DEV-5/DEV-7 follow-up scope. Shared contract changes belong to a DEV-6
+follow-up. Do not hide implementation work in this documentation story.
+
+## Stop and rollback conditions
+
+Stop the rollout immediately when any of the following occurs:
+
+- a fork, Dependabot, or `pull_request_target` job reaches `trusted-heavy`;
+- a canonical cache is written outside a trusted default-branch push;
+- a required-check name disappears, duplicates, or remains pending because of
+  the canary;
+- artifact identity, SHA, path, or trust verification fails;
+- a required evidence field or stage is missing;
+- the candidate has a higher unexplained failure/flake rate, or a repeated
+  infrastructure failure in the same stage/class pair;
+- median critical-path time regresses by more than 10%, runner queue erases the
+  intended gain, or the two-slot capacity envelope is exceeded;
+- rollback requires moving a tag, rewriting history, or removing security or
+  release coverage;
+- runner reconciliation leaves an orphan runner, lease, domain, seed, or
+  overlay, or audit attribution is incomplete.
+
+Use the hosted fallback as soon as a stop condition is met. Preserve evidence
+for at least 30 days and require a fresh hosted canary before retrying.

--- a/scripts/heavy-ci-rollout-docs-test.sh
+++ b/scripts/heavy-ci-rollout-docs-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+matrix="docs/workflows/heavy-ci-rollout-matrix.md"
+evidence="docs/workflows/heavy-ci-evidence-template.md"
+runbook="docs/playbooks/heavy-ci-consumer-cutover.md"
+
+for file in "$matrix" "$evidence" "$runbook"; do
+  [[ -f "$file" ]] || { echo "Missing DEV-8 artifact: $file"; exit 1; }
+done
+
+require_text() {
+  local file="$1"
+  local needle="$2"
+  grep -Fqi "$needle" "$file" || {
+    echo "$file must document: $needle"
+    exit 1
+  }
+}
+
+for repo in console notify tuinstra-site marcel-site wodiq-site devops; do
+  require_text "$matrix" "\`$repo\`"
+done
+
+for field in "Expected benefit" "Owner" "Dependencies" "Blockers" "Required-check review" "Fallback path"; do
+  require_text "$matrix" "$field"
+done
+
+for class in Heavy Medium Light; do
+  require_text "$matrix" "**$class**"
+done
+
+for metric in "before" "candidate" "Cache state" "Queue s" "estimated_cost_delta" "failure_rate" "flake_rate" "Trust and isolation" "Rollback readiness"; do
+  require_text "$evidence" "$metric"
+done
+
+require_text "$matrix" "At least five comparable successful first attempts"
+require_text "$matrix" "DEV-3"
+require_text "$matrix" "DEV-5"
+require_text "$matrix" "heavy-ci-consumer-cutover.md"
+require_text "$matrix" "heavy-ci-evidence-template.md"
+require_text "$runbook" "Hosted rollback procedure"
+require_text "$runbook" "Never force-push"
+
+echo "heavy CI rollout documentation test passed"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,6 +15,7 @@ required_paths=(
   "scripts/gate-baseline-scan.sh"
   "scripts/workflow-contract-test.sh"
   "scripts/heavy-ci-v2-contract-test.rb"
+  "scripts/heavy-ci-rollout-docs-test.sh"
   "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
@@ -32,5 +33,6 @@ ruby -e '
 '
 
 ruby -c scripts/heavy-ci-v2-contract-test.rb
+bash -n scripts/heavy-ci-rollout-docs-test.sh
 
 echo "lint passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,5 +24,6 @@ fi
 
 ./scripts/workflow-contract-test.sh
 ruby ./scripts/heavy-ci-v2-contract-test.rb
+./scripts/heavy-ci-rollout-docs-test.sh
 
 echo "test passed"


### PR DESCRIPTION
## Summary
- classify the remaining repositories and record rollout decisions, dependencies, blockers, required-check compatibility, and hosted fallbacks
- add a reusable before/after evidence template with sample-size, performance, cost, flake, trust, and rollback gates
- add a consumer cutover/rollback runbook and protect the documentation contract with automated tests

## Verification
- make lint
- make test (93 runner-platform tests plus workflow contract tests)
- DEV-8 Markdown link validation
- git diff --check

## Security and rollback
- hosted-first; devops remains excluded from trusted-heavy
- untrusted events cannot use trusted-heavy or write canonical caches
- rollback restores the prior full workflow SHA through a normal reviewed commit