### PR TITLE
DEV-10: Deliver fail-fast Heavy CI v2 preflight

### DIFF
--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -157,6 +157,7 @@ jobs:
           RUN_LIVE_SMOKE: ${{ inputs.run-live-smoke }}
         run: |
           set -uo pipefail
+          pr_author_type="${PR_AUTHOR_TYPE:-}"
           preflight_started=$(date +%s)
           decision=blocked
           reason_category=invalid-context
@@ -322,7 +323,7 @@ jobs:
           [[ -n "$DEFAULT_BRANCH" && -n "$REF_NAME" ]] || block_preflight invalid-context "default branch and ref name are required"
 
           untrusted=false
-          if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = *'[bot]' || "$TRIGGERING_ACTOR" = *'[bot]' || "$PR_AUTHOR_TYPE" = Bot ]]; then
+          if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = *'[bot]' || "$TRIGGERING_ACTOR" = *'[bot]' || "$pr_author_type" = Bot ]]; then
             untrusted=true
           fi
 

--- a/.github/workflows/reusable-heavy-ci-v2.yml
+++ b/.github/workflows/reusable-heavy-ci-v2.yml
@@ -85,6 +85,16 @@ on:
         value: ${{ jobs.build.outputs.cache-hit }}
       metrics-artifact:
         value: ${{ jobs.summary.outputs.metrics-artifact }}
+      preflight-decision:
+        value: ${{ jobs.preflight.outputs.preflight-decision }}
+      preflight-reason-category:
+        value: ${{ jobs.preflight.outputs.preflight-reason-category }}
+      preflight-evidence:
+        value: ${{ jobs.preflight.outputs.preflight-evidence }}
+      planned-expensive-jobs:
+        value: ${{ jobs.preflight.outputs.planned-expensive-jobs }}
+      avoided-expensive-jobs:
+        value: ${{ jobs.preflight.outputs.avoided-expensive-jobs }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -104,7 +114,17 @@ jobs:
       effective-execution-class: ${{ steps.contract.outputs.effective-execution-class }}
       matrix: ${{ steps.contract.outputs.matrix }}
       has-fanout: ${{ steps.contract.outputs.has-fanout }}
+      preflight-decision: ${{ steps.contract.outputs.decision }}
+      preflight-reason-category: ${{ steps.contract.outputs.reason-category }}
+      preflight-evidence: ${{ steps.contract.outputs.preflight-evidence }}
+      planned-expensive-jobs: ${{ steps.contract.outputs.planned-expensive-jobs }}
+      avoided-expensive-jobs: ${{ steps.contract.outputs.avoided-expensive-jobs }}
     steps:
+      - name: Checkout exact caller source for preflight
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Validate contract and route trust
         id: contract
         shell: bash
@@ -122,46 +142,209 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
           ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REF_NAME: ${{ github.ref_name }}
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          REUSABLE_WORKFLOW_REF: ${{ job.workflow_ref }}
+          REUSABLE_WORKFLOW_SHA: ${{ job.workflow_sha }}
+          REUSABLE_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
           RUN_UNIT: ${{ inputs.run-unit }}
           RUN_INTEGRATION: ${{ inputs.run-integration }}
           RUN_BROWSER: ${{ inputs.run-browser }}
           RUN_LIVE_SMOKE: ${{ inputs.run-live-smoke }}
         run: |
-          set -euo pipefail
-          case "$EXECUTION_CLASS" in hosted|trusted-heavy) ;; *) echo "execution-class must be hosted or trusted-heavy" >&2; exit 2 ;; esac
-          case "$CACHE_POLICY" in off|restore-only|trusted-write) ;; *) echo "cache-policy must be off, restore-only, or trusted-write" >&2; exit 2 ;; esac
+          set -uo pipefail
+          preflight_started=$(date +%s)
+          decision=blocked
+          reason_category=invalid-context
+          reason_detail=preflight-not-completed
+          requested_execution_class_evidence=invalid
+          effective_execution_class=hosted
+          runner='"ubuntu-24.04"'
+          trust_tier=untrusted
+          can_write_cache=false
+          candidate_expensive_jobs=1
+          planned_expensive_jobs=0
+          avoided_expensive_jobs=1
+          enabled_stage_count=0
+
+          json_escape() {
+            local value="$1"
+            value=${value//\\/\\\\}
+            value=${value//\"/\\\"}
+            value=${value//$'\n'/\\n}
+            value=${value//$'\r'/\\r}
+            value=${value//$'\t'/\\t}
+            printf '%s' "$value"
+          }
+
+          emit_preflight() {
+            local finished duration evidence
+            finished=$(date +%s)
+            duration=$((finished-preflight_started))
+            evidence=$(printf '{"schema_version":"heavy-ci/preflight-v1","decision":"%s","reason_category":"%s","requested_execution_class":"%s","effective_execution_class":"%s","trust_tier":"%s","event_name":"%s","enabled_stage_count":%s,"planned_expensive_jobs":%s,"avoided_expensive_jobs":%s,"duration_seconds":%s,"caller_workflow_sha":"%s","reusable_workflow_sha":"%s"}' \
+              "$(json_escape "$decision")" "$(json_escape "$reason_category")" "$(json_escape "$requested_execution_class_evidence")" \
+              "$(json_escape "$effective_execution_class")" "$(json_escape "$trust_tier")" "$(json_escape "$EVENT_NAME")" \
+              "$enabled_stage_count" "$planned_expensive_jobs" "$avoided_expensive_jobs" "$duration" \
+              "$(json_escape "$CALLER_WORKFLOW_SHA")" "$(json_escape "$REUSABLE_WORKFLOW_SHA")")
+            {
+              echo "decision=$decision"
+              echo "reason-category=$reason_category"
+              echo "preflight-evidence=$evidence"
+              echo "planned-expensive-jobs=$planned_expensive_jobs"
+              echo "avoided-expensive-jobs=$avoided_expensive_jobs"
+              echo "effective-execution-class=$effective_execution_class"
+              echo "runner=$runner"
+              echo "trust-tier=$trust_tier"
+              echo "can-write-cache=$can_write_cache"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo '### Heavy CI v2 preflight'
+              echo
+              echo '```json'
+              echo "$evidence"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          block_preflight() {
+            reason_category="$1"
+            reason_detail="$2"
+            decision=blocked
+            planned_expensive_jobs=0
+            avoided_expensive_jobs=$candidate_expensive_jobs
+            emit_preflight
+            echo "Heavy CI v2 preflight blocked [$reason_category]: $reason_detail" >&2
+            exit 2
+          }
+
+          skip_preflight() {
+            reason_category="$1"
+            reason_detail="$2"
+            decision=skip
+            planned_expensive_jobs=0
+            avoided_expensive_jobs=$candidate_expensive_jobs
+            emit_preflight
+            echo "Heavy CI v2 preflight skipped [$reason_category]: $reason_detail"
+            exit 0
+          }
+
+          case "$EXECUTION_CLASS" in
+            hosted|trusted-heavy) requested_execution_class_evidence="$EXECUTION_CLASS" ;;
+            *) block_preflight invalid-contract "execution-class must be hosted or trusted-heavy" ;;
+          esac
+          case "$CACHE_POLICY" in off|restore-only|trusted-write) ;; *) block_preflight invalid-contract "cache-policy must be off, restore-only, or trusted-write" ;; esac
           for token in "$CONTRACT_ID" "$CACHE_SCHEMA" "$TOOLCHAIN"; do
-            [[ "$token" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "contract-id, cache-schema, and toolchain accept only safe identifier characters" >&2; exit 2; }
+            [[ "$token" =~ ^[A-Za-z0-9._-]+$ ]] || block_preflight invalid-contract "contract-id, cache-schema, and toolchain accept only safe identifier characters"
           done
+
+          for toggle in "$RUN_UNIT" "$RUN_INTEGRATION" "$RUN_BROWSER" "$RUN_LIVE_SMOKE"; do
+            case "$toggle" in true|false) ;; *) block_preflight invalid-contract "stage toggles must be true or false" ;; esac
+          done
+          [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] || block_preflight invalid-contract "artifact-retention-days must be an integer"
+          (( RETENTION_DAYS >= 1 && RETENTION_DAYS <= 30 )) || block_preflight invalid-contract "artifact-retention-days must be between 1 and 30"
+
+          [[ "$RUN_UNIT" = true ]] && enabled_stage_count=$((enabled_stage_count+1))
+          [[ "$RUN_INTEGRATION" = true ]] && enabled_stage_count=$((enabled_stage_count+1))
+          [[ "$RUN_BROWSER" = true ]] && enabled_stage_count=$((enabled_stage_count+1))
+          [[ "$RUN_LIVE_SMOKE" = true ]] && enabled_stage_count=$((enabled_stage_count+1))
+          candidate_expensive_jobs=$((1+enabled_stage_count))
+          avoided_expensive_jobs=$candidate_expensive_jobs
+
           for path in "$CACHE_PATH" "$LOCKFILE" "$ENTRYPOINT" "$ARTIFACT_PATH"; do
-            [[ -n "$path" && "$path" != /* && ! "$path" =~ (^|/)\.\.(/|$) ]] || { echo "paths must be non-empty, repository-relative, and may not contain '..'" >&2; exit 2; }
+            [[ -n "$path" && "$path" != /* && "$path" != . && "$path" != */ && "$path" != *//* ]] || block_preflight unsafe-input "paths must be normalized repository-relative paths"
+            [[ "$path" != *$'\n'* && "$path" != *$'\r'* && "$path" != *$'\t'* ]] || block_preflight unsafe-input "paths may not contain control characters"
+            [[ ! "$path" =~ (^|/)\.\.?(/|$) && ! "$path" =~ (^|/)\.git(/|$) ]] || block_preflight unsafe-input "paths may not traverse parents, contain dot segments, or access .git"
           done
-          [[ "$CACHE_PATH" != *$'\n'* ]] || { echo "cache-path accepts one repository-relative path" >&2; exit 2; }
-          while IFS= read -r cache_entry; do
-            [[ -z "$cache_entry" ]] && continue
-            [[ "$cache_entry" != /* && ! "$cache_entry" =~ (^|/)\.\.(/|$) ]] || { echo "cache paths must be repository-relative" >&2; exit 2; }
-            [[ ! "$cache_entry" =~ (^|/)(node_modules|vendor|dist|build|\.output)(/|$) ]] || { echo "installed dependencies and build outputs may not be shared as dependency caches" >&2; exit 2; }
-          done <<< "$CACHE_PATH"
-          (( RETENTION_DAYS >= 1 && RETENTION_DAYS <= 30 )) || { echo "artifact-retention-days must be between 1 and 30" >&2; exit 2; }
+          [[ ! "$CACHE_PATH" =~ (^|/)(node_modules|vendor|dist|build|\.output)(/|$) ]] || block_preflight unsafe-input "installed dependencies and build outputs may not be shared as dependency caches"
+
+          path_contains() {
+            [[ "$1" = "$2" || "$1" = "$2/"* ]]
+          }
+          if path_contains "$CACHE_PATH" "$ARTIFACT_PATH" || path_contains "$ARTIFACT_PATH" "$CACHE_PATH"; then
+            block_preflight input-path-conflict "cache-path and artifact-path must not overlap"
+          fi
+          for protected_input in "$LOCKFILE" "$ENTRYPOINT"; do
+            if path_contains "$CACHE_PATH" "$protected_input" || path_contains "$ARTIFACT_PATH" "$protected_input"; then
+              block_preflight input-path-conflict "cache-path and artifact-path must not contain the adapter or lockfile"
+            fi
+          done
+          [[ "$LOCKFILE" != "$ENTRYPOINT" ]] || block_preflight input-path-conflict "lockfile and entrypoint must be distinct files"
+
+          has_symlink_component() {
+            local path="$1" component current=""
+            local -a components
+            IFS=/ read -r -a components <<< "$path"
+            for component in "${components[@]}"; do
+              current="${current:+$current/}$component"
+              [[ -L "$current" ]] && return 0
+            done
+            return 1
+          }
+          [[ -e "$ENTRYPOINT" ]] || block_preflight missing-entrypoint "entrypoint does not exist at the caller revision"
+          [[ -f "$ENTRYPOINT" ]] || block_preflight unsafe-input "entrypoint must be a regular file"
+          ! has_symlink_component "$ENTRYPOINT" || block_preflight unsafe-input "entrypoint may not use symbolic links"
+          [[ -e "$LOCKFILE" ]] || block_preflight missing-lockfile "lockfile does not exist at the caller revision"
+          [[ -f "$LOCKFILE" ]] || block_preflight unsafe-input "lockfile must be a regular file"
+          ! has_symlink_component "$LOCKFILE" || block_preflight unsafe-input "lockfile may not use symbolic links"
+          ! has_symlink_component "$CACHE_PATH" || block_preflight unsafe-input "cache-path may not use symbolic links"
+          ! has_symlink_component "$ARTIFACT_PATH" || block_preflight unsafe-input "artifact-path may not use symbolic links"
+
+          [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || block_preflight invalid-context "repository identity is malformed"
+          [[ "$REUSABLE_WORKFLOW_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || block_preflight invalid-context "reusable workflow repository identity is malformed"
+          [[ "$GITHUB_REPOSITORY_ID" =~ ^[1-9][0-9]*$ && "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ && "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || block_preflight invalid-context "repository and run identities must be positive integers"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ && "$CALLER_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && "$REUSABLE_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || block_preflight invalid-context "source, caller, and reusable workflow SHAs must be full commit hashes"
+          [[ "$CALLER_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/"* && "$CALLER_WORKFLOW_REF" =~ \.ya?ml@[^[:space:]@]+$ ]] || block_preflight invalid-context "caller workflow ref does not match the caller repository"
+          reusable_prefix="$REUSABLE_WORKFLOW_REPOSITORY/.github/workflows/reusable-heavy-ci-v2.yml@"
+          [[ "$REUSABLE_WORKFLOW_REF" = "$reusable_prefix"* ]] || block_preflight invalid-context "job workflow ref does not identify reusable-heavy-ci-v2.yml"
+          reusable_ref="${REUSABLE_WORKFLOW_REF#"$reusable_prefix"}"
+          [[ -n "$reusable_ref" && "$reusable_ref" != *[[:space:]]* ]] || block_preflight invalid-context "reusable workflow ref is malformed"
+          if [[ "$REUSABLE_WORKFLOW_REPOSITORY" = "$GITHUB_REPOSITORY" ]]; then
+            [[ "$REUSABLE_WORKFLOW_SHA" = "$CALLER_WORKFLOW_SHA" ]] || block_preflight invalid-context "same-repository caller and reusable workflows must resolve from the same commit"
+          else
+            [[ "$reusable_ref" =~ ^[0-9a-f]{40}$ ]] || block_preflight immutable-reference-required "cross-repository callers must pin Heavy CI v2 by full commit SHA"
+            [[ "$reusable_ref" = "$REUSABLE_WORKFLOW_SHA" ]] || block_preflight invalid-context "pinned and resolved reusable workflow SHAs do not match"
+          fi
+
+          case "$EVENT_NAME" in
+            push|pull_request|pull_request_target|merge_group|workflow_dispatch|schedule|repository_dispatch|workflow_run) ;;
+            *) block_preflight unsupported-event "event is not in the documented Heavy CI v2 allowlist" ;;
+          esac
+          case "$IS_FORK" in true|false) ;; *) block_preflight invalid-context "fork context must be true or false" ;; esac
+          if [[ "$IS_FORK" = true && "$EVENT_NAME" != pull_request && "$EVENT_NAME" != pull_request_target ]]; then
+            block_preflight invalid-context "fork context is inconsistent with the event"
+          fi
+          [[ -n "$ACTOR" && "$ACTOR" != *[[:space:]]* && "$ACTOR" != *$'\n'* && "$ACTOR" != *$'\r'* ]] || block_preflight invalid-context "actor identity is missing or malformed"
+          [[ -n "$TRIGGERING_ACTOR" && "$TRIGGERING_ACTOR" != *[[:space:]]* && "$TRIGGERING_ACTOR" != *$'\n'* && "$TRIGGERING_ACTOR" != *$'\r'* ]] || block_preflight invalid-context "triggering actor identity is missing or malformed"
+          [[ -n "$DEFAULT_BRANCH" && -n "$REF_NAME" ]] || block_preflight invalid-context "default branch and ref name are required"
 
           untrusted=false
           if [[ "$EVENT_NAME" = pull_request_target || "$IS_FORK" = true || "$ACTOR" = 'dependabot[bot]' ]]; then
             untrusted=true
           fi
-          if [[ "$EXECUTION_CLASS" = trusted-heavy && "$untrusted" = true ]]; then
-            echo "trusted-heavy is forbidden for pull_request_target, fork, and Dependabot execution" >&2
-            exit 2
-          fi
 
-          if [[ "$EXECUTION_CLASS" = trusted-heavy ]]; then
-            runner='["self-hosted","trusted-heavy"]'
-          else
+          if [[ "$untrusted" = true ]]; then
+            effective_execution_class=hosted
             runner='"ubuntu-24.04"'
+            trust_tier=untrusted
+            if [[ "$EXECUTION_CLASS" = trusted-heavy ]]; then
+              reason_category=untrusted-hosted-fallback
+            else
+              reason_category=untrusted-hosted
+            fi
+          elif [[ "$EXECUTION_CLASS" = trusted-heavy ]]; then
+            effective_execution_class=trusted-heavy
+            runner='["self-hosted","trusted-heavy"]'
+            trust_tier=trusted
+            reason_category=trusted-heavy-approved
+          else
+            effective_execution_class=hosted
+            runner='"ubuntu-24.04"'
+            trust_tier=trusted
+            reason_category=hosted-requested
           fi
-          trust_tier=trusted
-          [[ "$untrusted" = true ]] && trust_tier=untrusted
           can_write_cache=false
           if [[ "$CACHE_POLICY" = trusted-write && "$trust_tier" = trusted && "$EVENT_NAME" = push && "$REF_NAME" = "$DEFAULT_BRANCH" ]]; then
             can_write_cache=true
@@ -181,6 +364,11 @@ jobs:
           matrix+=']}'
           [[ ${#stages[@]} -gt 0 ]] && has_fanout=true || has_fanout=false
 
+          decision=proceed
+          planned_expensive_jobs=$candidate_expensive_jobs
+          avoided_expensive_jobs=0
+          emit_preflight
+
           artifact_name="heavy-ci-v2-${CONTRACT_ID}-${GITHUB_REPOSITORY_ID}-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           {
             echo "contract-version=heavy-ci/v2"
@@ -189,12 +377,13 @@ jobs:
             echo "runner=$runner"
             echo "trust-tier=$trust_tier"
             echo "can-write-cache=$can_write_cache"
-            echo "effective-execution-class=$EXECUTION_CLASS"
+            echo "effective-execution-class=$effective_execution_class"
             echo "matrix=$matrix"
             echo "has-fanout=$has_fanout"
           } >> "$GITHUB_OUTPUT"
 
   build:
+    if: ${{ needs.preflight.outputs.preflight-decision == 'proceed' }}
     needs: preflight
     runs-on: ${{ fromJSON(needs.preflight.outputs.runner) }}
     permissions:
@@ -208,6 +397,8 @@ jobs:
     steps:
       - name: Checkout exact source revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Validate repository adapter and lockfile
         shell: bash
@@ -326,7 +517,7 @@ jobs:
           retention-days: ${{ inputs.artifact-retention-days }}
 
   fanout:
-    if: ${{ needs.preflight.outputs.has-fanout == 'true' }}
+    if: ${{ needs.preflight.outputs.preflight-decision == 'proceed' && needs.preflight.outputs.has-fanout == 'true' }}
     needs: [preflight, build]
     strategy:
       fail-fast: false
@@ -337,6 +528,8 @@ jobs:
     steps:
       - name: Checkout exact source revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download build bundle by immutable artifact ID
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -418,7 +611,7 @@ jobs:
           retention-days: ${{ inputs.artifact-retention-days }}
 
   summary:
-    if: ${{ always() && needs.preflight.result == 'success' }}
+    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.preflight-decision == 'proceed' }}
     needs: [preflight, build, fanout]
     runs-on: ubuntu-24.04
     permissions:

--- a/docs/security/pipeline-security-policy.md
+++ b/docs/security/pipeline-security-policy.md
@@ -49,7 +49,7 @@ the DevOps platform.
 
 - Public contracts expose only `hosted` and `trusted-heavy`; arbitrary labels, groups, and `runs-on` fragments are prohibited.
 - `hosted` is the default and the fallback whenever a caller omits or supplies an invalid class.
-- Fork pull requests, Dependabot, and `pull_request_target` must never schedule `trusted-heavy`. The runner-selection expression enforces this before a job is queued, and contract validation fails a forbidden request on a hosted runner.
+- Fork pull requests, Dependabot, and `pull_request_target` must never schedule `trusted-heavy`. The hosted preflight enforces this before a heavy job is queued and routes a valid forbidden request to the documented hosted/full fallback.
 - Consumer repository variables may select the execution class only with an explicit hosted fallback. Manual inputs must be enumerated choices.
 
 ### 7) Build and Release Integrity
@@ -73,6 +73,7 @@ the DevOps platform.
 - Canonical cache writes are allowed only for trusted pushes to the default branch. Pull requests restore at most; forks, Dependabot, and `pull_request_target` use an isolated untrusted tier and cannot write.
 - Build artifacts are current-run handoff objects, downloaded by returned artifact ID and verified against source SHA, repository ID, run ID, run attempt, contract version, and payload SHA-256 before extraction.
 - Heavy CI jobs remain read-only and cannot publish packages, deploy, request OIDC tokens, or inherit caller secrets.
+- Heavy CI preflight validates the resolved caller and reusable workflow SHAs, requires full-SHA pins for cross-repository calls, verifies caller entrypoint/lockfile and cache/artifact path safety, and emits a machine-readable queue decision before heavy jobs become eligible.
 
 ## Pilot Repository Baseline
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,6 @@ All story branches must pass the local hard gates before commit:
 
 The local test gate validates required repository structure and baseline docs.
 
-`make test` also validates the heavy CI v2 public inputs and outputs, trust/cache negative cases, immutable artifact checks, action pinning, and the WODIQ- and Tracker-shaped fixtures. `.github/workflows/heavy-ci-v2-integration.yml` exercises both shapes on hosted GitHub runners when the contract or fixtures change.
+`make test` also executes the Heavy CI v2 preflight contract locally. It validates machine-readable decisions and quantified queue evidence, immutable caller/workflow identity, hosted fallback for fork/Dependabot/`pull_request_target`, checked-out adapter and lockfile inputs, path/symlink conflicts, public inputs and outputs, trust/cache negative cases, immutable artifact checks, action pinning, and the WODIQ- and Tracker-shaped fixtures. `.github/workflows/heavy-ci-v2-integration.yml` exercises both shapes on hosted GitHub runners when the contract or fixtures change.
 
 The integration workflow records per-stage NDJSON evidence. Consumer speed improvements require a separate hosted A/B canary with cold and warm cache runs; the contract test proves correctness and isolation, not performance.

--- a/docs/workflows/contracts/reusable-heavy-ci-v2.md
+++ b/docs/workflows/contracts/reusable-heavy-ci-v2.md
@@ -7,7 +7,7 @@
 ## Execution graph
 
 ```text
-hosted preflight
+hosted checkout + preflight decision
   -> bootstrap + build
        -> unit
        -> integration
@@ -17,6 +17,33 @@ hosted preflight
 ```
 
 Bootstrap and build execute exactly once. Every enabled fan-out stage downloads the same artifact by the artifact ID returned by the build job. Before extraction it verifies the contract version, source SHA, repository ID, run ID, run attempt, artifact name, archive checksum, and archive paths.
+
+The preflight is the only job eligible to run before the queue decision. It always uses `ubuntu-24.04`, checks out the caller revision with credentials disabled, and validates the caller source and routing context before a build or fan-out job can become eligible.
+
+## Preflight decision contract
+
+The machine-readable `preflight-decision` output is one of `blocked`, `skip`, or `proceed`. The current v2 policy emits `proceed` for a valid full run and `blocked` for a fail-closed validation result. `skip` is reserved in the schema for a future explicit no-work policy; v2 does not infer a skip from changed paths or from disabled optional stages because bootstrap/build semantics are caller-owned.
+
+`preflight-reason-category` is stable within `heavy-ci/preflight-v1`:
+
+| Decision | Reason category | Meaning |
+|---|---|---|
+| `proceed` | `hosted-requested` | A trusted context explicitly selected hosted execution. |
+| `proceed` | `trusted-heavy-approved` | A trusted context passed all gates and may queue the isolated heavy runner. |
+| `proceed` | `untrusted-hosted` | A fork, Dependabot, or `pull_request_target` context explicitly selected hosted execution. |
+| `proceed` | `untrusted-hosted-fallback` | An untrusted context requested `trusted-heavy`; the complete enabled stage set is routed to hosted instead. |
+| `blocked` | `invalid-contract` | An enum, identifier, boolean, or retention input is invalid. |
+| `blocked` | `invalid-context` | Repository, run, actor, fork, ref, or workflow identity context is missing or inconsistent. |
+| `blocked` | `unsupported-event` | The event is outside the documented allowlist. |
+| `blocked` | `immutable-reference-required` | A cross-repository caller did not pin this reusable workflow by a full commit SHA. |
+| `blocked` | `missing-entrypoint` | The caller revision does not contain the adapter. |
+| `blocked` | `missing-lockfile` | The caller revision does not contain the lockfile. |
+| `blocked` | `unsafe-input` | A path is unsafe, accesses `.git`, uses a symlink, or names a forbidden cache. |
+| `blocked` | `input-path-conflict` | Cache, artifact, adapter, or lockfile paths overlap unsafely. |
+
+`preflight-evidence` is one JSON object with schema `heavy-ci/preflight-v1`. It records the decision and reason, requested/effective execution class, trust tier, event, enabled-stage count, duration, caller and reusable workflow SHAs, and two queue-cost counters. `planned-expensive-jobs` counts build plus enabled fan-out jobs after approval. `avoided-expensive-jobs` reports that same candidate count when a validation blocks before queueing; it is zero for `proceed`. The evidence is also written to the hosted preflight job summary so a blocked run retains its decision even when workflow-call outputs are unavailable to the caller.
+
+The event allowlist is `push`, `pull_request`, `pull_request_target`, `merge_group`, `workflow_dispatch`, `schedule`, `repository_dispatch`, and `workflow_run`. Unknown events fail closed. Fork, Dependabot, and `pull_request_target` work always uses the isolated cache tier, cannot write caches, and runs the full enabled stage set on hosted when valid. Same-repository `./.github/workflows/...` calls must resolve caller and reusable files from the same commit. Cross-repository calls must use a 40-character SHA that equals the resolved reusable workflow SHA. Both resolved SHAs are validated and included in evidence.
 
 ## Adapter interface
 
@@ -53,11 +80,11 @@ The caller controls whether optional stages run. The shared workflow never encod
 | `run-live-smoke` | boolean | `false` | Enables `live-smoke`. |
 | `artifact-retention-days` | number | `14` | Allowed range 1-30 days. |
 
-All paths must be repository-relative and cannot contain `..`. Dependency-cache paths cannot contain `node_modules`, Composer `vendor`, `dist`, `build`, or `.output`; those are installed dependencies or build products, not trusted cross-run caches.
+All paths must be normalized, repository-relative, distinct from `.`, free of dot segments and control characters, and outside `.git`. The checked-out entrypoint and lockfile must be regular non-symlink files. Cache and artifact paths cannot use symlink components, overlap each other, or contain the adapter or lockfile. Dependency-cache paths cannot contain `node_modules`, Composer `vendor`, `dist`, `build`, or `.output`; those are installed dependencies or build products, not trusted cross-run caches.
 
 ## Outputs
 
-The workflow exports `contract-version`, `artifact-name`, `artifact-id`, `artifact-digest`, `payload-sha256`, `effective-execution-class`, `cache-key`, `cache-hit`, and `metrics-artifact`.
+The workflow exports `contract-version`, `artifact-name`, `artifact-id`, `artifact-digest`, `payload-sha256`, `effective-execution-class`, `cache-key`, `cache-hit`, `metrics-artifact`, `preflight-decision`, `preflight-reason-category`, `preflight-evidence`, `planned-expensive-jobs`, and `avoided-expensive-jobs`.
 
 Artifact names include contract ID, repository ID, source SHA, run ID, and run attempt. They are unique within retries and cannot overwrite another run's artifact. Failure and timing evidence is uploaded per stage and consolidated as newline-delimited JSON.
 
@@ -73,9 +100,9 @@ The exact cache key contains repository ID, contract major and ID, trust tier, r
 - `restore-only`: exact-key restore only; never save.
 - `trusted-write`: save only on a trusted `push` to the repository's default branch. All other events behave as restore-only.
 
-Forks, Dependabot, and `pull_request_target` are assigned the `untrusted` cache tier and cannot save. They cannot request `trusted-heavy`. Same-repository trusted pull requests may restore the exact trusted default-branch cache but cannot write it.
+Forks, Dependabot, and `pull_request_target` are assigned the `untrusted` cache tier and cannot save. A `trusted-heavy` request from those contexts selects the documented hosted/full fallback before any self-hosted job queues. Same-repository trusted pull requests may restore the exact trusted default-branch cache but cannot write it.
 
-The contract test contains negative cases for fork pull requests, Dependabot, `pull_request_target`, ordinary pull requests, unsafe cache paths, parent traversal, broad restore prefixes, privileged permissions, secret inheritance, incomplete artifact binding, and non-SHA Action references. The hosted preflight performs the same trust decision before any self-hosted job is queued.
+The contract test executes the actual hosted preflight script against positive and negative contexts. Cases cover hosted and trusted routing, local same-revision calls, fork/Dependabot/`pull_request_target` fallback, mutable cross-repository workflow refs, malformed identity context, missing or symlinked caller inputs, path conflicts, unsafe cache paths, parent traversal, broad restore prefixes, privileged permissions, secret inheritance, incomplete artifact binding, and non-SHA Action references.
 
 ## Security boundaries
 

--- a/scripts/heavy-ci-v2-contract-test.rb
+++ b/scripts/heavy-ci-v2-contract-test.rb
@@ -2,8 +2,13 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
 
 WORKFLOW = ".github/workflows/reusable-heavy-ci-v2.yml"
+CONTRACT_DOC = "docs/workflows/contracts/reusable-heavy-ci-v2.md"
 FIXTURES = %w[
   tests/fixtures/heavy-ci-v2/wodiq.yml
   tests/fixtures/heavy-ci-v2/tracker.yml
@@ -16,7 +21,7 @@ end
 
 text = File.read(WORKFLOW)
 required_inputs = %w[contract-id execution-class cache-policy cache-path cache-schema toolchain lockfile entrypoint artifact-path run-unit run-integration run-browser run-live-smoke artifact-retention-days]
-required_outputs = %w[contract-version artifact-name artifact-id artifact-digest payload-sha256 effective-execution-class cache-key cache-hit metrics-artifact]
+required_outputs = %w[contract-version artifact-name artifact-id artifact-digest payload-sha256 effective-execution-class cache-key cache-hit metrics-artifact preflight-decision preflight-reason-category preflight-evidence planned-expensive-jobs avoided-expensive-jobs]
 required_stages = %w[bootstrap build unit integration e2e-prepare browser live-smoke]
 
 required_inputs.each { |name| check.call(text.include?("      #{name}:"), "missing input #{name}") }
@@ -26,6 +31,10 @@ required_stages.each { |name| check.call(text.include?(name), "missing typed sta
 check.call(text.include?("default: hosted"), "hosted must remain the execution default")
 check.call(text.include?("hosted|trusted-heavy"), "execution-class enum is not enforced")
 check.call(text.include?("off|restore-only|trusted-write"), "cache-policy enum is not enforced")
+check.call(text.include?("decision=blocked") && text.include?("decision=skip") && text.include?("decision=proceed"), "preflight decision enum must include blocked, skip, and proceed")
+check.call(text.include?("reason-category"), "preflight must emit a stable reason category")
+check.call(text.include?("planned-expensive-jobs") && text.include?("avoided-expensive-jobs"), "preflight must quantify planned and avoided expensive jobs")
+check.call(text.include?("job.workflow_ref") && text.include?("job.workflow_sha") && text.include?("github.workflow_ref") && text.include?("github.workflow_sha"), "workflow and caller identity context is incomplete")
 check.call(text.include?("github.event.pull_request.head.repo.fork || false"), "fork boundary is missing")
 check.call(text.include?("dependabot[bot]"), "Dependabot boundary is missing")
 check.call(text.include?("pull_request_target"), "pull_request_target boundary is missing")
@@ -50,6 +59,7 @@ check.call(text.include?("mkdir -p evidence metrics"), "summary must tolerate a 
 %w[bootstrap build artifact-capture e2e-prepare].each { |stage| check.call(text.include?("stage\":\"#{stage}"), "timing evidence missing for #{stage}") }
 check.call(!text.match?(/^\s*(packages|deployments|id-token|attestations|security-events):\s*write\s*$/), "heavy CI grants a privileged write permission")
 check.call(!text.match?(/^\s*secrets:\s*inherit\s*$/), "secrets: inherit is prohibited")
+check.call(text.scan("persist-credentials: false").length >= 3, "checkout credentials must not persist into preflight, build, or fan-out scripts")
 
 text.scan(/^\s*uses:\s*([^\s#]+)(?:\s+#.*)?$/).flatten.each do |reference|
   next if reference.start_with?("./")
@@ -87,6 +97,127 @@ negative_contexts.each do |context|
   check.call(!can_write_cache?(policy: "trusted-write", ref: "main", default_branch: "main", **context), "non-default-push context can write the canonical cache: #{context}")
 end
 check.call(can_write_cache?(policy: "trusted-write", event: "push", fork: false, actor: "maintainer", ref: "main", default_branch: "main"), "trusted default-branch push cannot write cache")
+
+workflow = YAML.safe_load(text, aliases: true)
+preflight_step = workflow.fetch("jobs").fetch("preflight").fetch("steps").find { |step| step["id"] == "contract" }
+check.call(!preflight_step.nil?, "preflight contract step is missing")
+
+if preflight_step
+  preflight_script = preflight_step.fetch("run")
+  run_preflight = lambda do |overrides = {}, setup = nil|
+    Dir.mktmpdir("heavy-ci-v2-preflight") do |workspace|
+      FileUtils.mkdir_p(File.join(workspace, ".github", "ci"))
+      FileUtils.mkdir_p(File.join(workspace, ".git"))
+      File.write(File.join(workspace, ".github", "ci", "heavy-ci"), "#!/usr/bin/env bash\n")
+      File.write(File.join(workspace, "package-lock.json"), "{}\n")
+      setup&.call(workspace)
+
+      output = File.join(workspace, "github-output")
+      summary = File.join(workspace, "step-summary")
+      env = {
+        "CONTRACT_ID" => "contract-test",
+        "EXECUTION_CLASS" => "hosted",
+        "CACHE_POLICY" => "restore-only",
+        "CACHE_PATH" => ".cache/heavy-ci",
+        "CACHE_SCHEMA" => "v1",
+        "TOOLCHAIN" => "node24-npm11",
+        "LOCKFILE" => "package-lock.json",
+        "ENTRYPOINT" => ".github/ci/heavy-ci",
+        "ARTIFACT_PATH" => ".heavy-ci/payload",
+        "RETENTION_DAYS" => "14",
+        "EVENT_NAME" => "push",
+        "IS_FORK" => "false",
+        "ACTOR" => "maintainer",
+        "TRIGGERING_ACTOR" => "maintainer",
+        "DEFAULT_BRANCH" => "main",
+        "REF_NAME" => "main",
+        "RUN_UNIT" => "true",
+        "RUN_INTEGRATION" => "false",
+        "RUN_BROWSER" => "false",
+        "RUN_LIVE_SMOKE" => "false",
+        "CALLER_WORKFLOW_REF" => "consumer/app/.github/workflows/ci.yml@refs/heads/main",
+        "CALLER_WORKFLOW_SHA" => "1" * 40,
+        "REUSABLE_WORKFLOW_REF" => "Tuinstra-DEV/devops/.github/workflows/reusable-heavy-ci-v2.yml@#{"2" * 40}",
+        "REUSABLE_WORKFLOW_SHA" => "2" * 40,
+        "REUSABLE_WORKFLOW_REPOSITORY" => "Tuinstra-DEV/devops",
+        "GITHUB_REPOSITORY" => "consumer/app",
+        "GITHUB_REPOSITORY_ID" => "12345",
+        "GITHUB_SHA" => "3" * 40,
+        "GITHUB_RUN_ID" => "45678",
+        "GITHUB_RUN_ATTEMPT" => "1",
+        "GITHUB_WORKSPACE" => workspace,
+        "GITHUB_OUTPUT" => output,
+        "GITHUB_STEP_SUMMARY" => summary,
+        "RUNNER_OS" => "Linux",
+        "RUNNER_ARCH" => "X64"
+      }.merge(overrides)
+      stdout, stderr, status = Open3.capture3(env, "bash", "-c", preflight_script, chdir: workspace)
+      values = File.exist?(output) ? File.readlines(output, chomp: true).select { |line| line.include?("=") }.map { |line| line.split("=", 2) }.to_h : {}
+      evidence = values["preflight-evidence"] ? JSON.parse(values["preflight-evidence"]) : {}
+      { status: status, stdout: stdout, stderr: stderr, outputs: values, evidence: evidence, summary: File.exist?(summary) ? File.read(summary) : "" }
+    end
+  end
+
+  hosted = run_preflight.call
+  check.call(hosted[:status].success?, "valid hosted preflight failed: #{hosted[:stderr]}")
+  check.call(hosted[:outputs]["decision"] == "proceed", "valid hosted preflight did not proceed")
+  check.call(hosted[:outputs]["reason-category"] == "hosted-requested", "valid hosted preflight reason is unstable")
+  check.call(hosted[:outputs]["planned-expensive-jobs"] == "2", "hosted preflight did not count build plus unit jobs")
+  check.call(hosted[:evidence]["schema_version"] == "heavy-ci/preflight-v1", "preflight evidence schema is missing")
+
+  invalid_execution = run_preflight.call("EXECUTION_CLASS" => "bad\nvalue")
+  check.call(invalid_execution[:evidence]["requested_execution_class"] == "invalid", "invalid execution class leaked raw input into preflight evidence")
+
+  trusted = run_preflight.call("EXECUTION_CLASS" => "trusted-heavy")
+  check.call(trusted[:status].success? && trusted[:outputs]["effective-execution-class"] == "trusted-heavy", "trusted push cannot select trusted-heavy")
+
+  same_repository = run_preflight.call(
+    "GITHUB_REPOSITORY" => "Tuinstra-DEV/devops",
+    "CALLER_WORKFLOW_REF" => "Tuinstra-DEV/devops/.github/workflows/heavy-ci-v2-integration.yml@refs/heads/main",
+    "REUSABLE_WORKFLOW_REF" => "Tuinstra-DEV/devops/.github/workflows/reusable-heavy-ci-v2.yml@refs/heads/main",
+    "REUSABLE_WORKFLOW_SHA" => "1" * 40
+  )
+  check.call(same_repository[:status].success?, "same-revision local reusable workflow call was rejected")
+
+  [
+    { "EVENT_NAME" => "pull_request", "IS_FORK" => "true", "ACTOR" => "contributor", "EXECUTION_CLASS" => "trusted-heavy" },
+    { "EVENT_NAME" => "pull_request", "ACTOR" => "dependabot[bot]", "TRIGGERING_ACTOR" => "dependabot[bot]", "EXECUTION_CLASS" => "trusted-heavy" },
+    { "EVENT_NAME" => "pull_request_target", "EXECUTION_CLASS" => "trusted-heavy" }
+  ].each do |context|
+    result = run_preflight.call(context)
+    check.call(result[:status].success?, "untrusted context did not select safe hosted fallback: #{context}")
+    check.call(result[:outputs]["decision"] == "proceed" && result[:outputs]["effective-execution-class"] == "hosted", "untrusted context escaped hosted routing: #{context}")
+    check.call(result[:outputs]["reason-category"] == "untrusted-hosted-fallback", "untrusted fallback reason changed: #{context}")
+    check.call(result[:outputs]["can-write-cache"] == "false", "untrusted context can write cache: #{context}")
+  end
+
+  blocked_cases = [
+    ["invalid execution class", { "EXECUTION_CLASS" => "arbitrary-runner" }, nil, "invalid-contract"],
+    ["unsupported event", { "EVENT_NAME" => "deployment" }, nil, "unsupported-event"],
+    ["missing actor", { "ACTOR" => "" }, nil, "invalid-context"],
+    ["short caller SHA", { "CALLER_WORKFLOW_SHA" => "1234567" }, nil, "invalid-context"],
+    ["mutable remote workflow", { "REUSABLE_WORKFLOW_REF" => "Tuinstra-DEV/devops/.github/workflows/reusable-heavy-ci-v2.yml@main" }, nil, "immutable-reference-required"],
+    ["mismatched remote workflow SHA", { "REUSABLE_WORKFLOW_SHA" => "4" * 40 }, nil, "invalid-context"],
+    ["missing entrypoint", { "ENTRYPOINT" => ".github/ci/missing" }, nil, "missing-entrypoint"],
+    ["missing lockfile", { "LOCKFILE" => "missing.lock" }, nil, "missing-lockfile"],
+    ["cache/artifact overlap", { "CACHE_PATH" => ".heavy-ci", "ARTIFACT_PATH" => ".heavy-ci/payload" }, nil, "input-path-conflict"],
+    ["symlinked entrypoint", {}, lambda { |workspace| FileUtils.rm(File.join(workspace, ".github", "ci", "heavy-ci")); File.symlink("../../package-lock.json", File.join(workspace, ".github", "ci", "heavy-ci")) }, "unsafe-input"]
+  ]
+  blocked_cases.each do |label, env_overrides, setup, reason|
+    result = run_preflight.call(env_overrides, setup)
+    check.call(!result[:status].success?, "#{label} did not fail closed")
+    check.call(result[:outputs]["decision"] == "blocked", "#{label} did not emit a blocked decision")
+    check.call(result[:outputs]["reason-category"] == reason, "#{label} emitted #{result[:outputs]["reason-category"].inspect}, expected #{reason}")
+    check.call(result[:outputs]["planned-expensive-jobs"] == "0", "#{label} planned an expensive job")
+    check.call(result[:outputs]["avoided-expensive-jobs"].to_i >= 1, "#{label} did not quantify avoided expensive jobs")
+  end
+end
+
+contract_doc = File.read(CONTRACT_DOC)
+%w[blocked skip proceed hosted-requested trusted-heavy-approved untrusted-hosted untrusted-hosted-fallback invalid-contract invalid-context unsupported-event immutable-reference-required missing-entrypoint missing-lockfile unsafe-input input-path-conflict].each do |term|
+  check.call(contract_doc.include?("`#{term}`"), "#{CONTRACT_DOC} does not document preflight term #{term}")
+end
+check.call(contract_doc.include?("planned-expensive-jobs") && contract_doc.include?("avoided-expensive-jobs"), "#{CONTRACT_DOC} does not document quantified preflight evidence")
 
 fixture_shapes = FIXTURES.map do |path|
   fixture = YAML.safe_load(File.read(path), aliases: false)


### PR DESCRIPTION
## Summary

- Deliver the DEV-10 fail-fast Heavy CI v2 preflight and its contract coverage.
- Preserve the latest `main` changes through a normal merge commit.
- Emit deterministic decision, routing, cache, artifact, and avoided-job evidence before expensive fan-out.

## Verification

- `ruby scripts/heavy-ci-v2-contract-test.rb`
- `bash scripts/lint.sh`
- `bash scripts/test.sh`
- Result: all passed.

## Security and fail-closed behavior

The preflight rejects malformed contracts, unsafe paths, missing or symlinked inputs, invalid workflow provenance, mutable cross-repository reusable-workflow references, unsupported events, and inconsistent identities before expensive jobs can queue. Forks, bot actors, and `pull_request_target` use the hosted/untrusted fallback and cannot write trusted caches. Action references remain pinned to full commit SHAs; permissions and secret inheritance stay restricted.

## Rollback

Revert this PR with a new normal revert commit. That restores the previous Heavy CI v2 contract and routing behavior without rewriting history. Consumer PRs must be merged only after this reusable workflow is available on the target branch.

Refs: DEV-10
