### PR TITLE
fix[DEV-7] Preserve Heavy CI failure evidence

### DIFF
--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -251,6 +251,7 @@ jobs:
           CACHE_PATH: ${{ inputs.cache-path }}
           ARTIFACT_PATH: ${{ inputs.artifact-path }}
         run: |
+          set +e
           set -uo pipefail
           mkdir -p .heavy-ci/evidence "$CACHE_PATH"
           bootstrap_started=$(date +%s)
@@ -321,6 +322,7 @@ jobs:
           name: ${{ needs.preflight.outputs.artifact-name }}-evidence-build
           path: .heavy-ci/evidence
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: ${{ inputs.artifact-retention-days }}
 
   fanout:
@@ -382,6 +384,7 @@ jobs:
           STAGE: ${{ matrix.stage }}
           HEAVY_CI_ARTIFACT_PATH: ${{ inputs.artifact-path }}
         run: |
+          set +e
           set -uo pipefail
           mkdir -p .heavy-ci/evidence
           if [[ "$STAGE" = browser ]]; then
@@ -411,6 +414,7 @@ jobs:
           name: ${{ needs.preflight.outputs.artifact-name }}-evidence-${{ matrix.stage }}
           path: .heavy-ci/evidence
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: ${{ inputs.artifact-retention-days }}
 
   summary:
@@ -436,7 +440,7 @@ jobs:
           METRICS_ARTIFACT: ${{ needs.preflight.outputs.metrics-artifact }}
         run: |
           set -euo pipefail
-          mkdir -p metrics
+          mkdir -p evidence metrics
           find evidence -type f -name '*.json' -print0 | sort -z | xargs -0 -r cat > metrics/stages.ndjson
           echo "metrics-artifact=$METRICS_ARTIFACT" >> "$GITHUB_OUTPUT"
 

--- a/scripts/heavy-ci-v2-contract-test.rb
+++ b/scripts/heavy-ci-v2-contract-test.rb
@@ -44,6 +44,9 @@ check.call(text.include?("artifact-path may not contain symbolic links"), "artif
 check.call(text.include?("artifact contains a path outside artifact-path"), "artifact root confinement is missing")
 check.call(text.include?("compression-level: 0"), "already-compressed bundle should not be recompressed")
 check.call(text.include?("duration_seconds") && text.include?("status"), "stage timing/failure evidence is missing")
+check.call(text.scan("set +e").length == 2, "build and fan-out stages must capture adapter failures before exiting")
+check.call(text.scan("include-hidden-files: true").length == 2, "hidden build and fan-out evidence must be uploaded explicitly")
+check.call(text.include?("mkdir -p evidence metrics"), "summary must tolerate a missing evidence download")
 %w[bootstrap build artifact-capture e2e-prepare].each { |stage| check.call(text.include?("stage\":\"#{stage}"), "timing evidence missing for #{stage}") }
 check.call(!text.match?(/^\s*(packages|deployments|id-token|attestations|security-events):\s*write\s*$/), "heavy CI grants a privileged write permission")
 check.call(!text.match?(/^\s*secrets:\s*inherit\s*$/), "secrets: inherit is prohibited")


### PR DESCRIPTION
## What changed

- captures adapter exit codes before the shell exits so failed bootstrap/build/fan-out stages still emit timing evidence
- explicitly uploads evidence stored below `.heavy-ci`
- makes the summary tolerate a failed build with no downloadable evidence artifact
- adds regression assertions for all three failure paths

## Live reproduction

Tracker canary run 31578890215 failed during bootstrap. The shared shell exited before writing `bootstrap.json`; the build evidence upload found no files and the summary then failed on a missing `evidence` directory.

## Validation

- `make lint`
- `make test`
- `git diff --check`

This changes evidence handling only; runner trust, cache write policy, permissions, and stage routing are unchanged.
