### PR TITLE
DEV-11: add CI billing and burn-rate reporting

### DIFF
--- a/.github/workflows/ci-billing-report.yml
+++ b/.github/workflows/ci-billing-report.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate
         continue-on-error: true
         env:
-          CI_BILLING_TOKEN: ${{ secrets.CI_BILLING_REPORT_TOKEN }}
+          CI_BILLING_REPORT_TOKEN: ${{ secrets.CI_BILLING_REPORT_TOKEN }}
         run: |
           python3 scripts/ci_billing_report.py collect \
             --organization Tuinstra-DEV \

--- a/.github/workflows/ci-billing-report.yml
+++ b/.github/workflows/ci-billing-report.yml
@@ -1,0 +1,52 @@
+name: CI billing report
+
+on:
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-billing-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Generate sanitized billing evidence
+        id: generate
+        continue-on-error: true
+        env:
+          CI_BILLING_TOKEN: ${{ secrets.CI_BILLING_REPORT_TOKEN }}
+        run: |
+          python3 scripts/ci_billing_report.py collect \
+            --organization Tuinstra-DEV \
+            --output-dir evidence/ci-billing
+
+      - name: Add report to workflow summary
+        if: ${{ always() && hashFiles('evidence/ci-billing/*.md') != '' }}
+        run: sed -n '1,240p' evidence/ci-billing/*.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain sanitized billing evidence
+        if: ${{ always() && hashFiles('evidence/ci-billing/*') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-billing-${{ github.run_id }}-${{ github.run_attempt }}
+          path: evidence/ci-billing/
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Require usable source coverage
+        if: ${{ always() && steps.generate.outcome != 'success' }}
+        run: |
+          echo "CI billing evidence is incomplete; inspect the retained report when present." >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Shared deployment script documentation is available at
 Reusable Nuxt SSG CD workflow documentation is available at
 `docs/workflows/reusable-cd-nuxt-ssg.md`.
 
+## CI billing evidence
+
+The read-only GitHub Actions billing command and daily workflow generate
+sanitized current-period, rolling 7-day, and rolling 30-day reports. Setup,
+metric boundaries, degraded-data semantics, and durable archive procedure are
+documented in [`docs/operations/ci-billing-reporting.md`](docs/operations/ci-billing-reporting.md).
+
 ## Ephemeral heavy CI
 
 The production design and host automation for the two-slot Sanctuary

--- a/config/ci-billing-consumers.json
+++ b/config/ci-billing-consumers.json
@@ -1,0 +1,14 @@
+{
+  "organization": "Tuinstra-DEV",
+  "activeRepositories": [
+    "gate",
+    "WODIQ",
+    "tracker",
+    "notify",
+    "console",
+    "wodiq-site",
+    "marcel-site",
+    "tuinstra-site"
+  ],
+  "note": "Minimum known CI consumer inventory. Collection unions this list with the complete active organization repository listing so every additional active consumer remains separate."
+}

--- a/docs/operations/ci-billing-reporting.md
+++ b/docs/operations/ci-billing-reporting.md
@@ -1,0 +1,174 @@
+# GitHub Actions billing reporting
+
+## Purpose and scope
+
+`scripts/ci_billing_report.py` produces sanitized JSON and Markdown evidence for
+the current UTC calendar month, rolling 7 UTC days, and rolling 30 UTC days. It
+covers GitHub Actions only. Alerts, enforcement, chargeback, price negotiation,
+and non-GitHub costs remain out of scope.
+
+The authoritative billing source is the organization detailed usage endpoint:
+
+```text
+GET /organizations/{org}/settings/billing/usage?year=YYYY&month=M
+X-GitHub-Api-Version: 2026-03-10
+```
+
+The command deliberately does not depend on the preview `/usage/summary`
+endpoint. It fetches each calendar month needed by the 30-day interval and
+aggregates detailed rows locally, so rolling windows work across month and year
+boundaries. Product matching is case-insensitive, repository names may be bare
+or owner-qualified, fractional quantities are preserved, and timestamps are
+bucketed by their UTC date.
+
+## Authentication and least privilege
+
+Configure the repository Actions secret `CI_BILLING_REPORT_TOKEN` with a
+fine-grained token or GitHub App credential limited to `Tuinstra-DEV` and to
+read operations:
+
+- organization **Administration: read** for enhanced billing usage;
+- repository **Actions: read** and **Metadata: read** for every active consumer;
+- no contents, administration, workflow, or billing write permission.
+
+The scheduled workflow itself declares only `contents: read`. The credential is
+read from the named environment variable, is used only in an HTTP Authorization
+header, and is never written to a report, log, fixture, or archive. A missing or
+unauthorized credential produces an explicit non-zero, incomplete report when
+the command can write one; it never becomes a zero-cost report.
+
+Manual collection uses the same path as the daily schedule:
+
+```sh
+export CI_BILLING_REPORT_TOKEN='set outside shell history where possible'
+python3 scripts/ci_billing_report.py collect \
+  --organization Tuinstra-DEV \
+  --output-dir evidence/ci-billing
+```
+
+The command exits `0` for complete or explicitly degraded evidence and `2` for
+incomplete/unauthorized evidence or a command error. Raw API responses are held
+only in process memory. Output contains aggregates, source coverage, request
+counts, definitions, and issue codes—not credentials or unnecessary raw billing
+or job records.
+
+## Active consumers and absence semantics
+
+`config/ci-billing-consumers.json` is the minimum explicit consumer inventory.
+It names Tracker, WODIQ, and Gate plus the other known CI consumers. Collection
+unions that file with a fully paginated active organization-repository listing.
+This keeps every additional active repository as an individual `Other: <repo>`
+consumer before ranking or aggregation.
+
+If repository listing or access is partial, inventory status is degraded or
+incomplete. An active repository without a detailed billing row is emitted as
+`usageObservation: no_usage_observed`, with amount and quantity values `null`.
+It is not emitted as a confirmed numeric zero. A real zero is shown only when a
+returned billing row carries zero values.
+
+Review and update the inventory when a consumer is added, renamed, archived, or
+removed. A stale configured repository causes job collection to degrade instead
+of disappearing silently.
+
+## Metric boundaries
+
+The report intentionally has separate sections and machine-readable provenance:
+
+- **GitHub billing facts**: per repository, total, and Actions SKU gross,
+  discount, and net quantities and USD amounts. Minute SKUs, Linux, premium OS,
+  storage, and unknown future Actions SKUs remain separate. These rows are the
+  summarized billed facts returned by GitHub. Amounts are explicit API facts.
+  Quantity fields carry machine-readable provenance: `explicit_api_quantity`,
+  `derived_from_amount`, `derived_from_quantities`, or
+  `mixed_explicit_and_derived`. Detailed usage rows that omit discount/net
+  quantities require reconstruction from amount divided by unit price; those
+  reconstructed values are explicitly derived and are not described as direct
+  API quantities.
+- **Raw execution duration**: `completed_at - started_at` for completed jobs.
+- **Per-job rounded estimate**: each completed GitHub-hosted job duration rounded
+  up to a whole minute, then summed. It has no OS multiplier and is never
+  presented as billed truth.
+- **Self-hosted occupation**: job wall time inferred from the `self-hosted`
+  label. Runner attribution is explicitly inferred; unknown runners remain in a
+  separate metric.
+
+Runs and jobs use `per_page=100` pagination until a short page is received.
+GitHub permits rerunning a workflow for 30 days after its initial run, while the
+workflow-run `created` filter refers to that initial run. Collection therefore
+searches initial runs from 30 days before the earliest metric date through the
+report date. It adaptively splits that UTC date range when GitHub's 1,000-result
+filtered-search cap is reached. A cap that still occurs for one UTC day, or any
+failed partition/page, sets rerun completeness to `not_guaranteed` and degrades
+or invalidates the job source instead of silently omitting executions.
+
+Jobs use `filter=all`, distinct job IDs preserve rerun attempts, and duplicate
+job IDs from repeated pages are discarded. After the lookback search, only jobs
+whose actual `started_at` UTC date is inside the requested metric range are
+admitted. Jobs from old attempts outside the range are explicitly counted as
+discarded. A malformed timestamp cannot be proven out of range, so it is kept
+for validation and degrades telemetry. Jobs concluded as `skipped` without
+runner timestamps are not counted as execution and do not create a false
+telemetry error.
+
+Every source, metric block, aggregate, window, and projection carries one of:
+`complete`, `degraded`, `incomplete`, `unauthorized`, or `not_applicable`.
+Unknown totals are `null`, not zero. Aggregate status inherits the worst child
+status. HTTP 401 and ordinary HTTP 403 are unauthorized. HTTP 403 with
+`X-RateLimit-Remaining: 0` or `Retry-After`, and all HTTP 429 responses, are
+rate limits. The collector honors `Retry-After` or `X-RateLimit-Reset` when the
+wait fits its 25-minute API budget inside the 30-minute workflow timeout;
+otherwise it emits `rate_limited`. Exhausted rate-limit and 5xx retries are
+incomplete; mixed success is degraded.
+
+The current UTC day has no documented billing freshness SLA and is always
+marked degraded/partial. Newer hosted-job telemetry than the latest billing row
+adds a billing-lag issue. The month-end figure is labelled
+`LINEAR MONTH-END BURN PROJECTION (not an invoice forecast)` and includes method,
+assumptions, and low/medium confidence.
+
+## Evidence, rendering, and retention
+
+The daily workflow uploads JSON and Markdown for 90 days, enough for monthly
+comparison. Artifact retention is not the durable archive. Once per month,
+download the latest successful artifact and append its sanitized JSON to the
+access-controlled operations archive mounted at `/srv/ci-billing-archive`:
+
+```sh
+python3 scripts/ci_billing_report.py archive \
+  --report ~/Downloads/ci-billing-YYYY-MM-DD.json \
+  --archive-root /srv/ci-billing-archive
+```
+
+The archive layout is
+`/srv/ci-billing-archive/Tuinstra-DEV/YYYY/MM/ci-billing-YYYY-MM-DD.{json,md}`.
+The command validates the schema and sensitive-field names, writes files mode
+`0600`, and refuses to replace an existing date with different content. Back up
+that access-controlled, append-only mount and retain at least 13 monthly
+snapshots. Access and deletion should follow the normal operations change log.
+
+Markdown can be reproduced from any retained JSON without contacting GitHub:
+
+```sh
+python3 scripts/ci_billing_report.py render \
+  --input /srv/ci-billing-archive/Tuinstra-DEV/YYYY/MM/ci-billing-YYYY-MM-DD.json \
+  --output /tmp/ci-billing-YYYY-MM-DD.md
+```
+
+## Operational response
+
+- `degraded`: inspect issue codes and source/metric status. Current-day partial
+  is expected; pagination, invalid rows, unknown runner attribution, or billing
+  lag require follow-up.
+- `incomplete` or `unauthorized`: do not use totals or projections for a cost
+  decision. Correct scope/permissions, rate limiting, service availability, or
+  inventory access and rerun.
+- Never substitute job-rounded minutes or inferred self-hosted occupation for
+  GitHub-billed minute quantities.
+
+## Official references
+
+- [GitHub billing usage REST API](https://docs.github.com/en/rest/billing/usage)
+- [GitHub REST API rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
+- [GitHub workflow rerun window](https://docs.github.com/en/actions/how-tos/manage-workflow-runs)
+- [`actions/upload-artifact` releases](https://github.com/actions/upload-artifact/releases)
+- [`actions/checkout` releases](https://github.com/actions/checkout/releases)

--- a/scripts/ci_billing_report.py
+++ b/scripts/ci_billing_report.py
@@ -1278,7 +1278,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     collect.add_argument("--organization", required=True)
     collect.add_argument("--output-dir", required=True)
     collect.add_argument("--as-of", help="UTC date (YYYY-MM-DD); defaults to today")
-    collect.add_argument("--token-env", default="CI_BILLING_TOKEN")
+    collect.add_argument("--token-env", default="CI_BILLING_REPORT_TOKEN")
     collect.add_argument("--api-version", default=DEFAULT_API_VERSION)
     collect.add_argument("--consumer-inventory", default=str(DEFAULT_CONSUMER_INVENTORY))
 

--- a/scripts/ci_billing_report.py
+++ b/scripts/ci_billing_report.py
@@ -1,0 +1,1315 @@
+#!/usr/bin/env python3
+"""Generate sanitized GitHub Actions billing and job-telemetry reports."""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Any, Callable, Iterable
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+SCHEMA_VERSION = "devops.ci-billing-report/v1"
+DEFAULT_API_VERSION = "2026-03-10"
+RERUN_LOOKBACK_DAYS = 30
+DEFAULT_API_TIME_BUDGET_SECONDS = 25 * 60
+STATUS_ORDER = {
+    "not_applicable": -1,
+    "complete": 0,
+    "degraded": 1,
+    "incomplete": 2,
+    "unauthorized": 3,
+}
+SECRET_KEY_RE = re.compile(r"token|authorization|credential|secret", re.IGNORECASE)
+DEFAULT_CONSUMER_INVENTORY = Path(__file__).parents[1] / "config" / "ci-billing-consumers.json"
+
+
+class ReportError(RuntimeError):
+    pass
+
+
+class NotActions(ReportError):
+    pass
+
+
+class SourceFailure(ReportError):
+    def __init__(self, code: str, status: str, message: str, http_status: int | None = None):
+        super().__init__(message)
+        self.code = code
+        self.status = status
+        self.http_status = http_status
+
+
+class PaginationFailure(SourceFailure):
+    def __init__(self, failure: SourceFailure, partial: list[dict[str, Any]], pages: int):
+        super().__init__(failure.code, failure.status, str(failure), failure.http_status)
+        self.partial = partial
+        self.pages = pages
+
+
+def issue(code: str, severity: str, source: str, message: str) -> dict[str, str]:
+    if severity not in STATUS_ORDER:
+        raise ReportError(f"invalid status: {severity}")
+    return {"code": code, "severity": severity, "source": source, "message": message}
+
+
+def worst_status(*statuses: str) -> str:
+    relevant = [status for status in statuses if status != "not_applicable"]
+    if not relevant:
+        return "not_applicable"
+    return max(relevant, key=lambda status: STATUS_ORDER[status])
+
+
+def report_status(*statuses: str) -> str:
+    status = worst_status(*statuses)
+    return "incomplete" if status == "unauthorized" else status
+
+
+def parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ReportError("timestamp is missing")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ReportError("timestamp is invalid") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def decimal_value(value: Any, field: str) -> Decimal:
+    if isinstance(value, bool) or value is None:
+        raise ReportError(f"{field} is missing")
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ReportError(f"{field} is invalid") from exc
+    if not result.is_finite():
+        raise ReportError(f"{field} is invalid")
+    return result
+
+
+def optional_decimal(item: dict[str, Any], field: str) -> Decimal | None:
+    return decimal_value(item[field], field) if field in item and item[field] is not None else None
+
+
+def repository_name(value: Any, organization: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "unattributed"
+    name = value.strip()
+    owner, separator, repo = name.partition("/")
+    if separator and owner.casefold() == organization.casefold():
+        return repo
+    return name
+
+
+def sku_category(sku: str) -> str:
+    lowered = sku.casefold()
+    if "storage" in lowered:
+        return "storage"
+    if "linux" in lowered:
+        return "linux"
+    if "windows" in lowered or "macos" in lowered or "mac os" in lowered:
+        return "premium_os"
+    return "other_actions"
+
+
+def normalize_billing_item(item: dict[str, Any], organization: str) -> dict[str, Any]:
+    product = item.get("product")
+    if not isinstance(product, str) or product.casefold() != "actions":
+        raise NotActions("non-Actions billing item")
+    sku = item.get("sku")
+    unit_type = item.get("unitType")
+    if not isinstance(sku, str) or not sku or not isinstance(unit_type, str) or not unit_type:
+        raise ReportError("billing SKU or unit type is missing")
+
+    price = decimal_value(item.get("pricePerUnit"), "pricePerUnit")
+    gross_amount = decimal_value(item.get("grossAmount"), "grossAmount")
+    discount_amount = decimal_value(item.get("discountAmount"), "discountAmount")
+    net_amount = decimal_value(item.get("netAmount"), "netAmount")
+    gross_quantity = optional_decimal(item, "grossQuantity")
+    if gross_quantity is None:
+        gross_quantity = decimal_value(item.get("quantity"), "quantity")
+    gross_quantity_provenance = "explicit_api_quantity"
+    discount_quantity = optional_decimal(item, "discountQuantity")
+    discount_quantity_provenance = (
+        "explicit_api_quantity" if discount_quantity is not None else "unavailable"
+    )
+    net_quantity = optional_decimal(item, "netQuantity")
+    net_quantity_provenance = (
+        "explicit_api_quantity" if net_quantity is not None else "unavailable"
+    )
+    if discount_quantity is None:
+        if price:
+            discount_quantity = discount_amount / price
+            discount_quantity_provenance = "derived_from_amount"
+        elif not discount_amount:
+            discount_quantity = Decimal(0)
+            discount_quantity_provenance = "derived_from_amount"
+    if net_quantity is None:
+        if price:
+            net_quantity = net_amount / price
+            net_quantity_provenance = "derived_from_amount"
+        elif discount_quantity is not None:
+            net_quantity = gross_quantity - discount_quantity
+            net_quantity_provenance = "derived_from_quantities"
+
+    return {
+        "date": parse_timestamp(item.get("date")).date(),
+        "product": "Actions",
+        "sku": sku,
+        "category": sku_category(sku),
+        "unit_type": unit_type,
+        "repository": repository_name(item.get("repositoryName"), organization),
+        "price_per_unit": price,
+        "gross_quantity": gross_quantity,
+        "gross_quantity_provenance": gross_quantity_provenance,
+        "discount_quantity": discount_quantity,
+        "discount_quantity_provenance": discount_quantity_provenance,
+        "net_quantity": net_quantity,
+        "net_quantity_provenance": net_quantity_provenance,
+        "gross_amount": gross_amount,
+        "discount_amount": discount_amount,
+        "net_amount": net_amount,
+    }
+
+
+def infer_runner_type(job: dict[str, Any]) -> str:
+    explicit = job.get("runner_type")
+    if explicit in {"github_hosted", "self_hosted", "unknown"}:
+        return explicit
+    labels = {
+        str(label).casefold()
+        for label in job.get("labels", [])
+        if isinstance(label, str)
+    }
+    if "self-hosted" in labels:
+        return "self_hosted"
+    runner_name = str(job.get("runner_name") or "").casefold()
+    hosted_prefixes = ("ubuntu", "windows", "macos", "mac os")
+    if runner_name.startswith("github actions") or any(
+        label.startswith(hosted_prefixes) for label in labels
+    ):
+        return "github_hosted"
+    return "unknown"
+
+
+def job_identity(job: dict[str, Any]) -> str:
+    job_id = job.get("job_id", job.get("id"))
+    if isinstance(job_id, int) and not isinstance(job_id, bool):
+        return f"id:{job_id}"
+    fields = (
+        job.get("repository"), job.get("run_id"), job.get("run_attempt"),
+        job.get("name"), job.get("started_at"), job.get("completed_at"),
+    )
+    return "shape:" + hashlib.sha256(repr(fields).encode("utf-8")).hexdigest()
+
+
+def normalize_jobs(jobs: Iterable[dict[str, Any]]) -> tuple[list[dict[str, Any]], int, int]:
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    duplicates = 0
+    invalid = 0
+    for job in jobs:
+        if job.get("conclusion") == "skipped" and not job.get("started_at") \
+                and not job.get("completed_at"):
+            continue
+        identity = job_identity(job)
+        if identity in seen:
+            duplicates += 1
+            continue
+        seen.add(identity)
+        try:
+            started = parse_timestamp(job.get("started_at"))
+            completed = parse_timestamp(job.get("completed_at"))
+            duration = int((completed - started).total_seconds())
+            if duration < 0:
+                raise ReportError("job completion precedes start")
+        except ReportError:
+            invalid += 1
+            continue
+        normalized.append({
+            "identity": identity,
+            "repository": str(job.get("repository") or "unattributed"),
+            "date": started.date(),
+            "started_at": started,
+            "duration_seconds": duration,
+            "runner_type": infer_runner_type(job),
+            "run_id": job.get("run_id"),
+            "run_attempt": job.get("run_attempt", 1),
+        })
+    return normalized, duplicates, invalid
+
+
+def consumer_for(repository: str) -> str:
+    leaf = repository.rsplit("/", 1)[-1].casefold()
+    if leaf == "tracker":
+        return "Tracker"
+    if leaf == "wodiq":
+        return "WODIQ"
+    if leaf == "gate":
+        return "Gate"
+    return f"Other: {repository}"
+
+
+def number(value: Decimal | int | float | None) -> int | float | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value.normalize())
+    return value
+
+
+def sum_optional(items: Iterable[dict[str, Any]], field: str) -> Decimal | None:
+    values = [item[field] for item in items]
+    if any(value is None for value in values):
+        return None
+    return sum(values, Decimal(0))
+
+
+def metric(status: str, value: Decimal | int | float | None, unit: str,
+           provenance: str, *, values_complete: bool = True) -> dict[str, Any]:
+    result = {"status": status, "value": number(value) if values_complete else None,
+              "unit": unit, "provenance": provenance}
+    if not values_complete and value is not None:
+        result["observedValue"] = number(value)
+    return result
+
+
+def aggregate_quantity_provenance(items: Iterable[dict[str, Any]], field: str) -> str:
+    provenances = {str(item[f"{field}_provenance"]) for item in items}
+    if len(provenances) == 1:
+        return provenances.pop()
+    return "mixed_explicit_and_derived"
+
+
+def billing_quantity_metric_provenance(items: list[dict[str, Any]], field: str) -> str:
+    origin = aggregate_quantity_provenance(items, field) if items else "no_usage_observed"
+    return (
+        "GitHub enhanced billing usage API summarized quantity; "
+        f"quantityProvenance={origin}"
+    )
+
+
+def billing_row(items: list[dict[str, Any]], status: str, values_complete: bool) -> dict[str, Any]:
+    first = items[0]
+    return {
+        "status": status,
+        "sku": first["sku"],
+        "category": first["category"],
+        "unitType": first["unit_type"],
+        "grossQuantity": number(sum_optional(items, "gross_quantity")) if values_complete else None,
+        "discountQuantity": number(sum_optional(items, "discount_quantity")) if values_complete else None,
+        "netQuantity": number(sum_optional(items, "net_quantity")) if values_complete else None,
+        "quantityProvenance": {
+            "gross": aggregate_quantity_provenance(items, "gross_quantity"),
+            "discount": aggregate_quantity_provenance(items, "discount_quantity"),
+            "net": aggregate_quantity_provenance(items, "net_quantity"),
+        },
+        "grossAmount": number(sum_optional(items, "gross_amount")) if values_complete else None,
+        "discountAmount": number(sum_optional(items, "discount_amount")) if values_complete else None,
+        "netAmount": number(sum_optional(items, "net_amount")) if values_complete else None,
+    }
+
+
+def aggregate_billing(items: list[dict[str, Any]], status: str,
+                      values_complete: bool,
+                      active_repositories: Iterable[str] = ()) -> dict[str, Any]:
+    by_sku: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    by_repo: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in items:
+        by_sku[(item["sku"], item["unit_type"])].append(item)
+        by_repo[item["repository"]].append(item)
+
+    totals_by_sku = [
+        billing_row(group, status, values_complete)
+        for _key, group in sorted(by_sku.items())
+    ]
+    repositories = []
+    for repository, repo_items in sorted(by_repo.items()):
+        repo_skus: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for item in repo_items:
+            repo_skus[(item["sku"], item["unit_type"])].append(item)
+        repositories.append({
+            "status": status,
+            "repository": repository,
+            "consumer": consumer_for(repository),
+            "usageObservation": "usage_rows_observed",
+            "amounts": {
+                name: metric(status, sum_optional(repo_items, field), "USD",
+                             "GitHub enhanced billing usage API",
+                             values_complete=values_complete)
+                for name, field in (("gross", "gross_amount"),
+                                    ("discount", "discount_amount"),
+                                    ("net", "net_amount"))
+            },
+            "bySku": [billing_row(group, status, values_complete)
+                      for _key, group in sorted(repo_skus.items())],
+        })
+
+    observed_names = {row["repository"].casefold() for row in repositories}
+    absence_provenance = (
+        "Complete active-repository inventory contained no matching detailed billing row; "
+        "this is no usage observed, not a confirmed numeric zero"
+    )
+    for repository in sorted(set(active_repositories), key=str.casefold):
+        if repository.casefold() in observed_names:
+            continue
+        repositories.append({
+            "status": status,
+            "repository": repository,
+            "consumer": consumer_for(repository),
+            "usageObservation": "no_usage_observed",
+            "amounts": {
+                name: metric(status, None, "USD", absence_provenance)
+                for name in ("gross", "discount", "net")
+            },
+            "bySku": [],
+        })
+    repositories.sort(key=lambda row: row["repository"].casefold())
+
+    billed_minute_items = [item for item in items if item["unit_type"].casefold() == "minutes"]
+    provenance = "GitHub enhanced billing usage API; authoritative summarized billing fact"
+    return {
+        "status": status,
+        "scope": "Actions rows observed through report generation time",
+        "usageObservation": "usage_rows_observed" if items else "no_usage_observed",
+        "totalsBySku": totals_by_sku,
+        "repositories": repositories,
+        "amounts": {
+            name: metric(status, sum_optional(items, field), "USD", provenance,
+                         values_complete=values_complete)
+            for name, field in (
+                ("gross", "gross_amount"),
+                ("discount", "discount_amount"),
+                ("net", "net_amount"),
+            )
+        },
+        "githubBilledMinutes": {
+            "gross": metric(status, sum_optional(billed_minute_items, "gross_quantity"),
+                            "minutes", billing_quantity_metric_provenance(
+                                billed_minute_items, "gross_quantity"),
+                            values_complete=values_complete),
+            "discount": metric(status, sum_optional(billed_minute_items, "discount_quantity"),
+                               "minutes", billing_quantity_metric_provenance(
+                                   billed_minute_items, "discount_quantity"),
+                               values_complete=values_complete),
+            "net": metric(status, sum_optional(billed_minute_items, "net_quantity"),
+                          "minutes", billing_quantity_metric_provenance(
+                              billed_minute_items, "net_quantity"),
+                          values_complete=values_complete),
+        },
+    }
+
+
+def aggregate_jobs(jobs: list[dict[str, Any]], status: str) -> dict[str, Any]:
+    values_complete = status == "complete"
+    raw = sum(job["duration_seconds"] for job in jobs)
+    rounded = sum(math.ceil(job["duration_seconds"] / 60)
+                  for job in jobs if job["runner_type"] == "github_hosted")
+    self_hosted = sum(job["duration_seconds"]
+                      for job in jobs if job["runner_type"] == "self_hosted")
+    unknown = sum(job["duration_seconds"] for job in jobs if job["runner_type"] == "unknown")
+    attempts = {
+        (job.get("run_id"), job.get("run_attempt"))
+        for job in jobs if job.get("run_id") is not None
+    }
+    provenance = "GitHub Actions jobs API; job-derived and not a billing source"
+
+    def job_metric(value: int, unit: str) -> dict[str, Any]:
+        return metric(status, value, unit, provenance, values_complete=values_complete)
+
+    by_repo: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for job in jobs:
+        by_repo[job["repository"]].append(job)
+    repositories = []
+    for repository, repo_jobs in sorted(by_repo.items()):
+        repo_aggregate = aggregate_jobs(repo_jobs, status) if len(by_repo) > 1 else None
+        if repo_aggregate is None:
+            repo_raw = sum(job["duration_seconds"] for job in repo_jobs)
+            repo_rounded = sum(math.ceil(job["duration_seconds"] / 60)
+                               for job in repo_jobs if job["runner_type"] == "github_hosted")
+            repo_self = sum(job["duration_seconds"]
+                            for job in repo_jobs if job["runner_type"] == "self_hosted")
+            repo_totals = {
+                "rawExecutionDuration": job_metric(repo_raw, "seconds"),
+                "perJobRoundedEstimate": job_metric(repo_rounded, "minutes"),
+                "selfHostedOccupation": job_metric(repo_self, "seconds"),
+            }
+        else:
+            repo_totals = {
+                key: repo_aggregate["totals"][key]
+                for key in ("rawExecutionDuration", "perJobRoundedEstimate", "selfHostedOccupation")
+            }
+        repositories.append({"status": status, "repository": repository,
+                             "consumer": consumer_for(repository), "metrics": repo_totals})
+
+    return {
+        "status": status,
+        "warning": "These values are not GitHub-billed truth and must not be substituted for billing usage.",
+        "runnerAttribution": "inferred from job labels and runner_name; self-hosted occupation is inferred",
+        "roundingMethod": "ceil each completed GitHub-hosted job raw duration to whole minutes; no SKU multiplier",
+        "totals": {
+            "rawExecutionDuration": job_metric(raw, "seconds"),
+            "perJobRoundedEstimate": job_metric(rounded, "minutes"),
+            "selfHostedOccupation": job_metric(self_hosted, "seconds"),
+            "unknownRunnerDuration": job_metric(unknown, "seconds"),
+            "completedJobs": job_metric(len(jobs), "jobs"),
+            "workflowRunAttemptsIncluded": job_metric(len(attempts), "attempts"),
+        },
+        "repositories": repositories,
+    }
+
+
+def date_range(start: date, end: date) -> Iterable[date]:
+    current = start
+    while current <= end:
+        yield current
+        current += timedelta(days=1)
+
+
+def window_payload(name: str, start: date, end: date, billing: list[dict[str, Any]],
+                   jobs: list[dict[str, Any]], billing_status: str, job_status: str,
+                   billing_values_complete: bool,
+                   active_repositories: list[str], inventory_status: str) -> dict[str, Any]:
+    window_billing = [item for item in billing if start <= item["date"] <= end]
+    window_jobs = [job for job in jobs if start <= job["date"] <= end]
+    window_billing_values_complete = billing_values_complete and bool(window_billing)
+    facts = aggregate_billing(window_billing, billing_status, window_billing_values_complete,
+                              active_repositories)
+    telemetry = aggregate_jobs(window_jobs, job_status)
+
+    consumer_items: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in window_billing:
+        consumer_items[consumer_for(item["repository"])].append(item)
+    top_consumers = []
+    for consumer, rows in consumer_items.items():
+        amount = sum_optional(rows, "net_amount")
+        top_consumers.append({
+            "status": billing_status,
+            "consumer": consumer,
+            "netAmount": number(amount) if billing_values_complete else None,
+        })
+    observed_consumers = {row["consumer"] for row in top_consumers}
+    for repository in active_repositories:
+        consumer = consumer_for(repository)
+        if consumer in observed_consumers:
+            continue
+        top_consumers.append({
+            "status": billing_status,
+            "consumer": consumer,
+            "repository": repository,
+            "usageObservation": "no_usage_observed",
+            "netAmount": None,
+        })
+        observed_consumers.add(consumer)
+    top_consumers.sort(key=lambda row: (row["netAmount"] is not None,
+                                        row["netAmount"] or 0), reverse=True)
+
+    daily = []
+    for day in date_range(start, end):
+        day_billing = [item for item in window_billing if item["date"] == day]
+        day_jobs = [job for job in window_jobs if job["date"] == day]
+        day_facts = aggregate_billing(
+            day_billing, billing_status, billing_values_complete and bool(day_billing))
+        day_telemetry = aggregate_jobs(day_jobs, job_status)
+        daily.append({
+            "date": day.isoformat(),
+            "status": report_status(billing_status, job_status, inventory_status),
+            "billingObservation": day_facts["usageObservation"],
+            "billingNetAmount": day_facts["amounts"]["net"],
+            "githubBilledNetMinutes": day_facts["githubBilledMinutes"]["net"],
+            "rawExecutionDuration": day_telemetry["totals"]["rawExecutionDuration"],
+            "selfHostedOccupation": day_telemetry["totals"]["selfHostedOccupation"],
+        })
+    return {
+        "label": name,
+        "status": report_status(billing_status, job_status, inventory_status),
+        "startDate": start.isoformat(),
+        "endDate": end.isoformat(),
+        "billingFacts": facts,
+        "jobDerivedMetrics": telemetry,
+        "topConsumers": top_consumers,
+        "dailyTrend": daily,
+    }
+
+
+def build_report(*, organization: str, billing_items: list[dict[str, Any]],
+                 job_records: list[dict[str, Any]], as_of: date, generated_at: datetime,
+                 billing_source: dict[str, Any], job_source: dict[str, Any],
+                 source_issues: list[dict[str, str]]) -> dict[str, Any]:
+    normalized_billing: list[dict[str, Any]] = []
+    invalid_billing = 0
+    for raw in billing_items:
+        try:
+            normalized_billing.append(normalize_billing_item(raw, organization))
+        except NotActions:
+            continue
+        except ReportError:
+            invalid_billing += 1
+
+    jobs, duplicates, invalid_jobs = normalize_jobs(job_records)
+    billing_source = dict(billing_source)
+    job_source = dict(job_source)
+    issues = list(source_issues)
+    billing_status = billing_source.get("status", "incomplete")
+    job_status = job_source.get("status", "incomplete")
+
+    if invalid_billing:
+        billing_status = worst_status(billing_status, "degraded")
+        issues.append(issue("billing_rows_invalid", "degraded", "billing",
+                            f"{invalid_billing} Actions billing rows were invalid and excluded."))
+    if invalid_jobs:
+        job_status = worst_status(job_status, "degraded")
+        issues.append(issue("job_rows_invalid", "degraded", "jobs",
+                            f"{invalid_jobs} completed jobs lacked usable timestamps and were excluded."))
+    unknown_jobs = sum(job["runner_type"] == "unknown" for job in jobs)
+    if unknown_jobs:
+        job_status = worst_status(job_status, "degraded")
+        issues.append(issue("runner_attribution_unknown", "degraded", "jobs",
+                            f"{unknown_jobs} jobs could not be attributed to hosted or self-hosted runners."))
+
+    generated_utc = generated_at.astimezone(timezone.utc)
+    if as_of >= generated_utc.date():
+        billing_status = worst_status(billing_status, "degraded")
+        issues.append(issue(
+            "current_day_partial", "degraded", "billing",
+            "The current UTC day has no documented billing freshness SLA and is explicitly partial.",
+        ))
+
+    latest_billing = max((item["date"] for item in normalized_billing), default=None)
+    latest_hosted_job = max((job["date"] for job in jobs
+                             if job["runner_type"] == "github_hosted"), default=None)
+    if latest_hosted_job and (latest_billing is None or latest_hosted_job > latest_billing):
+        billing_status = worst_status(billing_status, "degraded")
+        issues.append(issue("billing_lags_job_telemetry", "degraded", "billing",
+                            "Completed hosted jobs are newer than the latest Actions billing row."))
+
+    successful_billing_requests = int(billing_source.get(
+        "successfulRequests",
+        max(int(billing_source.get("requests", 0)) - int(billing_source.get("failedRequests", 0)), 0),
+    ))
+    if not normalized_billing and successful_billing_requests:
+        issues.append(issue("no_actions_usage_observed", "complete", "billing",
+                            "The successful API response contained no Actions rows; reported zeros mean no rows observed."))
+
+    billing_source.update({
+        "status": billing_status,
+        "actionsItemsAccepted": len(normalized_billing),
+        "invalidActionsItems": invalid_billing,
+        "latestUsageDateUtc": latest_billing.isoformat() if latest_billing else None,
+        "currentUtcDayPartial": as_of >= generated_utc.date(),
+    })
+    job_source.update({
+        "status": job_status,
+        "completedJobsAccepted": len(jobs),
+        "duplicateJobsDiscarded": duplicates,
+        "invalidJobsDiscarded": invalid_jobs,
+        "runnerAttribution": "inferred",
+    })
+
+    inventory_raw = job_source.get("activeRepositories", [])
+    if isinstance(inventory_raw, list) and all(isinstance(repo, str) for repo in inventory_raw):
+        active_repositories = []
+        seen_repositories: set[str] = set()
+        for repository in inventory_raw:
+            canonical = repository_name(repository, organization)
+            if canonical.casefold() not in seen_repositories:
+                active_repositories.append(canonical)
+                seen_repositories.add(canonical.casefold())
+        inventory_status = "complete" if job_source.get("repositoryListingComplete", True) \
+            else "degraded"
+    else:
+        active_repositories = []
+        inventory_status = "incomplete"
+    if not active_repositories:
+        for repository in sorted({item["repository"] for item in normalized_billing}.union(
+                job["repository"] for job in jobs), key=str.casefold):
+            active_repositories.append(repository)
+        if active_repositories and inventory_status == "complete":
+            inventory_status = "degraded"
+
+    period_start = as_of.replace(day=1)
+    starts = {
+        "currentBillingPeriod": period_start,
+        "rolling7Days": as_of - timedelta(days=6),
+        "rolling30Days": as_of - timedelta(days=29),
+    }
+    billing_values_complete = bool(normalized_billing) and \
+        billing_status in {"complete", "degraded"} and \
+        int(billing_source.get("failedRequests", 0)) == 0 and invalid_billing == 0
+    windows = {
+        key: window_payload(label, start, as_of, normalized_billing, jobs,
+                            billing_status, job_status, billing_values_complete,
+                            active_repositories, inventory_status)
+        for key, start, label in (
+            ("currentBillingPeriod", starts["currentBillingPeriod"], "Current UTC billing period"),
+            ("rolling7Days", starts["rolling7Days"], "Rolling 7 UTC days"),
+            ("rolling30Days", starts["rolling30Days"], "Rolling 30 UTC days"),
+        )
+    }
+
+    current_net = windows["currentBillingPeriod"]["billingFacts"]["amounts"]["net"]["value"]
+    days_in_month = calendar.monthrange(as_of.year, as_of.month)[1]
+    projection_status = billing_status
+    projected = None
+    if current_net is not None and projection_status in {"complete", "degraded"}:
+        projected = Decimal(str(current_net)) / Decimal(as_of.day) * Decimal(days_in_month)
+    projection = {
+        "label": "LINEAR MONTH-END BURN PROJECTION (not an invoice forecast)",
+        "status": projection_status,
+        "method": "linear_daily_run_rate",
+        "confidence": "low" if projection_status != "complete" or as_of.day < 7 else "medium",
+        "currency": "USD",
+        "observedNetAmount": current_net,
+        "elapsedCalendarDays": as_of.day,
+        "calendarDaysInMonth": days_in_month,
+        "projectedNetAmount": number(projected),
+        "assumptions": "Observed current-period net amount divided by elapsed UTC calendar days, multiplied by month length.",
+    }
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": report_status(billing_status, job_status, inventory_status),
+        "organization": organization,
+        "generatedAt": generated_utc.isoformat().replace("+00:00", "Z"),
+        "asOfDateUtc": as_of.isoformat(),
+        "scope": "GitHub Actions only; excludes alerts, enforcement, chargeback, and non-GitHub costs",
+        "sources": {
+            "billing": billing_source,
+            "jobs": job_source,
+            "consumerInventory": {
+                "status": inventory_status,
+                "provenance": "GitHub active organization repository inventory",
+                "activeRepositories": active_repositories,
+                "absenceSemantics": "No detailed billing row is no_usage_observed, never confirmed zero.",
+            },
+        },
+        "issues": issues,
+        "metricDefinitions": {
+            "githubBilledMinutes": "Actions billing quantity for minute rows; direct API quantities are explicit, while quantities reconstructed from amount and unit price are marked derived in provenance.",
+            "rawExecutionDuration": "Completed-at minus started-at from the jobs API, before minute rounding.",
+            "perJobRoundedEstimate": "Each completed GitHub-hosted job duration rounded up independently; estimate only, with no SKU multiplier.",
+            "selfHostedOccupation": "Raw job wall time inferred as self-hosted from labels; not a GitHub billing amount.",
+        },
+        "windows": windows,
+        "burnProjection": projection,
+    }
+
+
+class GitHubClient:
+    def __init__(self, token: str, api_url: str, api_version: str,
+                 opener: Callable[..., Any] = urllib.request.urlopen,
+                 sleeper: Callable[[float], None] = time.sleep,
+                 wall_clock: Callable[[], float] = time.time,
+                 monotonic_clock: Callable[[], float] = time.monotonic,
+                 max_elapsed_seconds: int = DEFAULT_API_TIME_BUDGET_SECONDS):
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.api_version = api_version
+        self.opener = opener
+        self.sleeper = sleeper
+        self.wall_clock = wall_clock
+        self.monotonic_clock = monotonic_clock
+        self.max_elapsed_seconds = max_elapsed_seconds
+        self.started_monotonic = monotonic_clock()
+
+    @staticmethod
+    def rate_limit_delay(http_status: int, headers: dict[str, str], now: float) -> int | None:
+        remaining = headers.get("x-ratelimit-remaining")
+        retry_after = headers.get("retry-after")
+        is_rate_limited = http_status == 429 or remaining == "0" or \
+            (http_status == 403 and retry_after is not None)
+        if not is_rate_limited:
+            return None
+        if retry_after and retry_after.isdigit():
+            return max(1, int(retry_after))
+        reset = headers.get("x-ratelimit-reset")
+        if remaining == "0" and reset and reset.isdigit():
+            return max(1, math.ceil(int(reset) - now) + 1)
+        return 60
+
+    def wait_for_rate_limit(self, delay: int, http_status: int) -> None:
+        elapsed = self.monotonic_clock() - self.started_monotonic
+        if delay > self.max_elapsed_seconds - elapsed:
+            raise SourceFailure(
+                "rate_limited", "incomplete",
+                f"GitHub API rate-limit wait exceeds the bounded collection budget "
+                f"(HTTP {http_status})", http_status,
+            )
+        self.sleeper(delay)
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        query = urllib.parse.urlencode(params or {})
+        url = f"{self.api_url}{path}" + (f"?{query}" if query else "")
+        request = urllib.request.Request(url, headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": self.api_version,
+            "User-Agent": "devops-ci-billing-report/1",
+        })
+        for attempt in range(3):
+            try:
+                with self.opener(request, timeout=30) as response:
+                    payload = json.load(response)
+                return payload
+            except urllib.error.HTTPError as exc:
+                headers = {
+                    str(key).casefold(): str(value)
+                    for key, value in (exc.headers.items() if exc.headers else [])
+                }
+                delay = self.rate_limit_delay(exc.code, headers, self.wall_clock())
+                exc.close()
+                if delay is not None:
+                    if attempt < 2:
+                        self.wait_for_rate_limit(delay, exc.code)
+                        continue
+                    raise SourceFailure(
+                        "rate_limited", "incomplete",
+                        f"GitHub API remained rate limited after bounded retries "
+                        f"(HTTP {exc.code})", exc.code,
+                    ) from None
+                if exc.code in {401, 403}:
+                    raise SourceFailure("unauthorized", "unauthorized",
+                                        f"GitHub API request was unauthorized (HTTP {exc.code})", exc.code) from None
+                retryable = 500 <= exc.code <= 599
+                if retryable and attempt < 2:
+                    self.sleeper(2 ** attempt)
+                    continue
+                raise SourceFailure("service_error", "incomplete",
+                                    f"GitHub API request failed (HTTP {exc.code})", exc.code) from None
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+                if attempt < 2:
+                    self.sleeper(2 ** attempt)
+                    continue
+                raise SourceFailure("transport_error", "incomplete",
+                                    f"GitHub API request failed: {type(exc).__name__}") from None
+        raise AssertionError("unreachable")
+
+    def get_paginated(self, path: str, key: str,
+                      params: dict[str, Any] | None = None,
+                      accessible_cap: int | None = None) -> tuple[list[dict[str, Any]], int]:
+        records: list[dict[str, Any]] = []
+        base = dict(params or {})
+        base["per_page"] = 100
+        for page in range(1, 1001):
+            query = dict(base)
+            query["page"] = page
+            try:
+                payload = self.get(path, query)
+            except SourceFailure as exc:
+                raise PaginationFailure(exc, records, page - 1) from None
+            page_records = payload if key == "__root__" else (
+                payload.get(key) if isinstance(payload, dict) else None)
+            if not isinstance(page_records, list) or any(not isinstance(row, dict) for row in page_records):
+                failure = SourceFailure("invalid_response", "incomplete",
+                                        f"GitHub response did not contain a valid {key} list")
+                raise PaginationFailure(failure, records, page - 1) from None
+            records.extend(page_records)
+            reported_total = payload.get("total_count") if isinstance(payload, dict) else None
+            if accessible_cap is not None and isinstance(reported_total, int) \
+                    and reported_total > accessible_cap and len(records) >= accessible_cap:
+                failure = SourceFailure(
+                    "search_cap_exceeded",
+                    "incomplete",
+                    f"GitHub reports {reported_total} records but exposes at most "
+                    f"{accessible_cap} for this filtered query",
+                )
+                raise PaginationFailure(failure, records[:accessible_cap], page) from None
+            if len(page_records) < 100:
+                return records, page
+        failure = SourceFailure("pagination_limit", "incomplete",
+                                "GitHub pagination exceeded 1000 pages")
+        raise PaginationFailure(failure, records, 1000)
+
+
+def month_periods(start: date, end: date) -> list[tuple[int, int]]:
+    periods = []
+    cursor = start.replace(day=1)
+    while cursor <= end:
+        periods.append((cursor.year, cursor.month))
+        cursor = (cursor.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return periods
+
+
+def collection_start(as_of: date) -> date:
+    return min(as_of - timedelta(days=29), as_of.replace(day=1))
+
+
+def source_issue(source: str, failure: SourceFailure) -> dict[str, str]:
+    return issue(f"{source}_{failure.code}", failure.status, source, str(failure))
+
+
+def collect_billing(client: GitHubClient, organization: str, start: date,
+                    end: date) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, str]]]:
+    rows: list[dict[str, Any]] = []
+    failures: list[SourceFailure] = []
+    periods = month_periods(start, end)
+    succeeded = 0
+    path = f"/organizations/{urllib.parse.quote(organization, safe='')}/settings/billing/usage"
+    for year, month in periods:
+        try:
+            payload = client.get(path, {"year": year, "month": month})
+            items = payload.get("usageItems") if isinstance(payload, dict) else None
+            if not isinstance(items, list) or any(not isinstance(row, dict) for row in items):
+                raise SourceFailure("invalid_response", "incomplete",
+                                    "GitHub billing response did not contain a valid usageItems list")
+            rows.extend(items)
+            succeeded += 1
+        except SourceFailure as exc:
+            failures.append(exc)
+    if failures and not succeeded:
+        status = "unauthorized" if all(f.status == "unauthorized" for f in failures) else "incomplete"
+    elif failures:
+        status = "degraded"
+    else:
+        status = "complete"
+    metadata = {
+        "status": status,
+        "endpoint": "/organizations/{org}/settings/billing/usage",
+        "apiVersion": client.api_version,
+        "requestedPeriodsUtc": [f"{year:04d}-{month:02d}" for year, month in periods],
+        "requests": len(periods),
+        "successfulRequests": succeeded,
+        "failedRequests": len(failures),
+        "rawItemsReceived": len(rows),
+        "rawPayloadRetained": False,
+    }
+    return rows, metadata, [source_issue("billing", failure) for failure in failures]
+
+
+def active_repository_names(rows: Iterable[dict[str, Any]]) -> list[str]:
+    return sorted({str(repo["name"]) for repo in rows
+                   if isinstance(repo.get("name"), str)
+                   and not repo.get("archived") and not repo.get("disabled")})
+
+
+def collect_repositories(client: GitHubClient, organization: str) -> tuple[list[str], int]:
+    path = f"/orgs/{urllib.parse.quote(organization, safe='')}/repos"
+    repos, pages = client.get_paginated(path, "__root__", {"type": "all"})
+    return active_repository_names(repos), pages
+
+
+def collect_runs_partitioned(client: GitHubClient, path: str, start: date,
+                             end: date) -> tuple[
+                                 list[dict[str, Any]], int, int, list[SourceFailure]]:
+    """Collect runs with adaptive UTC date partitions under GitHub's 1,000 cap."""
+    try:
+        runs, pages = client.get_paginated(
+            path, "workflow_runs",
+            {"created": f"{start.isoformat()}..{end.isoformat()}", "status": "completed"},
+            accessible_cap=1000,
+        )
+        return runs, pages, 1, []
+    except PaginationFailure as exc:
+        if exc.code == "search_cap_exceeded" and start < end:
+            midpoint = start + timedelta(days=(end - start).days // 2)
+            left = collect_runs_partitioned(client, path, start, midpoint)
+            right = collect_runs_partitioned(client, path, midpoint + timedelta(days=1), end)
+            combined = left[0] + right[0]
+            deduplicated = {}
+            for index, run in enumerate(combined):
+                run_id = run.get("id")
+                key = f"id:{run_id}" if isinstance(run_id, int) else f"shape:{index}"
+                deduplicated[key] = run
+            return (list(deduplicated.values()), exc.pages + left[1] + right[1],
+                    left[2] + right[2], left[3] + right[3])
+        return exc.partial, exc.pages, 1, [exc]
+
+
+def job_executes_in_window(job: dict[str, Any], start: date, end: date) -> bool:
+    if job.get("conclusion") == "skipped" and not job.get("started_at") \
+            and not job.get("completed_at"):
+        return False
+    try:
+        started = parse_timestamp(job.get("started_at"))
+    except ReportError:
+        return True
+    return start <= started.date() <= end
+
+
+def collect_jobs(client: GitHubClient, organization: str, start: date, end: date,
+                 fallback_repositories: Iterable[str],
+                 configured_repositories: Iterable[str] = ()) -> tuple[
+                     list[dict[str, Any]], dict[str, Any], list[dict[str, str]]]:
+    failures: list[tuple[str, SourceFailure]] = []
+    pages = 0
+    repo_listing_complete = True
+    try:
+        repositories, repo_pages = collect_repositories(client, organization)
+        pages += repo_pages
+    except PaginationFailure as exc:
+        repositories = active_repository_names(exc.partial)
+        pages += exc.pages
+        repo_listing_complete = False
+        failures.append(("repository_listing", exc))
+    configured = {
+        repository_name(repo, organization) for repo in configured_repositories
+        if repo and repo != "unattributed"
+    }
+    repositories = sorted(set(repositories).union(configured).union(
+        repository_name(repo, organization) for repo in fallback_repositories
+        if repo and repo != "unattributed"
+    ))
+
+    records: list[dict[str, Any]] = []
+    jobs_outside_window = 0
+    run_search_partitions = 0
+    run_search_start = start - timedelta(days=RERUN_LOOKBACK_DAYS)
+    complete_repositories = 0
+    for repository in repositories:
+        encoded_repo = urllib.parse.quote(repository, safe="")
+        runs_path = f"/repos/{urllib.parse.quote(organization, safe='')}/{encoded_repo}/actions/runs"
+        runs, run_pages, partitions, run_failures = collect_runs_partitioned(
+            client, runs_path, run_search_start, end)
+        pages += run_pages
+        run_search_partitions += partitions
+        repo_complete = not run_failures
+        failures.extend((repository, failure) for failure in run_failures)
+        for run in runs:
+            run_id = run.get("id")
+            if not isinstance(run_id, int) or isinstance(run_id, bool):
+                repo_complete = False
+                failures.append((repository, SourceFailure(
+                    "invalid_run", "incomplete", "Workflow run lacked a numeric id")))
+                continue
+            jobs_path = f"/repos/{urllib.parse.quote(organization, safe='')}/{encoded_repo}/actions/runs/{run_id}/jobs"
+            try:
+                jobs, job_pages = client.get_paginated(jobs_path, "jobs", {"filter": "all"})
+                pages += job_pages
+            except PaginationFailure as exc:
+                jobs = exc.partial
+                pages += exc.pages
+                repo_complete = False
+                failures.append((repository, exc))
+            for job in jobs:
+                if not job_executes_in_window(job, start, end):
+                    jobs_outside_window += 1
+                    continue
+                enriched = dict(job)
+                enriched.update({
+                    "repository": repository,
+                    "job_id": job.get("id"),
+                    "run_id": run_id,
+                    "run_attempt": job.get("run_attempt", run.get("run_attempt", 1)),
+                })
+                records.append(enriched)
+        if repo_complete:
+            complete_repositories += 1
+
+    if failures and not records and not complete_repositories:
+        status = "unauthorized" if all(failure.status == "unauthorized"
+                                       for _repo, failure in failures) else "incomplete"
+    elif failures or not repo_listing_complete:
+        status = "degraded"
+    else:
+        status = "complete"
+    metadata = {
+        "status": status,
+        "endpoint": "/repos/{owner}/{repo}/actions/runs + /jobs?filter=all",
+        "apiVersion": client.api_version,
+        "requestedRangeUtc": {"start": start.isoformat(), "end": end.isoformat()},
+        "runCreatedLookbackStartUtc": run_search_start.isoformat(),
+        "rerunLookbackDays": RERUN_LOOKBACK_DAYS,
+        "runSearchPartitions": run_search_partitions,
+        "rerunCompleteness": (
+            "not_guaranteed" if failures else
+            "bounded_by_official_30_day_rerun_window"
+        ),
+        "executionTimestampFilter": "job started_at UTC date within requestedRangeUtc",
+        "jobsOutsideWindowDiscarded": jobs_outside_window,
+        "repositoriesRequested": len(repositories),
+        "repositoriesComplete": complete_repositories,
+        "repositoryListingComplete": repo_listing_complete,
+        "activeRepositories": repositories,
+        "configuredRepositories": sorted(configured),
+        "pagesFetched": pages,
+        "failedRequests": len(failures),
+        "rawJobsReceived": len(records),
+        "rawPayloadRetained": False,
+        "rerunPolicy": "30-day initial-run lookback; filter=all; distinct job ids retained; duplicate job ids discarded",
+    }
+    problems = [issue(f"jobs_{failure.code}", failure.status, "jobs",
+                      f"{scope}: {failure}") for scope, failure in failures]
+    return records, metadata, problems
+
+
+def load_consumer_inventory(path: Path, organization: str) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("organization") != organization:
+        raise ReportError("consumer inventory organization does not match the report organization")
+    repositories = payload.get("activeRepositories")
+    if not isinstance(repositories, list) or not repositories or any(
+            not isinstance(repo, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+", repo)
+            for repo in repositories):
+        raise ReportError("consumer inventory must contain safe active repository names")
+    required = {"tracker", "wodiq", "gate"}
+    if not required.issubset({repo.casefold() for repo in repositories}):
+        raise ReportError("consumer inventory must explicitly include Tracker, WODIQ, and Gate")
+    return repositories
+
+
+def fmt(value: Any, decimals: int = 3) -> str:
+    if value is None:
+        return "unavailable"
+    if isinstance(value, (int, float)):
+        return f"{value:.{decimals}f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        f"# GitHub Actions billing report — {report['asOfDateUtc']}", "",
+        f"**Status:** `{report['status']}`  ",
+        f"**Organization:** `{report['organization']}`  ",
+        f"**Generated (UTC):** `{report['generatedAt']}`", "",
+        "> Billing facts and job-derived telemetry are deliberately separate. Job estimates are not billed truth.", "",
+    ]
+    if report["issues"]:
+        lines.extend(["## Completeness and freshness", ""])
+        for problem in report["issues"]:
+            lines.append(f"- `{problem['severity']}` `{problem['code']}` — {problem['message']}")
+        lines.append("")
+
+    lines.extend(["## GitHub billing facts", ""])
+    for key in ("currentBillingPeriod", "rolling7Days", "rolling30Days"):
+        window = report["windows"][key]
+        facts = window["billingFacts"]
+        lines.extend([
+            f"### {window['label']} ({window['startDate']} through {window['endDate']})", "",
+            f"Status: `{facts['status']}`", "",
+            "| SKU | Category | Unit | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Gross USD | Discount USD | Net USD |",
+            "|---|---|---:|---:|---:|---:|---|---:|---:|---:|",
+        ])
+        if facts["totalsBySku"]:
+            for row in facts["totalsBySku"]:
+                quantity_provenance = row["quantityProvenance"]
+                provenance_text = "/".join(
+                    quantity_provenance[name] for name in ("gross", "discount", "net"))
+                lines.append("| {sku} | {category} | {unitType} | {grossQuantity} | "
+                             "{discountQuantity} | {netQuantity} | {provenance} | "
+                             "{grossAmount} | {discountAmount} | {netAmount} |".format(
+                                 provenance=provenance_text,
+                                 **{field: fmt(value) for field, value in row.items()
+                                    if field != "quantityProvenance"}))
+        else:
+            lines.append("| _No Actions rows observed_ | — | — | — | — | — | — | — | — | — |")
+        billed = facts["githubBilledMinutes"]
+        lines.extend([
+            "",
+            f"GitHub-billed net minutes: **{fmt(billed['net']['value'])}** "
+            f"(`{billed['net']['status']}`; summarized billing fact).", "",
+            "Per repository and SKU:", "",
+            "| Repository | Consumer | SKU | Gross qty | Discount qty | Net qty | Qty provenance (G/D/N) | Net USD |",
+            "|---|---|---|---:|---:|---:|---|---:|",
+        ])
+        if facts["repositories"]:
+            for repo in facts["repositories"]:
+                for row in repo["bySku"]:
+                    provenance_text = "/".join(
+                        row["quantityProvenance"][name]
+                        for name in ("gross", "discount", "net"))
+                    lines.append(f"| {repo['repository']} | {repo['consumer']} | {row['sku']} | "
+                                 f"{fmt(row['grossQuantity'])} | {fmt(row['discountQuantity'])} | "
+                                 f"{fmt(row['netQuantity'])} | {provenance_text} | "
+                                 f"{fmt(row['netAmount'])} |")
+        else:
+            lines.append("| _No repository rows observed_ | — | — | — | — | — | — | — |")
+        lines.append("")
+
+    lines.extend(["## Job-derived telemetry (not billing)", ""])
+    current = report["windows"]["currentBillingPeriod"]["jobDerivedMetrics"]
+    totals = current["totals"]
+    lines.extend([
+        f"Status: `{current['status']}`. {current['warning']}", "",
+        f"- Raw execution duration: **{fmt(totals['rawExecutionDuration']['value'])} seconds**.",
+        f"- Per-job rounded estimate: **{fmt(totals['perJobRoundedEstimate']['value'])} minutes**.",
+        f"- Self-hosted occupation (inferred): **{fmt(totals['selfHostedOccupation']['value'])} seconds**.",
+        f"- Unknown-runner duration: **{fmt(totals['unknownRunnerDuration']['value'])} seconds**.",
+        "",
+        "## Top consumers and daily trend", "",
+        "Top consumers are ranked by observed current-period net GitHub Actions amount. "
+        "The machine-readable JSON contains rankings and UTC daily trend for all three windows.", "",
+    ])
+    for row in report["windows"]["currentBillingPeriod"]["topConsumers"][:10]:
+        lines.append(f"- {row['consumer']}: USD {fmt(row['netAmount'])} (`{row['status']}`)")
+    projection = report["burnProjection"]
+    lines.extend([
+        "", "## Month-end projection", "",
+        f"**{projection['label']}**", "",
+        f"- Status: `{projection['status']}`; method: `{projection['method']}`; "
+        f"confidence: `{projection['confidence']}`.",
+        f"- Projected net amount: **USD {fmt(projection['projectedNetAmount'])}**.",
+        f"- {projection['assumptions']}", "",
+        "## Evidence handling", "",
+        "This is a sanitized aggregate. API credentials and raw API payloads are not retained. "
+        "Use the documented append-only archive command for month-over-month evidence.", "",
+    ])
+    return "\n".join(lines)
+
+
+def atomic_write(path: Path, content: str, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(content, encoding="utf-8")
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def ensure_sanitized(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if SECRET_KEY_RE.search(str(key)):
+                raise ReportError(f"report contains forbidden sensitive field at {path}.{key}")
+            ensure_sanitized(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            ensure_sanitized(child, f"{path}[{index}]")
+
+
+def archive_report(report_path: Path, archive_root: Path) -> tuple[Path, Path]:
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schemaVersion") != SCHEMA_VERSION:
+        raise ReportError("archive input is not a supported CI billing report")
+    ensure_sanitized(payload)
+    organization = str(payload.get("organization", "")).strip()
+    as_of = date.fromisoformat(str(payload.get("asOfDateUtc", "")))
+    if not organization or not re.fullmatch(r"[A-Za-z0-9_.-]+", organization):
+        raise ReportError("report organization is unsafe for an archive path")
+    destination = archive_root / organization / f"{as_of.year:04d}" / f"{as_of.month:02d}"
+    json_path = destination / f"ci-billing-{as_of.isoformat()}.json"
+    markdown_path = destination / f"ci-billing-{as_of.isoformat()}.md"
+    json_content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    markdown_content = render_markdown(payload)
+    for path, content in ((json_path, json_content), (markdown_path, markdown_content)):
+        if path.exists():
+            if path.read_text(encoding="utf-8") != content:
+                raise ReportError(f"append-only archive entry already exists with different content: {path}")
+            continue
+        atomic_write(path, content)
+    return json_path, markdown_path
+
+
+def exit_code_for_status(status: str) -> int:
+    return 0 if status in {"complete", "degraded"} else 2
+
+
+def collect_command(args: argparse.Namespace) -> int:
+    as_of = date.fromisoformat(args.as_of) if args.as_of else datetime.now(timezone.utc).date()
+    generated_at = datetime.now(timezone.utc)
+    start = collection_start(as_of)
+    token = os.environ.get(args.token_env, "")
+    configured_repositories = load_consumer_inventory(
+        Path(args.consumer_inventory), args.organization)
+    problems: list[dict[str, str]] = []
+    if token:
+        client = GitHubClient(token, "https://api.github.com", args.api_version)
+        billing_rows, billing_source, billing_problems = collect_billing(
+            client, args.organization, start, as_of)
+        billing_repositories = {
+            repository_name(row.get("repositoryName"), args.organization)
+            for row in billing_rows if isinstance(row.get("repositoryName"), str)
+        }
+        jobs, job_source, job_problems = collect_jobs(
+            client, args.organization, start, as_of, billing_repositories,
+            configured_repositories)
+        problems.extend(billing_problems)
+        problems.extend(job_problems)
+    else:
+        billing_rows = []
+        jobs = []
+        message = f"Environment variable {args.token_env} is missing; no API request was made."
+        billing_source = {"status": "unauthorized", "requests": 0, "failedRequests": 0,
+                          "rawPayloadRetained": False}
+        job_source = {"status": "unauthorized", "repositoriesRequested": 0,
+                      "repositoriesComplete": 0, "failedRequests": 0,
+                      "rawPayloadRetained": False,
+                      "repositoryListingComplete": False,
+                      "activeRepositories": configured_repositories,
+                      "configuredRepositories": configured_repositories}
+        problems.extend([
+            issue("billing_auth_missing", "unauthorized", "billing", message),
+            issue("jobs_auth_missing", "unauthorized", "jobs", message),
+        ])
+
+    result = build_report(
+        organization=args.organization,
+        billing_items=billing_rows,
+        job_records=jobs,
+        as_of=as_of,
+        generated_at=generated_at,
+        billing_source=billing_source,
+        job_source=job_source,
+        source_issues=problems,
+    )
+    output_dir = Path(args.output_dir)
+    json_path = output_dir / f"ci-billing-{as_of.isoformat()}.json"
+    markdown_path = output_dir / f"ci-billing-{as_of.isoformat()}.md"
+    atomic_write(json_path, json.dumps(result, indent=2, sort_keys=True) + "\n")
+    atomic_write(markdown_path, render_markdown(result))
+    print(json_path)
+    print(markdown_path)
+    return exit_code_for_status(result["status"])
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    collect = commands.add_parser("collect", help="collect and aggregate GitHub API evidence")
+    collect.add_argument("--organization", required=True)
+    collect.add_argument("--output-dir", required=True)
+    collect.add_argument("--as-of", help="UTC date (YYYY-MM-DD); defaults to today")
+    collect.add_argument("--token-env", default="CI_BILLING_TOKEN")
+    collect.add_argument("--api-version", default=DEFAULT_API_VERSION)
+    collect.add_argument("--consumer-inventory", default=str(DEFAULT_CONSUMER_INVENTORY))
+
+    render = commands.add_parser("render", help="re-render Markdown from sanitized JSON")
+    render.add_argument("--input", required=True)
+    render.add_argument("--output", required=True)
+
+    archive = commands.add_parser("archive", help="append a sanitized report to durable storage")
+    archive.add_argument("--report", required=True)
+    archive.add_argument("--archive-root", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        if args.command == "collect":
+            return collect_command(args)
+        if args.command == "render":
+            payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+            ensure_sanitized(payload)
+            atomic_write(Path(args.output), render_markdown(payload))
+            return 0
+        json_path, markdown_path = archive_report(Path(args.report), Path(args.archive_root))
+        print(json_path)
+        print(markdown_path)
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError, ReportError) as exc:
+        print(f"ci-billing-report: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 required_paths=(
   ".github/workflows/reusable-ci.yml"
+  ".github/workflows/ci-billing-report.yml"
   ".github/workflows/reusable-gate-baseline.yml"
   ".github/workflows/reusable-browser-quality.yml"
   ".github/workflows/reusable-ci-docker.yml"
@@ -17,6 +18,10 @@ required_paths=(
   "scripts/heavy-ci-v2-contract-test.rb"
   "scripts/heavy-ci-rollout-docs-test.sh"
   "scripts/heavy-ci-baseline-test.sh"
+  "scripts/ci_billing_report.py"
+  "tests/test_ci_billing_report.py"
+  "config/ci-billing-consumers.json"
+  "docs/operations/ci-billing-reporting.md"
   "templates/workflows/caller-gate-baseline.yml"
   "templates/docker/nuxt-ssg-nginx.Dockerfile"
 )
@@ -36,5 +41,7 @@ ruby -e '
 ruby -c scripts/heavy-ci-v2-contract-test.rb
 bash -n scripts/heavy-ci-rollout-docs-test.sh
 bash -n scripts/heavy-ci-baseline-test.sh
+python3 -c 'compile(open("scripts/ci_billing_report.py", encoding="utf-8").read(), "scripts/ci_billing_report.py", "exec")'
+python3 -m json.tool config/ci-billing-consumers.json >/dev/null
 
 echo "lint passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,5 +26,7 @@ fi
 ruby ./scripts/heavy-ci-v2-contract-test.rb
 ./scripts/heavy-ci-rollout-docs-test.sh
 ./scripts/heavy-ci-baseline-test.sh
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=scripts \
+  python3 -m unittest discover -s tests -p 'test_ci_billing_report.py'
 
 echo "test passed"

--- a/tests/test_ci_billing_report.py
+++ b/tests/test_ci_billing_report.py
@@ -650,6 +650,8 @@ class EvidenceTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("contents: read", workflow)
         self.assertIn("secrets.CI_BILLING_REPORT_TOKEN", workflow)
+        self.assertIn("CI_BILLING_REPORT_TOKEN: ${{ secrets.CI_BILLING_REPORT_TOKEN }}", workflow)
+        self.assertNotIn("CI_BILLING_TOKEN:", workflow)
         self.assertIn("retention-days: 90", workflow)
         self.assertIn("continue-on-error: true", workflow)
         self.assertIn("persist-credentials: false", workflow)
@@ -664,6 +666,14 @@ class EvidenceTests(unittest.TestCase):
         )
         self.assertNotIn("runs-on: ubuntu-latest", workflow)
         self.assertNotIn("contents: write", workflow)
+
+    def test_collector_defaults_to_documented_secret_environment_name(self):
+        args = report.parse_args([
+            "collect",
+            "--organization", "Tuinstra-DEV",
+            "--output-dir", "evidence/ci-billing",
+        ])
+        self.assertEqual(args.token_env, "CI_BILLING_REPORT_TOKEN")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ci_billing_report.py
+++ b/tests/test_ci_billing_report.py
@@ -1,0 +1,669 @@
+from datetime import date, datetime, timezone
+from decimal import Decimal
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import ci_billing_report as report
+
+
+class BillingNormalizationTests(unittest.TestCase):
+    def test_normalizes_live_api_shape_case_fractional_quantity_and_utc_date(self):
+        item = report.normalize_billing_item(
+            {
+                "date": "2026-08-11T23:30:00-02:00",
+                "product": "actions",
+                "sku": "Actions storage",
+                "quantity": 1.25,
+                "unitType": "gigabyte-hours",
+                "pricePerUnit": 0.25,
+                "grossAmount": 0.3125,
+                "discountAmount": 0.0625,
+                "netAmount": 0.25,
+                "repositoryName": "tracker",
+            },
+            "Tuinstra-DEV",
+        )
+
+        self.assertEqual(item["date"], date(2026, 8, 12))
+        self.assertEqual(item["repository"], "tracker")
+        self.assertEqual(item["product"], "Actions")
+        self.assertEqual(item["category"], "storage")
+        self.assertEqual(item["gross_quantity"], Decimal("1.25"))
+        self.assertEqual(item["discount_quantity"], Decimal("0.25"))
+        self.assertEqual(item["net_quantity"], Decimal("1"))
+        self.assertEqual(item["gross_quantity_provenance"], "explicit_api_quantity")
+        self.assertEqual(item["discount_quantity_provenance"], "derived_from_amount")
+        self.assertEqual(item["net_quantity_provenance"], "derived_from_amount")
+
+    def test_prefers_explicit_summary_quantities_when_present(self):
+        item = report.normalize_billing_item(
+            {
+                "date": "2026-08-01T00:00:00Z",
+                "product": "Actions",
+                "sku": "Actions Linux",
+                "unitType": "minutes",
+                "pricePerUnit": 0.008,
+                "grossQuantity": 2.5,
+                "discountQuantity": 1.5,
+                "netQuantity": 1,
+                "grossAmount": 0.02,
+                "discountAmount": 0.012,
+                "netAmount": 0.008,
+                "repositoryName": "Tuinstra-DEV/wodiq",
+            },
+            "Tuinstra-DEV",
+        )
+        self.assertEqual(item["repository"], "wodiq")
+        self.assertEqual(item["gross_quantity"], Decimal("2.5"))
+        self.assertEqual(item["discount_quantity"], Decimal("1.5"))
+        self.assertEqual(item["net_quantity"], Decimal("1"))
+        self.assertEqual(item["gross_quantity_provenance"], "explicit_api_quantity")
+        self.assertEqual(item["discount_quantity_provenance"], "explicit_api_quantity")
+        self.assertEqual(item["net_quantity_provenance"], "explicit_api_quantity")
+
+    def test_aggregate_exposes_derived_quantity_provenance(self):
+        normalized = report.normalize_billing_item(
+            {
+                "date": "2026-08-01T00:00:00Z",
+                "product": "actions",
+                "sku": "Actions Linux",
+                "quantity": 10,
+                "unitType": "minutes",
+                "pricePerUnit": 0.01,
+                "grossAmount": 0.1,
+                "discountAmount": 0.04,
+                "netAmount": 0.06,
+                "repositoryName": "tracker",
+            },
+            "Tuinstra-DEV",
+        )
+        aggregate = report.aggregate_billing([normalized], "complete", True)
+        sku = aggregate["totalsBySku"][0]
+        self.assertEqual(sku["quantityProvenance"]["gross"], "explicit_api_quantity")
+        self.assertEqual(sku["quantityProvenance"]["discount"], "derived_from_amount")
+        self.assertEqual(sku["quantityProvenance"]["net"], "derived_from_amount")
+        self.assertIn("derived_from_amount", aggregate["githubBilledMinutes"]["net"]["provenance"])
+
+
+class ReportTests(unittest.TestCase):
+    def setUp(self):
+        self.as_of = date(2026, 8, 12)
+        self.generated_at = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+        self.billing = [
+            {
+                "date": "2026-08-01T00:00:00Z",
+                "product": "actions",
+                "sku": "Actions Linux",
+                "quantity": 10.5,
+                "unitType": "minutes",
+                "pricePerUnit": 0.008,
+                "grossAmount": 0.084,
+                "discountAmount": 0.04,
+                "netAmount": 0.044,
+                "repositoryName": "tracker",
+            },
+            {
+                "date": "2026-08-10T14:00:00Z",
+                "product": "Actions",
+                "sku": "Actions macOS",
+                "quantity": 2,
+                "unitType": "minutes",
+                "pricePerUnit": 0.08,
+                "grossAmount": 0.16,
+                "discountAmount": 0,
+                "netAmount": 0.16,
+                "repositoryName": "wodiq",
+            },
+            {
+                "date": "2026-08-12T00:00:00Z",
+                "product": "ACTIONS",
+                "sku": "Actions storage",
+                "quantity": 3.5,
+                "unitType": "gigabyte-hours",
+                "pricePerUnit": 0.25,
+                "grossAmount": 0.875,
+                "discountAmount": 0,
+                "netAmount": 0.875,
+                "repositoryName": "gate",
+            },
+            {
+                "date": "2026-08-12T00:00:00Z",
+                "product": "Packages",
+                "sku": "Packages storage",
+                "quantity": 100,
+                "unitType": "gigabyte-hours",
+                "pricePerUnit": 1,
+                "grossAmount": 100,
+                "discountAmount": 0,
+                "netAmount": 100,
+                "repositoryName": "tracker",
+            },
+        ]
+        self.jobs = [
+            {
+                "repository": "tracker",
+                "started_at": "2026-08-10T10:00:00Z",
+                "completed_at": "2026-08-10T10:01:01Z",
+                "runner_type": "github_hosted",
+            },
+            {
+                "repository": "wodiq",
+                "started_at": "2026-08-11T10:00:00Z",
+                "completed_at": "2026-08-11T10:02:30Z",
+                "runner_type": "self_hosted",
+            },
+        ]
+
+    def build(self, jobs=None, job_status="complete", issues=None):
+        return report.build_report(
+            organization="Tuinstra-DEV",
+            billing_items=self.billing,
+            job_records=self.jobs if jobs is None else jobs,
+            as_of=self.as_of,
+            generated_at=self.generated_at,
+            billing_source={"status": "complete", "requests": 1, "failedRequests": 0},
+            job_source={
+                "status": job_status,
+                "repositoriesRequested": 3,
+                "repositoriesComplete": 3 if job_status == "complete" else 0,
+            },
+            source_issues=[] if issues is None else issues,
+        )
+
+    def test_builds_all_windows_per_repo_sku_consumers_trend_and_projection(self):
+        result = self.build()
+
+        self.assertEqual(result["status"], "degraded")
+        self.assertEqual(
+            set(result["windows"]),
+            {"currentBillingPeriod", "rolling7Days", "rolling30Days"},
+        )
+        current = result["windows"]["currentBillingPeriod"]
+        repos = {row["repository"]: row for row in current["billingFacts"]["repositories"]}
+        self.assertEqual(set(repos), {"tracker", "wodiq", "gate"})
+        self.assertEqual(repos["tracker"]["consumer"], "Tracker")
+        self.assertEqual(repos["wodiq"]["consumer"], "WODIQ")
+        self.assertEqual(repos["gate"]["consumer"], "Gate")
+        self.assertEqual(repos["tracker"]["bySku"][0]["grossQuantity"], 10.5)
+        self.assertEqual(repos["tracker"]["bySku"][0]["netQuantity"], 5.5)
+        self.assertEqual(repos["tracker"]["bySku"][0]["netAmount"], 0.044)
+        categories = {row["category"] for row in current["billingFacts"]["totalsBySku"]}
+        self.assertEqual(categories, {"linux", "premium_os", "storage"})
+        self.assertEqual(current["topConsumers"][0]["consumer"], "Gate")
+        self.assertEqual(current["dailyTrend"][-1]["date"], "2026-08-12")
+        self.assertEqual(
+            current["jobDerivedMetrics"]["totals"]["rawExecutionDuration"]["value"],
+            211,
+        )
+        self.assertEqual(
+            current["jobDerivedMetrics"]["totals"]["perJobRoundedEstimate"]["value"],
+            2,
+        )
+        self.assertEqual(
+            current["jobDerivedMetrics"]["totals"]["selfHostedOccupation"]["value"],
+            150,
+        )
+        self.assertIn("LINEAR MONTH-END BURN PROJECTION", result["burnProjection"]["label"])
+        self.assertNotIn("Packages", str(result))
+
+    def test_named_consumers_do_not_absorb_other_active_repositories(self):
+        self.assertEqual(report.consumer_for("tracker"), "Tracker")
+        self.assertEqual(report.consumer_for("WODIQ"), "WODIQ")
+        self.assertEqual(report.consumer_for("gate"), "Gate")
+        self.assertEqual(report.consumer_for("wodiq-site"), "Other: wodiq-site")
+        self.assertEqual(report.consumer_for("tracker-tools"), "Other: tracker-tools")
+
+    def test_job_telemetry_unavailable_is_null_and_degraded_not_zero(self):
+        result = self.build(
+            jobs=[],
+            job_status="unauthorized",
+            issues=[
+                report.issue(
+                    "job_telemetry_unauthorized",
+                    "unauthorized",
+                    "jobs",
+                    "GitHub job telemetry was unauthorized.",
+                )
+            ],
+        )
+
+        self.assertEqual(result["status"], "incomplete")
+        metrics = result["windows"]["rolling7Days"]["jobDerivedMetrics"]
+        self.assertEqual(metrics["status"], "unauthorized")
+        self.assertIsNone(metrics["totals"]["rawExecutionDuration"]["value"])
+        self.assertIsNone(metrics["totals"]["perJobRoundedEstimate"]["value"])
+        self.assertIsNone(metrics["totals"]["selfHostedOccupation"]["value"])
+
+    def test_unauthorized_billing_is_explicitly_incomplete(self):
+        result = report.build_report(
+            organization="Tuinstra-DEV",
+            billing_items=[],
+            job_records=[],
+            as_of=self.as_of,
+            generated_at=self.generated_at,
+            billing_source={"status": "unauthorized", "requests": 1, "failedRequests": 1},
+            job_source={"status": "complete", "repositoriesRequested": 0, "repositoriesComplete": 0},
+            source_issues=[
+                report.issue(
+                    "billing_unauthorized",
+                    "unauthorized",
+                    "billing",
+                    "GitHub billing usage was unauthorized.",
+                )
+            ],
+        )
+        self.assertEqual(result["status"], "incomplete")
+        self.assertEqual(result["windows"]["currentBillingPeriod"]["status"], "incomplete")
+        self.assertIsNone(result["burnProjection"]["projectedNetAmount"])
+
+    def test_successful_empty_billing_response_is_no_observation_not_zero(self):
+        result = report.build_report(
+            organization="Tuinstra-DEV",
+            billing_items=[],
+            job_records=[],
+            as_of=self.as_of,
+            generated_at=self.generated_at,
+            billing_source={"status": "complete", "requests": 1,
+                            "successfulRequests": 1, "failedRequests": 0},
+            job_source={"status": "complete", "repositoriesRequested": 1,
+                        "repositoriesComplete": 1, "repositoryListingComplete": True,
+                        "activeRepositories": ["tracker"]},
+            source_issues=[],
+        )
+        facts = result["windows"]["currentBillingPeriod"]["billingFacts"]
+        self.assertEqual(facts["usageObservation"], "no_usage_observed")
+        self.assertIsNone(facts["amounts"]["net"]["value"])
+        self.assertTrue(any(problem["code"] == "no_actions_usage_observed"
+                            for problem in result["issues"]))
+
+    def test_duplicate_pages_do_not_double_count_but_distinct_attempts_do(self):
+        jobs = [
+            {
+                "job_id": 10,
+                "run_id": 1,
+                "run_attempt": 1,
+                "repository": "tracker",
+                "started_at": "2026-08-10T10:00:00Z",
+                "completed_at": "2026-08-10T10:01:00Z",
+                "runner_type": "github_hosted",
+            },
+            {
+                "job_id": 10,
+                "run_id": 1,
+                "run_attempt": 1,
+                "repository": "tracker",
+                "started_at": "2026-08-10T10:00:00Z",
+                "completed_at": "2026-08-10T10:01:00Z",
+                "runner_type": "github_hosted",
+            },
+            {
+                "job_id": 11,
+                "run_id": 1,
+                "run_attempt": 2,
+                "repository": "tracker",
+                "started_at": "2026-08-10T10:02:00Z",
+                "completed_at": "2026-08-10T10:03:00Z",
+                "runner_type": "github_hosted",
+            },
+        ]
+        result = self.build(jobs=jobs)
+        totals = result["windows"]["rolling7Days"]["jobDerivedMetrics"]["totals"]
+        self.assertEqual(totals["completedJobs"]["value"], 2)
+        self.assertEqual(totals["workflowRunAttemptsIncluded"]["value"], 2)
+        self.assertEqual(totals["rawExecutionDuration"]["value"], 120)
+
+    def test_skipped_job_without_runner_timestamps_is_not_invalid_telemetry(self):
+        jobs, duplicates, invalid = report.normalize_jobs([
+            {
+                "id": 12,
+                "conclusion": "skipped",
+                "started_at": None,
+                "completed_at": None,
+                "labels": ["ubuntu-24.04"],
+            }
+        ])
+        self.assertEqual(jobs, [])
+        self.assertEqual(duplicates, 0)
+        self.assertEqual(invalid, 0)
+
+    def test_projection_declares_method_confidence_and_inherits_status(self):
+        projection = self.build()["burnProjection"]
+        self.assertEqual(projection["status"], "degraded")
+        self.assertEqual(projection["method"], "linear_daily_run_rate")
+        self.assertIn(projection["confidence"], {"low", "medium"})
+
+    def test_active_repo_without_billing_row_is_no_usage_observed_not_zero(self):
+        result = report.build_report(
+            organization="Tuinstra-DEV",
+            billing_items=self.billing,
+            job_records=self.jobs,
+            as_of=self.as_of,
+            generated_at=self.generated_at,
+            billing_source={"status": "complete", "requests": 1, "failedRequests": 0},
+            job_source={
+                "status": "complete",
+                "repositoriesRequested": 4,
+                "repositoriesComplete": 4,
+                "repositoryListingComplete": True,
+                "activeRepositories": ["tracker", "WODIQ", "gate", "notify"],
+            },
+            source_issues=[],
+        )
+        repositories = {
+            row["repository"]: row
+            for row in result["windows"]["currentBillingPeriod"]["billingFacts"]["repositories"]
+        }
+        self.assertEqual(repositories["notify"]["usageObservation"], "no_usage_observed")
+        self.assertIsNone(repositories["notify"]["amounts"]["net"]["value"])
+        self.assertEqual(repositories["tracker"]["usageObservation"], "usage_rows_observed")
+        top = {row["consumer"]: row for row in result["windows"]["currentBillingPeriod"]["topConsumers"]}
+        self.assertIn("Other: notify", top)
+        self.assertIsNone(top["Other: notify"]["netAmount"])
+
+    def test_markdown_has_separate_fact_and_estimate_sections(self):
+        markdown = report.render_markdown(self.build())
+        self.assertIn("## GitHub billing facts", markdown)
+        self.assertIn("## Job-derived telemetry (not billing)", markdown)
+        self.assertIn("GitHub-billed net minutes", markdown)
+        self.assertIn("Per-job rounded estimate", markdown)
+        self.assertIn("Self-hosted occupation", markdown)
+        self.assertIn("LINEAR MONTH-END BURN PROJECTION", markdown)
+
+
+class ApiCollectionTests(unittest.TestCase):
+    def test_month_periods_cross_calendar_month_boundary(self):
+        self.assertEqual(
+            report.month_periods(date(2026, 7, 14), date(2026, 8, 12)),
+            [(2026, 7), (2026, 8)],
+        )
+
+    def test_collection_start_covers_day_one_of_a_31_day_current_period(self):
+        self.assertEqual(report.collection_start(date(2026, 8, 31)), date(2026, 8, 1))
+        self.assertEqual(report.collection_start(date(2026, 8, 12)), date(2026, 7, 14))
+
+    def test_partial_repository_page_names_are_preserved(self):
+        client = object.__new__(report.GitHubClient)
+        partial = [
+            {"name": "tracker", "archived": False, "disabled": False},
+            {"name": "old", "archived": True, "disabled": False},
+        ]
+        client.api_version = "2026-03-10"
+        client.get_paginated = mock.Mock(side_effect=[
+            report.PaginationFailure(
+                report.SourceFailure("service_error", "incomplete", "HTTP 503", 503),
+                partial,
+                1,
+            ),
+            ([], 1),
+        ])
+        _jobs, source, problems = report.collect_jobs(
+            client, "Tuinstra-DEV", date(2026, 8, 1), date(2026, 8, 31), [])
+        self.assertEqual(source["activeRepositories"], ["tracker"])
+        self.assertFalse(source["repositoryListingComplete"])
+        self.assertEqual(source["status"], "degraded")
+        self.assertEqual(source["pagesFetched"], 2)
+        self.assertTrue(any(problem["code"] == "jobs_service_error" for problem in problems))
+
+    def test_rerun_created_before_window_is_found_and_filtered_by_job_execution_time(self):
+        client = object.__new__(report.GitHubClient)
+        client.api_version = "2026-03-10"
+
+        def paginate(path, key, params=None, accessible_cap=None):
+            if path.endswith("/repos"):
+                return ([{"name": "tracker", "archived": False, "disabled": False}], 1)
+            if path.endswith("/actions/runs"):
+                self.assertEqual(params["created"], "2026-07-02..2026-08-31")
+                self.assertEqual(accessible_cap, 1000)
+                return ([{"id": 42, "run_attempt": 2, "created_at": "2026-07-20T00:00:00Z"}], 1)
+            self.assertEqual(params["filter"], "all")
+            return ([
+                {"id": 100, "started_at": "2026-08-05T10:00:00Z",
+                 "completed_at": "2026-08-05T10:01:00Z", "conclusion": "success"},
+                {"id": 101, "started_at": "2026-07-25T10:00:00Z",
+                 "completed_at": "2026-07-25T10:01:00Z", "conclusion": "success"},
+            ], 1)
+
+        client.get_paginated = mock.Mock(side_effect=paginate)
+        jobs, source, problems = report.collect_jobs(
+            client, "Tuinstra-DEV", date(2026, 8, 1), date(2026, 8, 31), [])
+        self.assertEqual([job["job_id"] for job in jobs], [100])
+        self.assertEqual(source["runCreatedLookbackStartUtc"], "2026-07-02")
+        self.assertEqual(source["rerunLookbackDays"], 30)
+        self.assertEqual(source["rerunCompleteness"],
+                         "bounded_by_official_30_day_rerun_window")
+        self.assertEqual(source["jobsOutsideWindowDiscarded"], 1)
+        self.assertEqual(source["status"], "complete")
+        self.assertEqual(problems, [])
+
+    def test_run_search_cap_is_adaptively_partitioned(self):
+        client = object.__new__(report.GitHubClient)
+
+        def paginate(_path, _key, params=None, accessible_cap=None):
+            if params["created"] == "2026-07-01..2026-07-04":
+                raise report.PaginationFailure(
+                    report.SourceFailure("search_cap_exceeded", "incomplete", "cap"),
+                    [{"id": 999}], 10)
+            return ([{"id": int(params["created"][-2:])}], 1)
+
+        client.get_paginated = mock.Mock(side_effect=paginate)
+        runs, pages, partitions, failures = report.collect_runs_partitioned(
+            client, "/runs", date(2026, 7, 1), date(2026, 7, 4))
+        self.assertEqual(pages, 12)
+        self.assertEqual(partitions, 2)
+        self.assertEqual(len(runs), 2)
+        self.assertEqual(failures, [])
+
+    def test_single_day_run_search_cap_explicitly_degrades(self):
+        client = object.__new__(report.GitHubClient)
+        client.get_paginated = mock.Mock(side_effect=report.PaginationFailure(
+            report.SourceFailure("search_cap_exceeded", "incomplete", "cap"),
+            [{"id": 1}], 10))
+        runs, pages, partitions, failures = report.collect_runs_partitioned(
+            client, "/runs", date(2026, 7, 1), date(2026, 7, 1))
+        self.assertEqual(runs, [{"id": 1}])
+        self.assertEqual((pages, partitions), (10, 1))
+        self.assertEqual(failures[0].code, "search_cap_exceeded")
+
+    def test_unresolved_run_partition_marks_job_source_degraded(self):
+        client = object.__new__(report.GitHubClient)
+        client.api_version = "2026-03-10"
+        client.get_paginated = mock.Mock(side_effect=[
+            ([{"name": "tracker", "archived": False, "disabled": False}], 1),
+            ([{"id": 100, "started_at": "2026-08-02T00:00:00Z",
+               "completed_at": "2026-08-02T00:01:00Z", "conclusion": "success"}], 1),
+        ])
+        failure = report.SourceFailure("search_cap_exceeded", "incomplete", "cap")
+        with mock.patch.object(
+                report, "collect_runs_partitioned",
+                return_value=([{"id": 42, "run_attempt": 1}], 10, 1, [failure])):
+            jobs, source, problems = report.collect_jobs(
+                client, "Tuinstra-DEV", date(2026, 8, 1), date(2026, 8, 31), [])
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(source["status"], "degraded")
+        self.assertEqual(source["rerunCompleteness"], "not_guaranteed")
+        self.assertTrue(any(problem["code"] == "jobs_search_cap_exceeded"
+                            for problem in problems))
+
+    def test_pagination_reads_every_page_without_silent_truncation(self):
+        client = object.__new__(report.GitHubClient)
+        first = [{"id": index} for index in range(100)]
+        client.get = mock.Mock(side_effect=[{"jobs": first}, {"jobs": [{"id": 100}]}])
+        rows, pages = client.get_paginated("/jobs", "jobs", {"filter": "all"})
+        self.assertEqual(len(rows), 101)
+        self.assertEqual(pages, 2)
+        self.assertEqual(client.get.call_args_list[0].args[1]["per_page"], 100)
+        self.assertEqual(client.get.call_args_list[0].args[1]["filter"], "all")
+        self.assertEqual(client.get.call_args_list[1].args[1]["page"], 2)
+
+    def test_pagination_preserves_partial_rows_and_failure_status(self):
+        client = object.__new__(report.GitHubClient)
+        first = [{"id": index} for index in range(100)]
+        client.get = mock.Mock(side_effect=[
+            {"jobs": first},
+            report.SourceFailure("unauthorized", "unauthorized", "HTTP 403", 403),
+        ])
+        with self.assertRaises(report.PaginationFailure) as raised:
+            client.get_paginated("/jobs", "jobs")
+        self.assertEqual(len(raised.exception.partial), 100)
+        self.assertEqual(raised.exception.pages, 1)
+        self.assertEqual(raised.exception.status, "unauthorized")
+
+    def test_pagination_surfaces_github_filtered_search_cap(self):
+        client = object.__new__(report.GitHubClient)
+        first = [{"id": index} for index in range(100)]
+        client.get = mock.Mock(return_value={"total_count": 101, "workflow_runs": first})
+        with self.assertRaises(report.PaginationFailure) as raised:
+            client.get_paginated(
+                "/runs", "workflow_runs", {"created": "2026-08-01..2026-08-31"},
+                accessible_cap=100,
+            )
+        self.assertEqual(raised.exception.code, "search_cap_exceeded")
+        self.assertEqual(raised.exception.status, "incomplete")
+        self.assertEqual(len(raised.exception.partial), 100)
+        self.assertEqual(raised.exception.pages, 1)
+
+    def test_403_is_unauthorized_and_not_retried(self):
+        error = report.urllib.error.HTTPError("https://api.github.test/x", 403, "", {}, None)
+        opener = mock.Mock(side_effect=error)
+        client = report.GitHubClient("opaque", "https://api.github.test", "2026-03-10",
+                                     opener=opener, sleeper=mock.Mock())
+        with self.assertRaises(report.SourceFailure) as raised:
+            client.get("/x")
+        self.assertEqual(raised.exception.status, "unauthorized")
+        self.assertEqual(opener.call_count, 1)
+
+    def test_rate_limit_403_honors_reset_header_instead_of_reporting_unauthorized(self):
+        error = report.urllib.error.HTTPError(
+            "https://api.github.test/x", 403, "", {
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "1004",
+            }, None)
+        opener = mock.Mock(side_effect=[error, io.BytesIO(b'{"ok": true}')])
+        sleeper = mock.Mock()
+        client = report.GitHubClient(
+            "opaque", "https://api.github.test", "2026-03-10",
+            opener=opener, sleeper=sleeper, wall_clock=lambda: 1000,
+            monotonic_clock=mock.Mock(side_effect=[0, 0]))
+        self.assertEqual(client.get("/x"), {"ok": True})
+        sleeper.assert_called_once_with(5)
+
+    def test_rate_limit_wait_beyond_client_budget_emits_rate_limited(self):
+        error = report.urllib.error.HTTPError(
+            "https://api.github.test/x", 403, "", {
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "2000",
+            }, None)
+        sleeper = mock.Mock()
+        client = report.GitHubClient(
+            "opaque", "https://api.github.test", "2026-03-10",
+            opener=mock.Mock(side_effect=error), sleeper=sleeper,
+            wall_clock=lambda: 1000, monotonic_clock=mock.Mock(side_effect=[0, 1]),
+            max_elapsed_seconds=100)
+        with self.assertRaises(report.SourceFailure) as raised:
+            client.get("/x")
+        self.assertEqual(raised.exception.code, "rate_limited")
+        self.assertEqual(raised.exception.status, "incomplete")
+        sleeper.assert_not_called()
+
+    def test_429_and_5xx_retry_then_surface_incomplete(self):
+        for status in (429, 503):
+            with self.subTest(status=status):
+                error = report.urllib.error.HTTPError(
+                    "https://api.github.test/x", status, "", {}, None)
+                opener = mock.Mock(side_effect=error)
+                sleeper = mock.Mock()
+                client = report.GitHubClient(
+                    "opaque", "https://api.github.test", "2026-03-10",
+                    opener=opener, sleeper=sleeper)
+                with self.assertRaises(report.SourceFailure) as raised:
+                    client.get("/x")
+                self.assertEqual(raised.exception.status, "incomplete")
+                self.assertEqual(opener.call_count, 3)
+                self.assertEqual(sleeper.call_count, 2)
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_degraded_report_is_usable_but_incomplete_and_unauthorized_are_not(self):
+        self.assertEqual(report.exit_code_for_status("complete"), 0)
+        self.assertEqual(report.exit_code_for_status("degraded"), 0)
+        self.assertEqual(report.exit_code_for_status("incomplete"), 2)
+        self.assertEqual(report.exit_code_for_status("unauthorized"), 2)
+
+    def test_append_only_archive_is_sanitized_and_reproducible(self):
+        payload = {
+            "schemaVersion": report.SCHEMA_VERSION,
+            "status": "degraded",
+            "organization": "Tuinstra-DEV",
+            "generatedAt": "2026-08-12T12:00:00Z",
+            "asOfDateUtc": "2026-08-12",
+            "issues": [],
+            "windows": {
+                "currentBillingPeriod": {
+                    "label": "Current", "startDate": "2026-08-01", "endDate": "2026-08-12",
+                    "billingFacts": {"status": "degraded", "totalsBySku": [],
+                                     "repositories": [], "githubBilledMinutes": {
+                                         "net": {"status": "degraded", "value": 1}}},
+                    "jobDerivedMetrics": {"status": "complete", "warning": "not billing",
+                                          "totals": {
+                                              "rawExecutionDuration": {"value": 1},
+                                              "perJobRoundedEstimate": {"value": 1},
+                                              "selfHostedOccupation": {"value": 0},
+                                              "unknownRunnerDuration": {"value": 0}}},
+                    "topConsumers": [],
+                },
+                "rolling7Days": {"label": "7", "startDate": "2026-08-06", "endDate": "2026-08-12",
+                                 "billingFacts": {"status": "degraded", "totalsBySku": [],
+                                                  "repositories": [], "githubBilledMinutes": {
+                                                      "net": {"status": "degraded", "value": 1}}}},
+                "rolling30Days": {"label": "30", "startDate": "2026-07-14", "endDate": "2026-08-12",
+                                  "billingFacts": {"status": "degraded", "totalsBySku": [],
+                                                   "repositories": [], "githubBilledMinutes": {
+                                                       "net": {"status": "degraded", "value": 1}}}},
+            },
+            "burnProjection": {"label": "LINEAR MONTH-END BURN PROJECTION",
+                               "status": "degraded", "method": "linear_daily_run_rate",
+                               "confidence": "low", "projectedNetAmount": 1,
+                               "assumptions": "test"},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "report.json"
+            source.write_text(json.dumps(payload), encoding="utf-8")
+            first = report.archive_report(source, root / "archive")
+            second = report.archive_report(source, root / "archive")
+            self.assertEqual(first, second)
+            self.assertTrue(first[0].is_file())
+            self.assertEqual(first[0].stat().st_mode & 0o777, 0o600)
+
+    def test_archive_rejects_sensitive_field_names(self):
+        with self.assertRaises(report.ReportError):
+            report.ensure_sanitized({"githubToken": "do-not-store"})
+
+    def test_scheduled_workflow_is_read_only_and_retains_monthly_evidence(self):
+        workflow = (Path(__file__).parents[1] / ".github" / "workflows" /
+                    "ci-billing-report.yml").read_text(encoding="utf-8")
+        self.assertIn("schedule:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("secrets.CI_BILLING_REPORT_TOKEN", workflow)
+        self.assertIn("retention-days: 90", workflow)
+        self.assertIn("continue-on-error: true", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("runs-on: ubuntu-24.04", workflow)
+        self.assertIn(
+            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+            workflow,
+        )
+        self.assertIn(
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+            workflow,
+        )
+        self.assertNotIn("runs-on: ubuntu-latest", workflow)
+        self.assertNotIn("contents: write", workflow)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements DEV-11 CI billing and burn-rate reporting for the Tuinstra-DEV GitHub Actions fleet.

- Adds the scheduled/manual sanitized billing collector and 90-day evidence artifact.
- Aggregates current-month, rolling 7-day, and rolling 30-day GitHub Actions billing facts.
- Separates billed facts from job-derived duration estimates and self-hosted occupation.
- Preserves explicit degraded, incomplete, unauthorized, rate-limited, and no-usage semantics.
- Merges the latest `origin/main` with normal merge commit `5cb698d`.
- Aligns the documented credential name end-to-end on `CI_BILLING_REPORT_TOKEN`.

## Validation

- `make lint` ✅
- `make test` ✅ (93 runner/platform tests, 32 billing tests, workflow/documentation checks)
- Focused billing suite: 32 tests ✅
- Missing-credential collector preflight: exit code 2, explicit `billing_auth_missing` and `jobs_auth_missing`, no API request ✅
- No credential values were printed, persisted, or included in generated evidence ✅
- No merge conflicts remain; the only conflicts were the shared lint/test entrypoints and both DEV-11 billing and DEV-13 policy checks were retained.

## Live-run blocker

A live GitHub collection was not performed because this environment has no `CI_BILLING_REPORT_TOKEN` or `GITHUB_TOKEN`, and the local `gh` session reports an invalid token. No secret was created or rotated.

Operational setup after merge:

1. Configure repository Actions secret `CI_BILLING_REPORT_TOKEN`.
2. Use a least-privilege fine-grained token or GitHub App credential scoped to `Tuinstra-DEV` with organization Administration: read, repository Actions: read, and Metadata: read only.
3. Dispatch the workflow manually and verify the retained sanitized JSON/Markdown artifact and job summary.

## Security

The workflow declares `contents: read`, disables checkout credential persistence, uses the credential only in the Authorization header, and never writes raw API responses or credentials to artifacts.

## Rollback

Disable the schedule/workflow and revert the DEV-11 commits. The collector and evidence artifacts are additive; existing CI workflows are unaffected.

Refs: DEV-11
