### PR TITLE
DEV-10: Add live fail-fast acceptance evidence

### DIFF
--- a/.github/workflows/heavy-ci-v2-integration.yml
+++ b/.github/workflows/heavy-ci-v2-integration.yml
@@ -8,12 +8,21 @@ on:
       - tests/fixtures/heavy-ci-v2/**
       - scripts/heavy-ci-v2-contract-test.rb
   workflow_dispatch:
+    inputs:
+      evidence-mode:
+        description: Run the passing shapes or the intentional fail-fast evidence shapes
+        type: choice
+        options:
+          - proceed
+          - blocked
+        default: proceed
 
 permissions:
   contents: read
 
 jobs:
   wodiq-shape:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.evidence-mode == 'proceed' }}
     uses: ./.github/workflows/reusable-heavy-ci-v2.yml
     with:
       contract-id: wodiq-shape
@@ -26,6 +35,7 @@ jobs:
       run-browser: true
 
   tracker-shape:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.evidence-mode == 'proceed' }}
     uses: ./.github/workflows/reusable-heavy-ci-v2.yml
     with:
       contract-id: tracker-shape
@@ -33,6 +43,33 @@ jobs:
       cache-policy: off
       toolchain: node24-pnpm10-php83
       lockfile: tests/fixtures/heavy-ci-v2/tracker/pnpm-lock.yaml
+      entrypoint: tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
+      run-unit: true
+      run-integration: true
+      run-browser: true
+
+  wodiq-blocked-evidence:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.evidence-mode == 'blocked' }}
+    uses: ./.github/workflows/reusable-heavy-ci-v2.yml
+    with:
+      contract-id: wodiq-blocked-evidence
+      execution-class: hosted
+      cache-policy: off
+      toolchain: node24-npm11
+      lockfile: tests/fixtures/heavy-ci-v2/wodiq/missing-package-lock.json
+      entrypoint: tests/fixtures/heavy-ci-v2/wodiq/entrypoint.sh
+      run-unit: true
+      run-browser: true
+
+  tracker-blocked-evidence:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.evidence-mode == 'blocked' }}
+    uses: ./.github/workflows/reusable-heavy-ci-v2.yml
+    with:
+      contract-id: tracker-blocked-evidence
+      execution-class: hosted
+      cache-policy: off
+      toolchain: node24-pnpm10-php83
+      lockfile: tests/fixtures/heavy-ci-v2/tracker/missing-pnpm-lock.yaml
       entrypoint: tests/fixtures/heavy-ci-v2/tracker/entrypoint.sh
       run-unit: true
       run-integration: true


### PR DESCRIPTION
Adds an opt-in, manual-only blocked evidence mode to the existing Heavy CI v2 integration workflow. The normal pull-request/proceed behavior is unchanged.\n\nThe blocked mode intentionally supplies missing fixture lockfiles so each preflight must fail closed before build/fan-out jobs become eligible, giving auditable live evidence for DEV-10 AC6 without touching production consumers.\n\nVerification:\n- make lint\n- make test (93 platform, 16 routing, 32 billing tests)\n- normal main canary run 31718313035 passed both shapes\n\nRollback: normal revert of this test-only workflow change.