### PR TITLE
feat(DEV-13): add bounded dependency update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "01:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 2
+    groups:
+      routine-updates:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+

--- a/.github/workflows/reusable-browser-quality.yml
+++ b/.github/workflows/reusable-browser-quality.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   browser-quality:
-    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && !endsWith(github.actor, '[bot]') && (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && github.event.pull_request.user.type != 'Bot')) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       contents: read
     defaults:
@@ -66,6 +66,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
           ACTOR: ${{ github.actor }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || '' }}
           WORKDIR: ${{ inputs.workdir }}
           BROWSER: ${{ inputs.browser }}
           TEST_SCRIPT: ${{ inputs['test-script'] }}
@@ -74,8 +75,8 @@ jobs:
         run: |
           set -euo pipefail
           case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
-          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
-            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = *'[bot]' ]] || [[ "$PR_AUTHOR_TYPE" = Bot ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and dependency-bot execution" >&2
             exit 2
           fi
           case "$BROWSER" in chromium|firefox|webkit) ;; *) echo "browser must be chromium, firefox, or webkit" >&2; exit 2 ;; esac

--- a/.github/workflows/reusable-ci-docker.yml
+++ b/.github/workflows/reusable-ci-docker.yml
@@ -56,7 +56,7 @@ on:
 
 jobs:
   build-and-scan:
-    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && !endsWith(github.actor, '[bot]') && (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && github.event.pull_request.user.type != 'Bot')) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       contents: read
     outputs:
@@ -70,6 +70,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
           ACTOR: ${{ github.actor }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || '' }}
           WORKDIR: ${{ inputs.workdir }}
           DOCKERFILE: ${{ inputs.dockerfile }}
           TRIVY_EXIT_CODE: ${{ inputs['trivy-exit-code'] }}
@@ -77,8 +78,8 @@ jobs:
         run: |
           set -euo pipefail
           case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
-          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
-            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = *'[bot]' ]] || [[ "$PR_AUTHOR_TYPE" = Bot ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and dependency-bot execution" >&2
             exit 2
           fi
           for path in "$WORKDIR" "$DOCKERFILE"; do

--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -122,6 +122,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
           ACTOR: ${{ github.actor }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || '' }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REF_NAME: ${{ github.ref_name }}
           RUN_UNIT: ${{ inputs.run-unit }}
@@ -147,7 +148,7 @@ jobs:
           (( RETENTION_DAYS >= 1 && RETENTION_DAYS <= 30 )) || { echo "artifact-retention-days must be between 1 and 30" >&2; exit 2; }
 
           untrusted=false
-          if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = 'dependabot[bot]' ]]; then
+          if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = *'[bot]' || "$PR_AUTHOR_TYPE" = Bot ]]; then
             untrusted=true
           fi
           if [[ "$EXECUTION_CLASS" = trusted-heavy && "$untrusted" = true ]]; then

--- a/.github/workflows/reusable-release-image.yml
+++ b/.github/workflows/reusable-release-image.yml
@@ -65,7 +65,7 @@ on:
 
 jobs:
   release-image:
-    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs['execution-class'] == 'trusted-heavy' && github.event_name != 'pull_request_target' && !endsWith(github.actor, '[bot]') && (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && github.event.pull_request.user.type != 'Bot')) && fromJSON('["self-hosted","trusted-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       attestations: write
       contents: read
@@ -85,6 +85,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
           ACTOR: ${{ github.actor }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || '' }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs['image-name'] }}
           WORKDIR: ${{ inputs.workdir }}
@@ -94,8 +95,8 @@ jobs:
         run: |
           set -euo pipefail
           case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
-          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = 'dependabot[bot]' ]]; }; then
-            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
+          if [[ "$EXECUTION_CLASS" = trusted-heavy ]] && { [[ "$EVENT_NAME" = pull_request_target ]] || [[ "$IS_FORK" = true ]] || [[ "$ACTOR" = *'[bot]' ]] || [[ "$PR_AUTHOR_TYPE" = Bot ]]; }; then
+            echo "trusted-heavy is forbidden for pull_request_target, fork, and dependency-bot execution" >&2
             exit 2
           fi
           if [[ ! "$REGISTRY" =~ ^[a-z0-9.-]+(:[0-9]+)?$ ]]; then

--- a/docs/evidence/DEV-13-ci-billing-baseline-2026-08-12.md
+++ b/docs/evidence/DEV-13-ci-billing-baseline-2026-08-12.md
@@ -1,0 +1,147 @@
+# GitHub Actions billing report — 2026-08-12
+
+**Status:** `degraded`  
+**Organization:** `Tuinstra-DEV`  
+**Generated (UTC):** `2026-08-12T18:41:16.323693Z`
+
+> Billing facts and job-derived telemetry are deliberately separate. Job estimates are not billed truth.
+
+## Completeness and freshness
+
+- `incomplete` `jobs_service_error` — subtrack-site: GitHub API request failed (HTTP 404)
+- `degraded` `job_rows_invalid` — 358 completed jobs lacked usable timestamps and were excluded.
+- `degraded` `runner_attribution_unknown` — 263 jobs could not be attributed to hosted or self-hosted runners.
+- `degraded` `current_day_partial` — The current UTC day has no documented billing freshness SLA and is explicitly partial.
+
+## GitHub billing facts
+
+### Current UTC billing period (2026-08-01 through 2026-08-12)
+
+Status: `degraded`
+
+| SKU | Category | Unit | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Gross USD | Discount USD | Net USD |
+|---|---|---:|---:|---:|---:|---|---:|---:|---:|
+| Actions Linux | linux | Minutes | 3873 | 3219 | 654 | explicit_api_quantity/derived_from_amount/derived_from_amount | 23.238 | 19.314 | 3.924 |
+| Actions storage | storage | GigabyteHours | 294.664 | 294.663 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.099 | 0.099 | 0 |
+
+GitHub-billed net minutes: **654** (`degraded`; summarized billing fact).
+
+Per repository and SKU:
+
+| Repository | Consumer | SKU | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Net USD |
+|---|---|---|---:|---:|---:|---|---:|
+| console | Other: console | Actions storage | 21.945 | 21.944 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions Linux | 49 | 49 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions storage | 0 | 0 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| gate | Gate | Actions Linux | 282 | 282 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| gate | Gate | Actions storage | 12.678 | 12.678 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| notify | Other: notify | Actions storage | 0.325 | 0.325 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions Linux | 10 | 10 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions storage | 0.001 | 0.001 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| tracker | Tracker | Actions Linux | 3158 | 2504 | 654 | explicit_api_quantity/derived_from_amount/derived_from_amount | 3.924 |
+| tracker | Tracker | Actions storage | 128.189 | 128.189 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| WODIQ | WODIQ | Actions Linux | 368 | 368 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| WODIQ | WODIQ | Actions storage | 131.484 | 131.483 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| wodiq-site | Other: wodiq-site | Actions Linux | 6 | 6 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| wodiq-site | Other: wodiq-site | Actions storage | 0.042 | 0.042 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+
+### Rolling 7 UTC days (2026-08-06 through 2026-08-12)
+
+Status: `degraded`
+
+| SKU | Category | Unit | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Gross USD | Discount USD | Net USD |
+|---|---|---:|---:|---:|---:|---|---:|---:|---:|
+| Actions Linux | linux | Minutes | 3508 | 2854 | 654 | explicit_api_quantity/derived_from_amount/derived_from_amount | 21.048 | 17.124 | 3.924 |
+| Actions storage | storage | GigabyteHours | 140.52 | 140.519 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.047 | 0.047 | 0 |
+
+GitHub-billed net minutes: **654** (`degraded`; summarized billing fact).
+
+Per repository and SKU:
+
+| Repository | Consumer | SKU | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Net USD |
+|---|---|---|---:|---:|---:|---|---:|
+| console | Other: console | Actions storage | 11.486 | 11.485 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions Linux | 49 | 49 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions storage | 0 | 0 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| gate | Gate | Actions Linux | 188 | 188 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| gate | Gate | Actions storage | 6.712 | 6.712 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| notify | Other: notify | Actions storage | 0.187 | 0.187 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions Linux | 10 | 10 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions storage | 0.001 | 0.001 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| tracker | Tracker | Actions Linux | 2893 | 2239 | 654 | explicit_api_quantity/derived_from_amount/derived_from_amount | 3.924 |
+| tracker | Tracker | Actions storage | 74.488 | 74.488 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| WODIQ | WODIQ | Actions Linux | 362 | 362 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| WODIQ | WODIQ | Actions storage | 47.621 | 47.621 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| wodiq-site | Other: wodiq-site | Actions Linux | 6 | 6 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| wodiq-site | Other: wodiq-site | Actions storage | 0.024 | 0.024 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+
+### Rolling 30 UTC days (2026-07-14 through 2026-08-12)
+
+Status: `degraded`
+
+| SKU | Category | Unit | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Gross USD | Discount USD | Net USD |
+|---|---|---:|---:|---:|---:|---|---:|---:|---:|
+| Actions Linux | linux | Minutes | 8779.667 | 5627 | 3152.667 | explicit_api_quantity/derived_from_amount/derived_from_amount | 52.678 | 33.762 | 18.916 |
+| Actions storage | storage | GigabyteHours | 665.367 | 665.362 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.224 | 0.224 | 0 |
+
+GitHub-billed net minutes: **3152.667** (`degraded`; summarized billing fact).
+
+Per repository and SKU:
+
+| Repository | Consumer | SKU | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Net USD |
+|---|---|---|---:|---:|---:|---|---:|
+| console | Other: console | Actions Linux | 70 | 0 | 70 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.42 |
+| console | Other: console | Actions storage | 81.446 | 81.445 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions Linux | 117 | 117 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| devops | Other: devops | Actions storage | 0 | 0 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| gate | Gate | Actions Linux | 413 | 288 | 125 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.75 |
+| gate | Gate | Actions storage | 63.139 | 63.138 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| marcel-site | Other: marcel-site | Actions Linux | 2 | 0 | 2 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.012 |
+| notify | Other: notify | Actions Linux | 356 | 219 | 137 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.822 |
+| notify | Other: notify | Actions storage | 0.678 | 0.677 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions Linux | 10 | 10 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| openairco-site | Other: openairco-site | Actions storage | 0.001 | 0.001 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| tracker | Tracker | Actions Linux | 6272.667 | 4171 | 2101.667 | explicit_api_quantity/derived_from_amount/derived_from_amount | 12.61 |
+| tracker | Tracker | Actions storage | 234.389 | 234.388 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| tuinstra-site | Other: tuinstra-site | Actions Linux | 3 | 0 | 3 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.018 |
+| WODIQ | WODIQ | Actions Linux | 1519 | 816 | 703 | explicit_api_quantity/derived_from_amount/derived_from_amount | 4.218 |
+| WODIQ | WODIQ | Actions storage | 285.625 | 285.624 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+| wodiq-site | Other: wodiq-site | Actions Linux | 17 | 6 | 11 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0.066 |
+| wodiq-site | Other: wodiq-site | Actions storage | 0.09 | 0.089 | 0 | explicit_api_quantity/derived_from_amount/derived_from_amount | 0 |
+
+## Job-derived telemetry (not billing)
+
+Status: `degraded`. These values are not GitHub-billed truth and must not be substituted for billing usage.
+
+- Raw execution duration: **unavailable seconds**.
+- Per-job rounded estimate: **unavailable minutes**.
+- Self-hosted occupation (inferred): **unavailable seconds**.
+- Unknown-runner duration: **unavailable seconds**.
+
+## Top consumers and daily trend
+
+Top consumers are ranked by observed current-period net GitHub Actions amount. The machine-readable JSON contains rankings and UTC daily trend for all three windows.
+
+- Tracker: USD 3.924 (`degraded`)
+- Other: wodiq-site: USD 0 (`degraded`)
+- Other: notify: USD 0 (`degraded`)
+- Gate: USD 0 (`degraded`)
+- WODIQ: USD 0 (`degraded`)
+- Other: console: USD 0 (`degraded`)
+- Other: devops: USD 0 (`degraded`)
+- Other: openairco-site: USD 0 (`degraded`)
+- Other: marcel-site: USD unavailable (`degraded`)
+- Other: subtrack-site: USD unavailable (`degraded`)
+
+## Month-end projection
+
+**LINEAR MONTH-END BURN PROJECTION (not an invoice forecast)**
+
+- Status: `degraded`; method: `linear_daily_run_rate`; confidence: `low`.
+- Projected net amount: **USD 10.137**.
+- Observed current-period net amount divided by elapsed UTC calendar days, multiplied by month length.
+
+## Evidence handling
+
+This is a sanitized aggregate. API credentials and raw API payloads are not retained. Use the documented append-only archive command for month-over-month evidence.
+

--- a/docs/evidence/DEV-13-dependabot-actions-baseline-2026-08-11.json
+++ b/docs/evidence/DEV-13-dependabot-actions-baseline-2026-08-11.json
@@ -1,0 +1,180 @@
+{
+  "schema": "DEV-13/dependabot-actions-baseline-v2",
+  "collector": {
+    "version": 2,
+    "invocation": "ruby scripts/collect-dependabot-actions-baseline.rb 2026-07-13 2026-08-11",
+    "actions_query": "GET /repos/{repository}/actions/runs actor=dependabot[bot] created=2026-07-13..2026-08-11; GET each run /jobs filter=all",
+    "pull_request_query": "gh search prs --owner {owner} --app dependabot --merged --merged-at 2026-07-13..2026-08-11; filter repository.nameWithOwner to the 11-repository scope",
+    "dependency_row_rule": "Grouped PR count from 'Bumps the ... group with N updates'; otherwise count body lines beginning 'Bump ' or 'Bumps '.",
+    "runner_attribution": "self-hosted label wins; otherwise GitHub Actions runner name or hosted OS label; remaining jobs are unknown"
+  },
+  "start_date": "2026-07-13",
+  "end_date": "2026-08-11",
+  "actor": "dependabot[bot]",
+  "repositories": {
+    "Tuinstra-DEV/WODIQ": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/console": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/devops": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/gate": {
+      "workflow_runs": 32,
+      "completed_jobs": 69,
+      "hosted_jobs": 52,
+      "self_hosted_jobs": 10,
+      "unknown_jobs": 7,
+      "per_job_rounded_hosted_minutes": 122,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 5558,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/marcel-site": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/notify": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/openairco-site": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "marcel-tuinstra/sudoku-spark-web": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/tracker": {
+      "workflow_runs": 169,
+      "completed_jobs": 294,
+      "hosted_jobs": 266,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 28,
+      "per_job_rounded_hosted_minutes": 907,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 46590,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/tuinstra-site": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    },
+    "Tuinstra-DEV/wodiq-site": {
+      "workflow_runs": 0,
+      "completed_jobs": 0,
+      "hosted_jobs": 0,
+      "self_hosted_jobs": 0,
+      "unknown_jobs": 0,
+      "per_job_rounded_hosted_minutes": 0,
+      "per_job_rounded_unknown_minutes": 0,
+      "raw_job_seconds": 0,
+      "errors": [
+
+      ]
+    }
+  },
+  "merged_updates_by_repository": {
+    "Tuinstra-DEV/tracker": {
+      "merged_prs": 14,
+      "dependency_rows": 14
+    }
+  },
+  "unparsed_pull_requests": [
+
+  ],
+  "totals": {
+    "workflow_runs": 201,
+    "completed_jobs": 363,
+    "hosted_jobs": 318,
+    "self_hosted_jobs": 10,
+    "unknown_jobs": 35,
+    "per_job_rounded_hosted_minutes": 1029,
+    "per_job_rounded_unknown_minutes": 0,
+    "raw_job_seconds": 52148,
+    "merged_dependabot_prs": 14,
+    "merged_dependency_updates": 14
+  }
+}

--- a/docs/evidence/DEV-13-security-settings-preflight-2026-08-12.json
+++ b/docs/evidence/DEV-13-security-settings-preflight-2026-08-12.json
@@ -1,0 +1,19 @@
+{
+  "schema": "DEV-13/dependabot-security-settings-v1",
+  "verified_at": "2026-08-12",
+  "source": "GitHub REST vulnerability-alerts and automated-security-fixes endpoints",
+  "raw_payload_retained": false,
+  "repositories": {
+    "Tuinstra-DEV/WODIQ": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/console": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/devops": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/gate": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/marcel-site": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/notify": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/openairco-site": {"alerts": true, "security_updates": true},
+    "marcel-tuinstra/sudoku-spark-web": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/tracker": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/tuinstra-site": {"alerts": true, "security_updates": true},
+    "Tuinstra-DEV/wodiq-site": {"alerts": true, "security_updates": true}
+  }
+}

--- a/docs/standards/dependency-update-policy.md
+++ b/docs/standards/dependency-update-policy.md
@@ -1,0 +1,78 @@
+# Dependency Update and CI-Minute Policy
+
+## Goal
+
+Keep dependencies current without letting routine bot activity consume a
+disproportionate share of GitHub Actions minutes or runner capacity.
+
+## Normal lane
+
+- GitHub-native Dependabot is the single version-update bot in all rollout
+  repositories; Renovate is not required.
+- Each package ecosystem checks monthly at an explicit, repository-staggered
+  Europe/Amsterdam time.
+- Patch and minor updates are grouped into one routine PR per ecosystem.
+- Each ecosystem is capped at two open version PRs. This normally leaves room
+  for one routine group and one major, but two majors can occupy both slots;
+  the 14-day major disposition prevents indefinite routine starvation.
+- Dependency PRs never automerge under this policy.
+- Pending majors are reviewed monthly and must have an owner or disposition
+  within 14 days.
+- GitHub Actions are monitored everywhere. Newly onboarded Dockerfiles remain a
+  monthly human-owned review exception because runtime changes need coordinated
+  validation; Gate and Tracker retain automated Docker updates.
+
+## Fast and controlled lanes
+
+- Dependabot security updates use GitHub's separate security queue, so ordinary
+  version limits do not block actionable fixes.
+- Dependency graph, alerts and Dependabot security updates must be enabled in
+  repository settings before a rollout wave is promoted.
+- Major updates stay outside routine groups and require explicit human review.
+- A compatibility ignore that also blocks the only secure version creates a
+  manual-remediation obligation for the repository owner: triage immediately
+  and open a coordinated fix within 24 hours.
+- Fork and bot pull requests cannot receive trusted-heavy runner access or
+  canonical cache-write permissions.
+
+## Measurement
+
+Use the DEV-11 billing collector for the 30 days before rollout and again for
+the first complete 30-day window beginning the day after the last consumer
+merge. Record total and dependency-bot workflow attempts, per-job-rounded
+hosted minutes, self-hosted occupation, p50/p95 first-check completion,
+dependency freshness, failure rate and flaky-rerun rate.
+Reproduce the bot-specific figures with
+`ruby scripts/collect-dependabot-actions-baseline.rb START_DATE END_DATE`.
+
+A successful rollout must meet both primary thresholds:
+
+- at least 20% fewer dependency-bot workflow run attempts in Gate and Tracker
+  combined; and
+- at least 15% fewer per-job-rounded dependency-bot minutes in Gate and Tracker
+  combined.
+
+From the 2026-07-13 through 2026-08-11 baseline, that means no more than 160
+Gate-plus-Tracker Dependabot runs and no more than 874 per-job-rounded hosted
+minutes in the comparison window.
+
+Portfolio non-regression is mandatory: all 11 repositories combined must not
+exceed the baseline of 201 Dependabot runs or 1,029 rounded hosted minutes.
+
+For normalization, a merged dependency update is one dependency row reported
+in a merged Dependabot PR's metadata; a grouped PR can therefore contain
+multiple updates. If that count differs by more than 20% between windows,
+normalize runs and rounded minutes per merged dependency update; both normalized
+values must improve by at least 10%. The baseline contains 14 merged dependency
+updates, so its normalization anchors are 14.36 runs and 73.50 rounded hosted
+minutes per merged update.
+
+Unknown runner attribution is not silently treated as zero cost. The baseline's
+35 unknown jobs all had zero rounded duration, but any unknown job with positive
+duration or any collector/API error in an after-window blocks promotion and
+completion until it is classified or the window is recollected.
+
+Guardrails: p95 first-check completion may worsen by no more than 10%; ordinary
+dependency freshness must stay within 35 days; security-fix PR creation must
+stay within 24 hours of an actionable alert; failure and flaky-rerun rates may
+increase by no more than 2 percentage points.

--- a/docs/standards/renovate.md
+++ b/docs/standards/renovate.md
@@ -1,94 +1,13 @@
 # Renovate Presets
 
-This repo provides shared Renovate presets that consumer repos can extend
-for consistent dependency update behavior across all projects.
+The legacy shared Renovate presets remain available for compatibility. They are
+not used by the DEV-13 rollout because the Renovate GitHub App is not installed
+for the Tuinstra-DEV organization as of 2026-08-12.
 
-## Available Presets
+DEV-13 uses GitHub-native Dependabot so every repository has an operational,
+auditable dependency-update path without adding an external app or credential.
+See dependency-update-policy.md and the rollout matrix for the active policy.
 
-| Preset | Use Case |
-|--------|----------|
-| `renovate/default.json` | Base preset for all repos |
-| `renovate/nuxt.json` | Nuxt/Vue projects |
-| `renovate/symfony.json` | Symfony/PHP projects |
-
-## Usage
-
-In your consumer repo, create a `renovate.json` file that extends the
-appropriate preset:
-
-### Nuxt Projects
-
-```json
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>marcel-tuinstra/devops:renovate/nuxt"
-  ]
-}
-```
-
-### Symfony Projects
-
-```json
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>marcel-tuinstra/devops:renovate/symfony"
-  ]
-}
-```
-
-## Default Behavior
-
-All presets inherit from `renovate/default.json` which provides:
-
-- **Base branch:** `develop` (updates target develop, not main)
-- **Automerge patches:** Patch updates merge automatically after CI passes
-- **Group minor updates:** Minor updates are batched into a single PR
-- **Pin Docker digests:** Docker images are pinned to immutable digests
-- **Security priority:** Vulnerability alerts get `security` and `priority` labels
-- **Lock file maintenance:** Weekly lock file refresh (Monday before 6am)
-
-## Package Grouping
-
-### Nuxt Preset
-
-Groups related packages to reduce PR noise:
-
-- `nuxt` — Nuxt core and plugins
-- `vue` — Vue core and utilities
-- `nuxt-ui` — Nuxt UI components
-- `typescript` — TypeScript and type definitions
-- `eslint` — ESLint and plugins
-- `tailwind` — Tailwind CSS and plugins
-
-### Symfony Preset
-
-Groups PHP ecosystem packages:
-
-- `symfony` — Symfony framework and bundles
-- `doctrine` — Doctrine ORM and migrations
-- `phpstan` — PHPStan static analysis
-- `coding-standards` — PHP-CS-Fixer and Symplify
-- `api-platform` — API Platform packages
-
-## Overriding Settings
-
-Consumer repos can override any setting by adding it after the extends:
-
-```json
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>marcel-tuinstra/devops:renovate/nuxt"
-  ],
-  "automerge": false,
-  "schedule": ["after 10pm and before 5am every weekday"]
-}
-```
-
-## Requirements
-
-- The `marcel-tuinstra/devops` repo must be public (it is).
-- Consumer repos must have Renovate GitHub App installed.
-- Consumer repos must have a `develop` branch (per branching strategy).
+Do not enable Renovate for a repository that already has Dependabot version
+updates without first disabling one bot; two active bots would duplicate pull
+requests and CI runs.

--- a/docs/workflows/contracts/reusable-browser-quality.md
+++ b/docs/workflows/contracts/reusable-browser-quality.md
@@ -26,7 +26,7 @@ Output `report-artifact` is `browser-quality-<github.sha>`. The workflow accepts
 
 ## Execution trust boundary
 
-`execution-class` accepts only `hosted` or `trusted-heavy`. Omitted and invalid values select `ubuntu-24.04`; invalid values then fail validation. `trusted-heavy` resolves only to `[self-hosted, trusted-heavy]` and is rejected for fork pull requests, `pull_request_target`, and Dependabot. Callers must preserve a hosted path for untrusted changes.
+`execution-class` accepts only `hosted` or `trusted-heavy`. Omitted and invalid values select `ubuntu-24.04`; invalid values then fail validation. `trusted-heavy` resolves only to `[self-hosted, trusted-heavy]` and is rejected for fork pull requests, `pull_request_target`, and every actor whose login ends in `[bot]`, including Dependabot and Renovate. Callers must preserve a hosted path for untrusted changes.
 
 Consumer repositories can use a controlled repository variable while retaining the safe default:
 
@@ -39,4 +39,3 @@ jobs:
 ```
 
 For manual callers, expose a `workflow_dispatch` choice containing only `hosted` and `trusted-heavy`. Never pass a free-form runner label.
-

--- a/docs/workflows/contracts/reusable-ci-docker.md
+++ b/docs/workflows/contracts/reusable-ci-docker.md
@@ -31,7 +31,7 @@ The existing v1 inputs remain valid. v10 adds `execution-class`, `artifact-reten
 
 The build/scan job grants only `contents: read`. The optional upload job grants `actions: read`, `contents: read`, and `security-events: write`. No secrets are accepted. `build-args` is the only build-argument source and is for non-secret values only.
 
-The execution trust boundary and repository-variable/manual fallback are documented in [reusable-browser-quality](reusable-browser-quality.md). Fork pull requests, `pull_request_target`, and Dependabot can never select a trusted runner.
+The execution trust boundary and repository-variable/manual fallback are documented in [reusable-browser-quality](reusable-browser-quality.md). Fork pull requests, `pull_request_target`, and bot actors such as Dependabot or Renovate can never select a trusted runner.
 
 ## Example
 

--- a/docs/workflows/contracts/reusable-heavy-ci-v2.md
+++ b/docs/workflows/contracts/reusable-heavy-ci-v2.md
@@ -73,9 +73,9 @@ The exact cache key contains repository ID, contract major and ID, trust tier, r
 - `restore-only`: exact-key restore only; never save.
 - `trusted-write`: save only on a trusted `push` to the repository's default branch. All other events behave as restore-only.
 
-Forks, Dependabot, and `pull_request_target` are assigned the `untrusted` cache tier and cannot save. They cannot request `trusted-heavy`. Same-repository trusted pull requests may restore the exact trusted default-branch cache but cannot write it.
+Forks, bot actors such as Dependabot or Renovate, and `pull_request_target` are assigned the `untrusted` cache tier and cannot save. They cannot request `trusted-heavy`. Same-repository trusted pull requests may restore the exact trusted default-branch cache but cannot write it.
 
-The contract test contains negative cases for fork pull requests, Dependabot, `pull_request_target`, ordinary pull requests, unsafe cache paths, parent traversal, broad restore prefixes, privileged permissions, secret inheritance, incomplete artifact binding, and non-SHA Action references. The hosted preflight performs the same trust decision before any self-hosted job is queued.
+The contract test contains negative cases for fork pull requests, Dependabot, Renovate, `pull_request_target`, ordinary pull requests, unsafe cache paths, parent traversal, broad restore prefixes, privileged permissions, secret inheritance, incomplete artifact binding, and non-SHA Action references. The hosted preflight performs the same trust decision before any self-hosted job is queued.
 
 ## Security boundaries
 

--- a/docs/workflows/dependency-rollout-baseline.md
+++ b/docs/workflows/dependency-rollout-baseline.md
@@ -1,0 +1,70 @@
+# Dependency Policy Baseline
+
+Captured on 2026-08-12 for the rolling window 2026-07-14 through 2026-08-12.
+
+## Dependency pull-request bursts
+
+| Repository | Dependabot PRs created | Configured ecosystems | Previous maximum ordinary open PRs |
+| --- | ---: | ---: | ---: |
+| Tuinstra-DEV/tracker | 17 | 5 | 25 |
+| Tuinstra-DEV/gate | 10 | 5 | 25 |
+
+The previous maximum is five PRs multiplied by five ecosystems. All ecosystems
+ran monthly without explicit times. The other nine repositories had no matching
+Dependabot or Renovate PRs in this window. A live installation check also
+confirmed that no Renovate App was installed for Tuinstra-DEV, so a Renovate
+rollout would not have been operational.
+
+On 2026-08-12 the repository settings preflight found Dependabot security
+updates enabled only for Gate. Dependency alerts and automated security fixes
+were then enabled and API-verified for all 11 rollout repositories. No token,
+alert payload or vulnerability detail is retained in this evidence.
+The sanitized result is
+docs/evidence/DEV-13-security-settings-preflight-2026-08-12.json (SHA-256
+87466c2f39534e0d6e389ae62d11df7f6e3bd130a586bdcf2be16752043e2c6e).
+
+## Short-job and rounding risk
+
+Gate and Tracker have the largest required-check surfaces. Consolidating those
+jobs without coordinated branch-rule changes would risk lost required contexts
+and failure evidence. DEV-13 instead reduces dependency-triggered run count
+while preserving job topology.
+
+The DEV-11 collector produced
+docs/evidence/DEV-13-ci-billing-baseline-2026-08-12.md (SHA-256
+53a0831a1e3177a0146a68e0bdea50c57fb5c065b04569ba1685fb655f2a37ec).
+The report is degraded: billing returned 3,152.667 net minutes, but its
+job-derived duration, rounding and runner-attribution totals are unavailable.
+One stale inventory entry (subtrack-site) returned 404. Keep that caveat in the
+after comparison and do not infer job totals from the degraded collector.
+
+A separate actor-filtered Actions extraction covers 30 complete UTC days
+(2026-07-13 through 2026-08-11) and all 11 repositories:
+docs/evidence/DEV-13-dependabot-actions-baseline-2026-08-11.json (SHA-256
+e74277bf72634ee2e4136c9bfdcf455d8d67b34d67e13bb2eeca94352d1538a0).
+It records 201 Dependabot workflow runs and 1,029 per-job-rounded hosted
+minutes: Gate contributed 32 runs/122 minutes and Tracker 169 runs/907 minutes.
+The other nine repositories had zero Dependabot runs. All job API requests
+completed. The committed collector and invocation make the extraction
+reproducible. It also found 14 merged Dependabot PRs containing 14 dependency
+rows, all in Tracker; baseline normalized values are therefore 14.36 runs and
+73.50 rounded hosted minutes per merged update. The 35 jobs with unknown runner
+attribution all had zero rounded duration; an after-window with any
+positive-duration unknown job cannot pass.
+
+## Modelled configuration effect
+
+| Control | Before | After |
+| --- | --- | --- |
+| Gate/Tracker ordinary PR concurrency | Up to 5 per ecosystem | 2 per ecosystem |
+| Patch/minor shape | One PR per dependency | One grouped PR per ecosystem |
+| Schedule | Unspecified monthly time | Explicit monthly stagger |
+| Major visibility | Individual but unbounded | Separate, second slot, 14-day disposition |
+| Security fixes | Separate GitHub queue | Unchanged separate queue |
+| Runner trust | Dependabot-specific in some workflows | Generic bot boundary |
+
+## Completion gate
+
+DEV-13 remains Started until the staged configs have been accepted by GitHub,
+the first complete 30-day after-window is recorded, both reduction thresholds
+pass and no guardrail is breached.

--- a/docs/workflows/dependency-rollout-evidence-template.md
+++ b/docs/workflows/dependency-rollout-evidence-template.md
@@ -1,0 +1,76 @@
+# Dependency Policy Rollout Evidence
+
+## Observation windows
+
+- Baseline: YYYY-MM-DD through YYYY-MM-DD
+- After: YYYY-MM-DD through YYYY-MM-DD
+- Collector command/report location:
+- Report SHA-256:
+- Source status (billing/jobs/inventory):
+- Last consumer merge date:
+
+## Results
+
+| Metric | Baseline | After | Delta | Guardrail/result |
+| --- | ---: | ---: | ---: | --- |
+| Billable GitHub Actions minutes |  |  |  | Lower |
+| Dependency-bot PRs |  |  |  | Lower or equal |
+| Dependency-bot CI runs |  |  |  | Lower |
+| Rounded dependency-bot minutes |  |  |  | At least 15% lower |
+| All-11 Dependabot CI runs | 201 |  |  | At most 201 |
+| All-11 rounded hosted minutes | 1,029 |  |  | At most 1,029 |
+| Merged dependency updates | 14 |  |  | Count PR metadata rows |
+| CI runs per merged dependency update | 14.36 |  |  | At least 10% lower when normalized |
+| Rounded minutes per merged dependency update | 73.50 |  |  | At least 10% lower when normalized |
+| Unknown runner jobs / rounded duration | 35 / 0 |  |  | After must have zero positive-duration unknowns |
+| PR feedback p50/p95 |  |  |  | Not worse |
+| Median dependency age |  |  |  | Not worse |
+| Failed runs / flaky reruns |  |  |  | Not worse |
+| Pending major updates / oldest age |  |  |  | Owner or disposition within 14 days |
+
+Definitions:
+
+- dependency-bot run: a workflow run whose triggering actor ends in [bot] and
+  whose pull request changes dependency manifests, lockfiles or action pins;
+- rounded minutes: sum of each GitHub-hosted job duration rounded up to a whole
+  minute; report self-hosted occupation separately and never call it billed;
+- first-check completion: elapsed time from PR creation to the first terminal
+  required-check set;
+- freshness: days between upstream release and merged routine update;
+- flaky rerun: a failed attempt followed by a successful rerun at the same SHA.
+- merged dependency update: one dependency row in a merged Dependabot PR's
+  metadata, including every row inside a grouped PR.
+- wave projection: after the initial scheduled check and `d` complete days,
+  `ceil(observed / d * 30)` for runs and rounded hosted minutes.
+
+Pass thresholds:
+
+- Gate plus Tracker bot workflow attempts: at least 20% lower;
+- Gate plus Tracker rounded bot minutes: at least 15% lower;
+- all-11 Dependabot attempts and rounded hosted minutes: no increase;
+- p95 first-check completion: no more than 10% worse;
+- routine dependency freshness: at most 35 days;
+- actionable security alert to fix PR: at most 24 hours;
+- failure and flaky-rerun rates: no increase above 2 percentage points.
+- collector/API errors, unparsed dependency PRs and unknown runner jobs with
+  positive duration: zero.
+
+## Safety checks
+
+- Security update latency:
+- Security alerts blocked by compatibility ignores and manual remediation:
+- Major-update visibility:
+- Fork/bot trusted-runner exposure:
+- Canonical cache writes from untrusted actors:
+
+## Decision
+
+- Keep, adjust or rollback:
+- Repositories affected:
+- Follow-up:
+
+## Rollback trigger
+
+- Guardrail breached:
+- Revert commit or consumer config:
+- Owner and completion time:

--- a/docs/workflows/dependency-rollout-matrix.md
+++ b/docs/workflows/dependency-rollout-matrix.md
@@ -1,0 +1,55 @@
+# Dependency Policy Rollout Matrix
+
+| Repository | Ecosystems | Target | Rollout order | Rollback |
+| --- | --- | --- | ---: | --- |
+| Tuinstra-DEV/devops | GitHub Actions | main | 1 | Revert config and policy commit |
+| Tuinstra-DEV/marcel-site | GitHub Actions, npm | develop | 2, hosted-only canary | Restore removed Renovate config and remove Dependabot config |
+| Tuinstra-DEV/openairco-site | GitHub Actions, npm | develop | 3 | Restore removed Renovate config and remove Dependabot config |
+| Tuinstra-DEV/tuinstra-site | GitHub Actions, npm | develop | 3 | Restore removed Renovate config and remove Dependabot config |
+| Tuinstra-DEV/wodiq-site | GitHub Actions, npm | develop | 3 | Restore removed Renovate config and remove Dependabot config |
+| marcel-tuinstra/sudoku-spark-web | GitHub Actions, npm | develop | 3 | Remove Dependabot config |
+| Tuinstra-DEV/console | GitHub Actions, Composer, npm | develop | 4 | Restore removed Renovate config and remove Dependabot config |
+| Tuinstra-DEV/notify | GitHub Actions, Composer, npm | main | 4 | Remove Dependabot config |
+| Tuinstra-DEV/WODIQ | GitHub Actions, npm | develop | 4 | Remove Dependabot config |
+| Tuinstra-DEV/gate | GitHub Actions, Docker (3 directories), Composer, npm | develop | 5 | Revert Dependabot config |
+| Tuinstra-DEV/tracker | GitHub Actions, Docker (3 directories), Composer, npm | default branch | 5 | Revert Dependabot config |
+
+Merge DevOps first, then marcel-site as the hosted-only canary. Confirm GitHub
+accepts its config, creates the expected routine group or reports no updates,
+and targets develop. Observe each wave through its initial dependency check and
+for at least seven complete days. Promote only with zero config errors, no more
+than one routine PR plus visible majors per ecosystem, zero trusted-heavy bot
+jobs, security-fix creation within 24 hours, and projected all-11 runs/minutes
+within the non-regression caps. Otherwise stop and roll back that wave.
+For an observation of `d` complete days, project each cumulative count as
+`ceil(observed / d * 30)`; begin the observation only after the wave's initial
+scheduled dependency check. This deliberately conservative linear projection
+is a promotion gate, not the final result. Any collector error, unparsed
+dependency PR, unknown runner job with positive duration, or missing initial
+check blocks promotion.
+
+Gate had 13 open ordinary Dependabot PRs on 2026-08-12: five Composer, four npm,
+three GitHub Actions and one Docker. Merge or intentionally close ordinary PRs
+until each ecosystem is at or below two before expecting the new grouped
+topology to converge. Never close security-fix PRs as queue cleanup.
+
+Rollback in exact reverse wave order. Revert or remove consumer configs first,
+preserve open security-fix PRs, and restore the previous tracked Renovate file
+only where one existed. Those restored files are historical compatibility, not
+an active updater while the Renovate App is absent. The functional containment
+state is security updates enabled with ordinary version updates disabled.
+Revert DevOps policy last.
+
+Before staging any wave, run the cross-repository contract from a workspace
+containing all 11 worktrees:
+`DEPENDABOT_FLEET_ROOT=/path/to/DEV-13 make test` in the DevOps worktree.
+A single-repository CI checkout cannot prove sibling repository state; the
+staged release gate therefore requires this explicit fleet run in addition to
+each repository's own checks.
+
+Docker base-image majors are excluded from the newly onboarded repositories in
+DEV-13 because they can require coordinated runtime and deployment changes.
+Repository owners review Dockerfile base images monthly and open a normal,
+human-owned change when needed. Gate and Tracker retain automated Docker checks
+because those existing paths already have compatibility constraints and CI
+coverage.

--- a/scripts/collect-dependabot-actions-baseline.rb
+++ b/scripts/collect-dependabot-actions-baseline.rb
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "json"
+require "open3"
+require "thread"
+require "time"
+
+REPOSITORIES = %w[
+  Tuinstra-DEV/WODIQ
+  Tuinstra-DEV/console
+  Tuinstra-DEV/devops
+  Tuinstra-DEV/gate
+  Tuinstra-DEV/marcel-site
+  Tuinstra-DEV/notify
+  Tuinstra-DEV/openairco-site
+  marcel-tuinstra/sudoku-spark-web
+  Tuinstra-DEV/tracker
+  Tuinstra-DEV/tuinstra-site
+  Tuinstra-DEV/wodiq-site
+].freeze
+
+OWNERS = REPOSITORIES.map { |repository| repository.split("/", 2).first }.uniq.freeze
+ACTOR = "dependabot[bot]"
+
+def run_json(*command)
+  stdout, stderr, status = Open3.capture3(*command)
+  raise "#{command.take(3).join(' ')} failed: #{stderr.lines.first&.strip}" unless status.success?
+
+  JSON.parse(stdout)
+end
+
+def api_pages(*arguments)
+  run_json("gh", "api", *arguments, "--paginate", "--slurp").flat_map do |page|
+    if page.is_a?(Hash) && page.key?("workflow_runs")
+      page["workflow_runs"]
+    elsif page.is_a?(Hash) && page.key?("jobs")
+      page["jobs"]
+    else
+      page
+    end
+  end
+end
+
+def job_duration_seconds(job)
+  return unless job["started_at"] && job["completed_at"]
+
+  (Time.parse(job["completed_at"]) - Time.parse(job["started_at"])).to_i
+rescue ArgumentError
+  nil
+end
+
+def dependency_rows(body)
+  grouped = body.match(/^Bumps the .+ group with (\d+) updates?:/i)
+  return grouped[1].to_i if grouped
+
+  body.scan(/^Bumps? /i).size
+end
+
+start_date, end_date = ARGV
+abort "usage: collect-dependabot-actions-baseline.rb START_DATE END_DATE" unless start_date && end_date && ARGV.size == 2
+
+Date.iso8601(start_date)
+Date.iso8601(end_date)
+abort "START_DATE must not be after END_DATE" if start_date > end_date
+
+repositories = {}
+REPOSITORIES.each do |repository|
+  runs = api_pages(
+    "-X", "GET", "repos/#{repository}/actions/runs",
+    "-f", "actor=#{ACTOR}",
+    "-f", "created=#{start_date}..#{end_date}",
+    "-f", "per_page=100"
+  ).uniq { |run| run["id"] }
+
+  queue = Queue.new
+  runs.each { |run| queue << run }
+  mutex = Mutex.new
+  jobs = []
+  errors = []
+
+  [8, [runs.length, 1].max].min.times.map do
+    Thread.new do
+      loop do
+        begin
+          run = queue.pop(true)
+          run_jobs = api_pages(
+            "-X", "GET", "repos/#{repository}/actions/runs/#{run.fetch('id')}/jobs",
+            "-f", "filter=all", "-f", "per_page=100"
+          )
+          mutex.synchronize { jobs.concat(run_jobs) }
+        rescue ThreadError
+          break
+        rescue StandardError => error
+          mutex.synchronize { errors << "#{run&.fetch('id', 'unknown')}: #{error.message}" }
+        end
+      end
+    end
+  end.each(&:join)
+
+  accepted = jobs.map do |job|
+    seconds = job_duration_seconds(job)
+    next unless seconds && seconds >= 0
+
+    labels = Array(job["labels"]).map(&:downcase)
+    runner = job["runner_name"].to_s.downcase
+    self_hosted = labels.include?("self-hosted")
+    hosted = !self_hosted && (
+      runner.start_with?("github actions") ||
+      labels.any? { |label| label.start_with?("ubuntu", "windows", "macos", "mac os") }
+    )
+    {seconds: seconds, hosted: hosted, self_hosted: self_hosted}
+  end.compact
+
+  repositories[repository] = {
+    workflow_runs: runs.length,
+    completed_jobs: accepted.length,
+    hosted_jobs: accepted.count { |job| job[:hosted] },
+    self_hosted_jobs: accepted.count { |job| job[:self_hosted] },
+    unknown_jobs: accepted.count { |job| !job[:hosted] && !job[:self_hosted] },
+    per_job_rounded_hosted_minutes: accepted.sum { |job| job[:hosted] ? (job[:seconds] / 60.0).ceil : 0 },
+    per_job_rounded_unknown_minutes: accepted.sum { |job| !job[:hosted] && !job[:self_hosted] ? (job[:seconds] / 60.0).ceil : 0 },
+    raw_job_seconds: accepted.sum { |job| job[:seconds] },
+    errors: errors
+  }
+end
+
+pull_requests = OWNERS.flat_map do |owner|
+  rows = run_json(
+    "gh", "search", "prs",
+    "--owner", owner,
+    "--app", "dependabot",
+    "--merged",
+    "--merged-at", "#{start_date}..#{end_date}",
+    "--limit", "1000",
+    "--json", "repository,number,title,body,closedAt,url"
+  )
+  abort "Dependabot PR search reached its 1000-result safety limit for #{owner}" if rows.size == 1000
+  rows.select { |pull_request| REPOSITORIES.include?(pull_request.dig("repository", "nameWithOwner")) }
+end
+
+unparsed_pull_requests = []
+merged_updates = Hash.new { |hash, repository| hash[repository] = {merged_prs: 0, dependency_rows: 0} }
+pull_requests.each do |pull_request|
+  repository = pull_request.dig("repository", "nameWithOwner")
+  count = dependency_rows(pull_request.fetch("body", ""))
+  unparsed_pull_requests << "#{repository}##{pull_request['number']}" if count.zero?
+  merged_updates[repository][:merged_prs] += 1
+  merged_updates[repository][:dependency_rows] += count
+end
+
+totals = repositories.values.each_with_object(Hash.new(0)) do |row, sum|
+  row.each { |key, value| sum[key] += value if value.is_a?(Integer) }
+end
+totals[:merged_dependabot_prs] = merged_updates.values.sum { |row| row[:merged_prs] }
+totals[:merged_dependency_updates] = merged_updates.values.sum { |row| row[:dependency_rows] }
+
+puts JSON.pretty_generate({
+  schema: "DEV-13/dependabot-actions-baseline-v2",
+  collector: {
+    version: 2,
+    invocation: "ruby scripts/collect-dependabot-actions-baseline.rb #{start_date} #{end_date}",
+    actions_query: "GET /repos/{repository}/actions/runs actor=#{ACTOR} created=#{start_date}..#{end_date}; GET each run /jobs filter=all",
+    pull_request_query: "gh search prs --owner {owner} --app dependabot --merged --merged-at #{start_date}..#{end_date}; filter repository.nameWithOwner to the 11-repository scope",
+    dependency_row_rule: "Grouped PR count from 'Bumps the ... group with N updates'; otherwise count body lines beginning 'Bump ' or 'Bumps '.",
+    runner_attribution: "self-hosted label wins; otherwise GitHub Actions runner name or hosted OS label; remaining jobs are unknown"
+  },
+  start_date: start_date,
+  end_date: end_date,
+  actor: ACTOR,
+  repositories: repositories,
+  merged_updates_by_repository: merged_updates,
+  unparsed_pull_requests: unparsed_pull_requests,
+  totals: totals
+})

--- a/scripts/dependency-update-fleet-test.rb
+++ b/scripts/dependency-update-fleet-test.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+
+abort "usage: dependency-update-fleet-test.rb repo=dependabot.yml ..." unless ARGV.size == 11
+
+expected_update_counts = {
+  "console" => 3,
+  "devops" => 1,
+  "gate" => 4,
+  "marcel-site" => 2,
+  "notify" => 3,
+  "openairco-site" => 2,
+  "sudoku-spark-web" => 2,
+  "tracker" => 4,
+  "tuinstra-site" => 2,
+  "wodiq" => 2,
+  "wodiq-site" => 2
+}
+required_docker_directories = {
+  "gate" => %w[/backend/docker/php /backend/docker/web /frontend/docker],
+  "tracker" => %w[/code /code/infra/php /code/web/docker]
+}
+
+times = {}
+ARGV.each do |argument|
+  repository, path = argument.split("=", 2)
+  abort "invalid repository=config argument" unless repository && path
+
+  config = YAML.safe_load(File.read(path))
+  abort "#{repository}: schema version must be 2" unless config["version"] == 2
+  updates = config.fetch("updates")
+  abort "#{repository}: unexpected update-lane count" unless updates.size == expected_update_counts.fetch(repository)
+  abort "#{repository}: GitHub Actions coverage missing" unless updates.any? { |update| update["package-ecosystem"] == "github-actions" }
+
+  if required_docker_directories.key?(repository)
+    docker = updates.select { |update| update["package-ecosystem"] == "docker" }
+    abort "#{repository}: Docker must use one shared concurrency lane" unless docker.size == 1
+    actual = Array(docker.first["directories"] || docker.first["directory"]).sort
+    abort "#{repository}: Docker coverage is incomplete" unless actual == required_docker_directories.fetch(repository).sort
+  end
+
+  updates.each do |update|
+    ecosystem = update.fetch("package-ecosystem")
+    abort "#{repository}/#{ecosystem}: cadence must be monthly" unless update.dig("schedule", "interval") == "monthly"
+    abort "#{repository}/#{ecosystem}: timezone must be Europe/Amsterdam" unless update.dig("schedule", "timezone") == "Europe/Amsterdam"
+    abort "#{repository}/#{ecosystem}: PR limit must be 2" unless update["open-pull-requests-limit"] == 2
+    group = update.dig("groups", "routine-updates")
+    abort "#{repository}/#{ecosystem}: version-only routine group missing" unless group&.fetch("applies-to", nil) == "version-updates"
+    abort "#{repository}/#{ecosystem}: majors must remain separate" unless group["update-types"] == %w[minor patch]
+
+    time = update.dig("schedule", "time")
+    abort "#{repository}/#{ecosystem}: schedule time missing" unless time
+    previous = times[time]
+    abort "#{repository}/#{ecosystem}: schedule overlaps #{previous} at #{time}" if previous
+    times[time] = "#{repository}/#{ecosystem}"
+  end
+end
+
+abort "fleet must contain exactly 27 staggered update lanes" unless times.size == 27
+puts "dependency update fleet test passed (11 repositories, #{times.size} unique ecosystem schedules)"

--- a/scripts/dependency-update-policy-test.rb
+++ b/scripts/dependency-update-policy-test.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+require "json"
+
+root = File.expand_path("..", __dir__)
+config = YAML.safe_load(File.read(File.join(root, ".github/dependabot.yml")))
+abort "Dependabot schema version must be 2" unless config["version"] == 2
+abort "DevOps must monitor GitHub Actions" unless config["updates"].any? { |update| update["package-ecosystem"] == "github-actions" }
+
+config["updates"].each do |update|
+  abort "Version PR limit must be capped at 2" unless update["open-pull-requests-limit"] == 2
+  abort "Updates must be monthly" unless update.dig("schedule", "interval") == "monthly"
+  group = update.dig("groups", "routine-updates")
+  abort "Routine group is missing" unless group
+  abort "Routine group must apply only to version updates" unless group["applies-to"] == "version-updates"
+  abort "Majors must remain outside the routine group" unless group["update-types"] == %w[minor patch]
+end
+
+matrix = File.read(File.join(root, "docs/workflows/dependency-rollout-matrix.md"))
+repositories = %w[
+  Tuinstra-DEV/devops
+  Tuinstra-DEV/console
+  Tuinstra-DEV/gate
+  Tuinstra-DEV/marcel-site
+  Tuinstra-DEV/notify
+  Tuinstra-DEV/openairco-site
+  marcel-tuinstra/sudoku-spark-web
+  Tuinstra-DEV/tracker
+  Tuinstra-DEV/tuinstra-site
+  Tuinstra-DEV/WODIQ
+  Tuinstra-DEV/wodiq-site
+]
+repositories.each { |repository| abort "Rollout matrix misses #{repository}" unless matrix.include?(repository) }
+
+evidence = File.read(File.join(root, "docs/workflows/dependency-rollout-evidence-template.md"))
+%w[Baseline After Rollback].each do |heading|
+  abort "Evidence template misses #{heading}" unless evidence.include?(heading)
+end
+
+baseline = File.read(File.join(root, "docs/workflows/dependency-rollout-baseline.md"))
+{"Tuinstra-DEV/tracker" => "17", "Tuinstra-DEV/gate" => "10"}.each do |repository, count|
+  abort "Baseline misses #{repository} count #{count}" unless baseline.include?("| #{repository} | #{count} |")
+end
+
+policy = File.read(File.join(root, "docs/standards/dependency-update-policy.md"))
+["at least 20% fewer", "at least 15% fewer", "within 35 days", "within 24 hours"].each do |threshold|
+  abort "Policy misses measurable threshold: #{threshold}" unless policy.include?(threshold)
+end
+
+bot_baseline = JSON.parse(File.read(File.join(root, "docs/evidence/DEV-13-dependabot-actions-baseline-2026-08-11.json")))
+abort "Bot baseline must cover all 11 repositories" unless bot_baseline["repositories"].size == 11
+abort "Bot run baseline changed unexpectedly" unless bot_baseline.dig("totals", "workflow_runs") == 201
+abort "Bot minute baseline changed unexpectedly" unless bot_baseline.dig("totals", "per_job_rounded_hosted_minutes") == 1029
+abort "Bot baseline collector is not reproducible" unless bot_baseline.dig("collector", "invocation")&.include?("collect-dependabot-actions-baseline.rb")
+abort "Bot PR baseline is not scoped to the 11 repositories" unless bot_baseline.dig("collector", "pull_request_query")&.include?("11-repository scope")
+abort "Merged dependency-update baseline changed unexpectedly" unless bot_baseline.dig("totals", "merged_dependency_updates") == 14
+abort "Bot baseline contains unparsed pull requests" unless bot_baseline["unparsed_pull_requests"] == []
+abort "Unknown baseline jobs unexpectedly contain rounded duration" unless bot_baseline.dig("totals", "per_job_rounded_unknown_minutes") == 0
+
+security = JSON.parse(File.read(File.join(root, "docs/evidence/DEV-13-security-settings-preflight-2026-08-12.json")))
+abort "Security preflight must cover all 11 repositories" unless security["repositories"].size == 11
+security["repositories"].each do |repository, state|
+  abort "#{repository}: Dependabot security lane not enabled" unless state == {"alerts" => true, "security_updates" => true}
+end
+
+abort "Rollback order is not consumer-first" unless matrix.include?("consumer")
+abort "Rollback must preserve security PRs" unless matrix.downcase.include?("preserve open security-fix prs")
+abort "Wave projection formula is missing" unless matrix.include?("ceil(observed / d * 30)")
+
+puts "dependency update policy test passed"

--- a/scripts/heavy-ci-v2-contract-test.rb
+++ b/scripts/heavy-ci-v2-contract-test.rb
@@ -27,7 +27,8 @@ check.call(text.include?("default: hosted"), "hosted must remain the execution d
 check.call(text.include?("hosted|trusted-heavy"), "execution-class enum is not enforced")
 check.call(text.include?("off|restore-only|trusted-write"), "cache-policy enum is not enforced")
 check.call(text.include?("github.event.pull_request.head.repo.fork || false"), "fork boundary is missing")
-check.call(text.include?("dependabot[bot]"), "Dependabot boundary is missing")
+check.call(text.include?("*'[bot]'"), "dependency-bot boundary is missing")
+check.call(text.include?("github.event.pull_request.user.type || ''"), "immutable bot-author boundary is missing")
 check.call(text.include?("pull_request_target"), "pull_request_target boundary is missing")
 check.call(text.include?("EVENT_NAME\" = push") && text.include?("REF_NAME\" = \"$DEFAULT_BRANCH"), "canonical cache write is not restricted to default-branch pushes")
 check.call(text.include?("actions/cache/restore@") && text.include?("actions/cache/save@"), "split restore/save cache actions are required")
@@ -67,7 +68,7 @@ def cache_path?(path)
 end
 
 def untrusted?(event:, fork:, actor:)
-  event == "pull_request_target" || fork || actor == "dependabot[bot]"
+  event == "pull_request_target" || fork || actor.end_with?("[bot]")
 end
 
 def can_write_cache?(policy:, event:, fork:, actor:, ref:, default_branch:)
@@ -80,6 +81,7 @@ end
 negative_contexts = [
   { event: "pull_request", fork: true, actor: "contributor" },
   { event: "pull_request", fork: false, actor: "dependabot[bot]" },
+  { event: "pull_request", fork: false, actor: "renovate[bot]" },
   { event: "pull_request_target", fork: false, actor: "maintainer" },
   { event: "pull_request", fork: false, actor: "maintainer" }
 ]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -17,6 +17,16 @@ required_paths=(
   "scripts/heavy-ci-v2-contract-test.rb"
   "scripts/heavy-ci-rollout-docs-test.sh"
   "scripts/heavy-ci-baseline-test.sh"
+  "scripts/dependency-update-policy-test.rb"
+  "scripts/dependency-update-fleet-test.rb"
+  ".github/dependabot.yml"
+  "docs/standards/dependency-update-policy.md"
+  "docs/workflows/dependency-rollout-matrix.md"
+  "docs/workflows/dependency-rollout-evidence-template.md"
+  "docs/workflows/dependency-rollout-baseline.md"
+  "docs/evidence/DEV-13-ci-billing-baseline-2026-08-12.md"
+  "docs/evidence/DEV-13-dependabot-actions-baseline-2026-08-11.json"
+  "docs/evidence/DEV-13-security-settings-preflight-2026-08-12.json"
   "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
@@ -34,7 +44,11 @@ ruby -e '
 '
 
 ruby -c scripts/heavy-ci-v2-contract-test.rb
+ruby -c scripts/dependency-update-policy-test.rb
+ruby -c scripts/dependency-update-fleet-test.rb
+ruby -c scripts/collect-dependabot-actions-baseline.rb
 bash -n scripts/heavy-ci-rollout-docs-test.sh
 bash -n scripts/heavy-ci-baseline-test.sh
+ruby scripts/dependency-update-policy-test.rb
 
 echo "lint passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,5 +26,23 @@ fi
 ruby ./scripts/heavy-ci-v2-contract-test.rb
 ./scripts/heavy-ci-rollout-docs-test.sh
 ./scripts/heavy-ci-baseline-test.sh
+ruby ./scripts/dependency-update-policy-test.rb
+
+if [[ -n "${DEPENDABOT_FLEET_ROOT:-}" ]]; then
+  ruby ./scripts/dependency-update-fleet-test.rb \
+    "console=${DEPENDABOT_FLEET_ROOT}/console/.github/dependabot.yml" \
+    "devops=${DEPENDABOT_FLEET_ROOT}/devops/.github/dependabot.yml" \
+    "gate=${DEPENDABOT_FLEET_ROOT}/gate/.github/dependabot.yml" \
+    "marcel-site=${DEPENDABOT_FLEET_ROOT}/marcel-site/.github/dependabot.yml" \
+    "notify=${DEPENDABOT_FLEET_ROOT}/notify/.github/dependabot.yml" \
+    "openairco-site=${DEPENDABOT_FLEET_ROOT}/openairco-site/.github/dependabot.yml" \
+    "sudoku-spark-web=${DEPENDABOT_FLEET_ROOT}/sudoku-spark-web/.github/dependabot.yml" \
+    "tracker=${DEPENDABOT_FLEET_ROOT}/tracker/.github/dependabot.yml" \
+    "tuinstra-site=${DEPENDABOT_FLEET_ROOT}/tuinstra-site/.github/dependabot.yml" \
+    "wodiq=${DEPENDABOT_FLEET_ROOT}/wodiq/.github/dependabot.yml" \
+    "wodiq-site=${DEPENDABOT_FLEET_ROOT}/wodiq-site/.github/dependabot.yml"
+else
+  echo "DEPENDABOT_FLEET_ROOT not set; cross-repository policy check skipped"
+fi
 
 echo "test passed"

--- a/scripts/workflow-contract-test.sh
+++ b/scripts/workflow-contract-test.sh
@@ -56,7 +56,8 @@ for file in "${contract_files[@]}"; do
   grep -Fq "|| 'ubuntu-24.04'" "$file" || fail "$file does not use the safe hosted fallback"
   grep -Fq "github.event_name != 'pull_request_target'" "$file" || fail "$file does not keep pull_request_target off trusted runners"
   grep -Fq '!github.event.pull_request.head.repo.fork' "$file" || fail "$file does not keep forks off trusted runners"
-  grep -Fq "github.actor != 'dependabot[bot]'" "$file" || fail "$file does not keep Dependabot off trusted runners"
+  grep -Fq "!endsWith(github.actor, '[bot]')" "$file" || fail "$file does not keep bots off trusted runners"
+  grep -Fq "github.event.pull_request.user.type != 'Bot'" "$file" || fail "$file does not preserve bot authorship after synchronization"
 done
 
 docker_workflow=".github/workflows/reusable-ci-docker.yml"


### PR DESCRIPTION
## What changed

- add a bounded, GitHub-native Dependabot policy and staged rollout plan for the 11 in-scope repositories
- add reproducible baseline evidence, security-settings evidence, measurement thresholds and rollback controls
- prevent bot-authored pull requests from reaching trusted-heavy runner paths, including after maintainer backmerges
- add policy, workflow and cross-repository fleet contract tests

## Why

Routine dependency PR bursts and per-job rounding are consuming avoidable GitHub Actions minutes. The policy groups low-risk updates, staggers schedules, limits concurrency and preserves expedited security updates.

## Verification

- `make lint`
- `DEPENDABOT_FLEET_ROOT=/Users/marceltuinstra/Documents/Codex/ci-cost-optimization/worktrees/DEV-13 make test`
- 93 runner tests plus workflow and heavy-CI contracts
- 11-repository / 27-lane fleet contract
- final Ultra delta review: no blockers for staged delivery

Tracker: DEV-13
