### PR TITLE
fix[DEV-8] Align README with immutable SHA policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,19 @@ Auth0 is the accepted central identity provider for the DevOps platform and down
    - `make lint`
    - `make test`
 4. Reuse workflows from other repositories with:
-   - `uses: marcel-tuinstra/devops/.github/workflows/reusable-ci.yml@v1`
+   - `uses: Tuinstra-DEV/devops/.github/workflows/reusable-ci.yml@<full-40-character-commit-sha>`
+   - Resolve an approved immutable release tag once, review the commit, and pin
+     that full SHA. Do not use a moving branch or major-version reference.
 
 ## Access Model
 
 - Repository visibility: public (required for reusable workflow consumption).
 - No secrets, credentials, or application code are stored in this repository.
 - Write access remains limited to maintainers of this DevOps platform repo.
-- Consumer repos reference workflows via `uses: marcel-tuinstra/devops/.github/workflows/<workflow>@v1`.
+- Consumer repos reference workflows via
+  `uses: Tuinstra-DEV/devops/.github/workflows/<workflow>@<full-40-character-commit-sha>`.
+  See the [workflow versioning policy](docs/workflows/versioning-policy.md) for
+  release, migration, and rollback rules.
 
 ## Consumer Onboarding
 

--- a/scripts/heavy-ci-rollout-docs-test.sh
+++ b/scripts/heavy-ci-rollout-docs-test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 matrix="docs/workflows/heavy-ci-rollout-matrix.md"
 evidence="docs/workflows/heavy-ci-evidence-template.md"
 runbook="docs/playbooks/heavy-ci-consumer-cutover.md"
+readme="README.md"
 
 for file in "$matrix" "$evidence" "$runbook"; do
   [[ -f "$file" ]] || { echo "Missing DEV-8 artifact: $file"; exit 1; }
@@ -41,5 +42,17 @@ require_text "$matrix" "heavy-ci-consumer-cutover.md"
 require_text "$matrix" "heavy-ci-evidence-template.md"
 require_text "$runbook" "Hosted rollback procedure"
 require_text "$runbook" "Never force-push"
+require_text "$readme" "Tuinstra-DEV/devops/.github/workflows/"
+require_text "$readme" "<full-40-character-commit-sha>"
+
+if grep -Fq "marcel-tuinstra/devops/.github/workflows/" "$readme"; then
+  echo "$readme must use the current Tuinstra-DEV/devops repository"
+  exit 1
+fi
+
+if grep -Eq 'uses:.*@v[0-9]+' "$readme"; then
+  echo "$readme must pin consumer workflows to an immutable full commit SHA"
+  exit 1
+fi
 
 echo "heavy CI rollout documentation test passed"


### PR DESCRIPTION
## What changed

- replace the obsolete personal-repository and mutable v1 examples with the current Tuinstra-DEV repository and a full-SHA placeholder
- link the workflow versioning policy from onboarding
- add a regression check that rejects the old namespace and mutable major-version references

## Why

DEV-8 governs safe consumer rollout, but the top-level README contradicted the immutable-SHA versioning and rollback policy.

## Validation

- make lint
- make test
- git diff --check

No workflow behavior, runner routing, permissions, cache policy, or consumer repository changes.