### PR TITLE
DEV-11: Support keychain-backed billing collection

### DIFF
--- a/docs/operations/ci-billing-reporting.md
+++ b/docs/operations/ci-billing-reporting.md
@@ -46,6 +46,23 @@ python3 scripts/ci_billing_report.py collect \
   --output-dir evidence/ci-billing
 ```
 
+For an operator workstation that is already authenticated with `gh`, use the
+credential-preserving mode below. It invokes `gh api` for read-only requests;
+the credential remains in the system keychain and is never exported to an
+environment variable, report, log, fixture, or archive:
+
+```sh
+python3 scripts/ci_billing_report.py collect \
+  --organization Tuinstra-DEV \
+  --output-dir evidence/ci-billing \
+  --auth-mode gh-cli
+```
+
+The existing `gh` account still needs organization Administration read and
+repository Actions/Metadata read access. This mode is for attended operational
+collection. The scheduled workflow continues to require the dedicated,
+least-privilege `CI_BILLING_REPORT_TOKEN`; it never falls back to `GITHUB_TOKEN`.
+
 The command exits `0` for complete or explicitly degraded evidence and `2` for
 incomplete/unauthorized evidence or a command error. Raw API responses are held
 only in process memory. Output contains aggregates, source coverage, request

--- a/scripts/ci_billing_report.py
+++ b/scripts/ci_billing_report.py
@@ -14,6 +14,7 @@ import math
 import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 import time
 from typing import Any, Callable, Iterable
@@ -839,6 +840,69 @@ class GitHubClient:
         raise PaginationFailure(failure, records, 1000)
 
 
+class GitHubCliClient(GitHubClient):
+    """Use an existing gh login without exporting or persisting its credential."""
+
+    def __init__(self, api_version: str,
+                 runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+                 sleeper: Callable[[float], None] = time.sleep,
+                 monotonic_clock: Callable[[], float] = time.monotonic,
+                 max_elapsed_seconds: int = DEFAULT_API_TIME_BUDGET_SECONDS):
+        super().__init__("", "https://api.github.com", api_version,
+                         sleeper=sleeper, monotonic_clock=monotonic_clock,
+                         max_elapsed_seconds=max_elapsed_seconds)
+        self.runner = runner
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        query = urllib.parse.urlencode(params or {})
+        endpoint = path.lstrip("/") + (f"?{query}" if query else "")
+        command = [
+            "gh", "api", "--method", "GET",
+            "-H", f"X-GitHub-Api-Version: {self.api_version}",
+            endpoint,
+        ]
+        for attempt in range(3):
+            try:
+                completed = self.runner(
+                    command, capture_output=True, text=True, timeout=30, check=False)
+            except (OSError, subprocess.SubprocessError) as exc:
+                if attempt < 2:
+                    self.sleeper(2 ** attempt)
+                    continue
+                raise SourceFailure(
+                    "transport_error", "incomplete",
+                    f"GitHub CLI request failed: {type(exc).__name__}") from None
+            if completed.returncode == 0:
+                try:
+                    return json.loads(completed.stdout)
+                except json.JSONDecodeError:
+                    raise SourceFailure(
+                        "invalid_response", "incomplete",
+                        "GitHub CLI response was not valid JSON") from None
+
+            match = re.search(r"HTTP\s+(\d{3})", completed.stderr or "")
+            status = int(match.group(1)) if match else None
+            if status == 429:
+                if attempt < 2:
+                    self.wait_for_rate_limit(60, status)
+                    continue
+                raise SourceFailure(
+                    "rate_limited", "incomplete",
+                    "GitHub CLI remained rate limited after bounded retries", status) from None
+            if status in {401, 403}:
+                raise SourceFailure(
+                    "unauthorized", "unauthorized",
+                    f"GitHub CLI request was unauthorized (HTTP {status})", status) from None
+            if status is not None and 500 <= status <= 599 and attempt < 2:
+                self.sleeper(2 ** attempt)
+                continue
+            raise SourceFailure(
+                "service_error", "incomplete",
+                f"GitHub CLI request failed{f' (HTTP {status})' if status else ''}",
+                status) from None
+        raise AssertionError("unreachable")
+
+
 def month_periods(start: date, end: date) -> list[tuple[int, int]]:
     periods = []
     cursor = start.replace(day=1)
@@ -1221,8 +1285,9 @@ def collect_command(args: argparse.Namespace) -> int:
     configured_repositories = load_consumer_inventory(
         Path(args.consumer_inventory), args.organization)
     problems: list[dict[str, str]] = []
-    if token:
-        client = GitHubClient(token, "https://api.github.com", args.api_version)
+    if token or args.auth_mode == "gh-cli":
+        client = (GitHubClient(token, "https://api.github.com", args.api_version)
+                  if token else GitHubCliClient(args.api_version))
         billing_rows, billing_source, billing_problems = collect_billing(
             client, args.organization, start, as_of)
         billing_repositories = {
@@ -1279,6 +1344,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     collect.add_argument("--output-dir", required=True)
     collect.add_argument("--as-of", help="UTC date (YYYY-MM-DD); defaults to today")
     collect.add_argument("--token-env", default="CI_BILLING_REPORT_TOKEN")
+    collect.add_argument(
+        "--auth-mode", choices=("token", "gh-cli"), default="token",
+        help="token reads --token-env; gh-cli uses the existing authenticated gh session")
     collect.add_argument("--api-version", default=DEFAULT_API_VERSION)
     collect.add_argument("--consumer-inventory", default=str(DEFAULT_CONSUMER_INVENTORY))
 

--- a/tests/test_ci_billing_report.py
+++ b/tests/test_ci_billing_report.py
@@ -526,6 +526,27 @@ class ApiCollectionTests(unittest.TestCase):
         self.assertEqual(len(raised.exception.partial), 100)
         self.assertEqual(raised.exception.pages, 1)
 
+    def test_gh_cli_client_uses_keychain_backed_api_without_token_argument(self):
+        runner = mock.Mock(return_value=report.subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"ok": true}', stderr=""))
+        client = report.GitHubCliClient("2026-03-10", runner=runner)
+
+        self.assertEqual(client.get("/orgs/Tuinstra-DEV/repos", {"page": 2}), {"ok": True})
+        command = runner.call_args.args[0]
+        self.assertEqual(command[:4], ["gh", "api", "--method", "GET"])
+        self.assertIn("orgs/Tuinstra-DEV/repos?page=2", command)
+        self.assertFalse(any("token" in part.casefold() for part in command))
+
+    def test_gh_cli_client_sanitizes_unauthorized_failure(self):
+        runner = mock.Mock(return_value=report.subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="sensitive detail (HTTP 403)"))
+        client = report.GitHubCliClient("2026-03-10", runner=runner)
+
+        with self.assertRaises(report.SourceFailure) as raised:
+            client.get("/settings/billing")
+        self.assertEqual(raised.exception.status, "unauthorized")
+        self.assertNotIn("sensitive detail", str(raised.exception))
+
     def test_403_is_unauthorized_and_not_retried(self):
         error = report.urllib.error.HTTPError("https://api.github.test/x", 403, "", {}, None)
         opener = mock.Mock(side_effect=error)
@@ -674,6 +695,16 @@ class EvidenceTests(unittest.TestCase):
             "--output-dir", "evidence/ci-billing",
         ])
         self.assertEqual(args.token_env, "CI_BILLING_REPORT_TOKEN")
+        self.assertEqual(args.auth_mode, "token")
+
+    def test_collector_supports_explicit_gh_cli_authentication(self):
+        args = report.parse_args([
+            "collect",
+            "--organization", "Tuinstra-DEV",
+            "--output-dir", "evidence/ci-billing",
+            "--auth-mode", "gh-cli",
+        ])
+        self.assertEqual(args.auth_mode, "gh-cli")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds an explicit attended collection mode that invokes authenticated read-only GitHub API requests through gh without exporting or persisting its keychain credential.\n\nThe scheduled workflow remains unchanged and fail-closed on its dedicated CI_BILLING_REPORT_TOKEN; it never falls back to GITHUB_TOKEN. Errors remain sanitized and the same aggregation, status and retention semantics are used.\n\nVerification:\n- make lint\n- make test (93 platform, 16 routing, 35 billing tests)\n- live full report collection is running separately as acceptance evidence\n\nRollback: normal revert of this merge commit.