### PR TITLE
DEV-11: Pin attended collector credential source

### DIFF
--- a/docs/operations/ci-billing-reporting.md
+++ b/docs/operations/ci-billing-reporting.md
@@ -62,6 +62,10 @@ The existing `gh` account still needs organization Administration read and
 repository Actions/Metadata read access. This mode is for attended operational
 collection. The scheduled workflow continues to require the dedicated,
 least-privilege `CI_BILLING_REPORT_TOKEN`; it never falls back to `GITHUB_TOKEN`.
+The child process is pinned to `github.com` and removes `GH_TOKEN`,
+`GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, and `GITHUB_ENTERPRISE_TOKEN` from its
+environment so those variables cannot silently override the reviewed keychain
+identity.
 
 The command exits `0` for complete or explicitly degraded evidence and `2` for
 incomplete/unauthorized evidence or a command error. Raw API responses are held

--- a/scripts/ci_billing_report.py
+++ b/scripts/ci_billing_report.py
@@ -27,6 +27,8 @@ SCHEMA_VERSION = "devops.ci-billing-report/v1"
 DEFAULT_API_VERSION = "2026-03-10"
 RERUN_LOOKBACK_DAYS = 30
 DEFAULT_API_TIME_BUDGET_SECONDS = 25 * 60
+GH_TOKEN_OVERRIDE_ENV = (
+    "GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN")
 STATUS_ORDER = {
     "not_applicable": -1,
     "complete": 0,
@@ -858,13 +860,18 @@ class GitHubCliClient(GitHubClient):
         endpoint = path.lstrip("/") + (f"?{query}" if query else "")
         command = [
             "gh", "api", "--method", "GET",
+            "--hostname", "github.com",
             "-H", f"X-GitHub-Api-Version: {self.api_version}",
             endpoint,
         ]
+        environment = os.environ.copy()
+        for variable in GH_TOKEN_OVERRIDE_ENV:
+            environment.pop(variable, None)
         for attempt in range(3):
             try:
                 completed = self.runner(
-                    command, capture_output=True, text=True, timeout=30, check=False)
+                    command, capture_output=True, text=True, timeout=30, check=False,
+                    env=environment)
             except (OSError, subprocess.SubprocessError) as exc:
                 if attempt < 2:
                     self.sleeper(2 ** attempt)

--- a/tests/test_ci_billing_report.py
+++ b/tests/test_ci_billing_report.py
@@ -531,11 +531,20 @@ class ApiCollectionTests(unittest.TestCase):
             args=[], returncode=0, stdout='{"ok": true}', stderr=""))
         client = report.GitHubCliClient("2026-03-10", runner=runner)
 
-        self.assertEqual(client.get("/orgs/Tuinstra-DEV/repos", {"page": 2}), {"ok": True})
+        with mock.patch.dict(report.os.environ, {
+                "GH_TOKEN": "override", "GITHUB_TOKEN": "override",
+                "GH_ENTERPRISE_TOKEN": "override", "GITHUB_ENTERPRISE_TOKEN": "override"}):
+            self.assertEqual(
+                client.get("/orgs/Tuinstra-DEV/repos", {"page": 2}), {"ok": True})
         command = runner.call_args.args[0]
         self.assertEqual(command[:4], ["gh", "api", "--method", "GET"])
+        self.assertIn("--hostname", command)
+        self.assertIn("github.com", command)
         self.assertIn("orgs/Tuinstra-DEV/repos?page=2", command)
         self.assertFalse(any("token" in part.casefold() for part in command))
+        environment = runner.call_args.kwargs["env"]
+        self.assertTrue(all(variable not in environment
+                            for variable in report.GH_TOKEN_OVERRIDE_ENV))
 
     def test_gh_cli_client_sanitizes_unauthorized_failure(self):
         runner = mock.Mock(return_value=report.subprocess.CompletedProcess(


### PR DESCRIPTION
Closes the independent security review P2 on the attended gh-cli collector.\n\n- pins gh api to github.com\n- removes GH_TOKEN, GITHUB_TOKEN, GH_ENTERPRISE_TOKEN and GITHUB_ENTERPRISE_TOKEN from only the child process environment\n- prevents environment credentials from silently overriding the reviewed keychain identity\n- documents and tests the boundary\n\nThe scheduled dedicated-secret path is unchanged.\n\nVerification:\n- make lint\n- make test (93 platform, 16 routing, 35 billing tests)\n\nRollback: normal revert of this merge commit.